### PR TITLE
fix: react: ignore react in production build to avoid conflicts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,9 @@ npm-debug.log*
 README.md
 stats.json
 tsconfig.json
-webpack.config.js
+webpack.common.js
+webpack.dev.js
+webpack.prod.js
 yarn.lock
 yarn-debug.log*
 yarn-error.log*
@@ -28,5 +30,6 @@ yarn-error.log*
 .env.local
 .env.production.local
 .env.test.local
+.versionrc.json
 
 lib/octuple.js.LICENSE.txt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@eightfold.ai/octuple",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "license": "MIT",
     "main": "lib/octuple.js",
     "types": "lib/octuple.d.ts",

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -5,9 +5,13 @@ process.env.NODE_ENV = 'production';
 
 module.exports = {
     ...WebpackCommonConfig,
+    externals: {
+        react: 'commonjs react',
+        'react-dom': 'commonjs react-dom',
+    },
     plugins: [
         new webpack.DefinePlugin({
-            VERSION: JSON.stringify(require('./package.json').version)
-        })
-    ]
+            VERSION: JSON.stringify(require('./package.json').version),
+        }),
+    ],
 };


### PR DESCRIPTION
Using components from the current release results in this error code https://reactjs.org/docs/error-decoder.html/?invariant=321

This change sets-up webpack to ignore adding react and react-dom to the prod bundle