### PR TITLE
chore: install peers: moves install peers to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "@floating-ui/react-dom": "0.6.0",
         "@mdi/react": "1.5.0",
         "bodymovin": "4.13.0",
-        "install-peers": "^1.0.3",
         "lottie-web": "5.8.1",
         "react-flip-toolkit": "7.0.13"
     },
@@ -118,6 +117,7 @@
         "html-webpack-plugin": "5.5.0",
         "husky": "7.0.4",
         "identity-obj-proxy": "3.0.0",
+        "install-peers": "1.0.3",
         "install-peers-cli": "2.2.0",
         "jest": "27.4.3",
         "jest-matchmedia-mock": "1.1.0",


### PR DESCRIPTION
Auto installed dep needs to be a dev dependency