### PR TITLE
fix: readme: fixes asset and documentation urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It represents a collection of assets, utilities, and React components for buildi
 
 ## Changelog
 
-You can view the complete list of additions, fixes, and changes in the [change log](./CHANGELOG.md)
+You can view the complete list of additions, fixes, and changes in the [change log](https://github.com/EightfoldAI/octuple/blob/main/CHANGELOG.md)
 
 ## Usage
 
@@ -39,15 +39,15 @@ There are many ways to contribute to the Octuple project. Review the following s
 
 Please use the 'Get Help' tool at the bottom of any screen to submit bugs and suggestions.
 
-![Get Help](./public/assets/GetHelp.png)
+![Get Help](https://raw.githubusercontent.com/EightfoldAI/octuple/main/public/assets/GetHelp.png)
 
 ### Create an issue on GitHub
 
-![New Issue](./public/assets/NewIssue.png)
+![New Issue](https://raw.githubusercontent.com/EightfoldAI/octuple/main/public/assets/NewIssue.png)
 
 ### Pull requests
 
-Review the guidance for pull requests and the contribution workflow in our [contributor guide](./src/CONTRIBUTING.md).
+Review the guidance for pull requests and the contribution workflow in our [contributor guide](https://github.com/EightfoldAI/octuple/blob/main/src/CONTRIBUTING.md).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eightfold.ai/octuple",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "license": "MIT",
     "main": "lib/octuple.js",
     "types": "lib/octuple.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "test": "jest",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "format": "prettier --write \"**/*.+(js|jsx|ts|tsx|json|css|scss|md)\"",
-        "postinstall": "husky install",
+        "prepare": "husky install",
         "lint-staged": "lint-staged",
         "release": "standard-version",
         "release:minor": "standard-version --release-as minor",


### PR DESCRIPTION
the readme was using relative urls, this change fixes it