### PR TITLE
fix: button: use root inverse text color instead of local variable

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -49,7 +49,6 @@
     --button-two-state-focus-outline-color: var(--primary-color-40);
     --button-two-state-active-outline-color: var(--primary-color-70);
     --button-two-state-visited-outline-color: var(--primary-color-70);
-    --text-color: var(--text-inverse-color);
     background-color: inherit;
     border: 2px solid rgba(var(--button-primary-default-border-color), 0.01);
     border-radius: $corner-radius-s;
@@ -242,18 +241,18 @@
 .button-primary {
     background-color: var(--button-primary-default-background-color);
     border-color: var(--button-primary-default-border-color);
-    color: var(--text-color);
+    color: var(--text-inverse-color);
 
     &:hover {
         background-color: var(--button-primary-hover-background-color);
         border-color: var(--button-primary-hover-border-color);
-        color: var(--text-color);
+        color: var(--text-inverse-color);
     }
 
     &:active {
         background-color: var(--button-primary-active-background-color);
         border-color: var(--button-primary-active-border-color);
-        color: var(--text-color);
+        color: var(--text-inverse-color);
     }
 
     &:focus-visible {
@@ -412,7 +411,7 @@
         width: 1px;
 
         &.split-divider-primary {
-            background-color: var(--text-color);
+            background-color: var(--text-inverse-color);
         }
 
         &.split-divider-secondary {


### PR DESCRIPTION
in some scenarios the root style was overriding the local