### PR TITLE
fix: extend RadioButtonProps and CheckBoxProps to OcBaseProps

### DIFF
--- a/src/components/Selectors/RadioButton/RadioButton.tsx
+++ b/src/components/Selectors/RadioButton/RadioButton.tsx
@@ -44,7 +44,7 @@ export const RadioButton: FC<RadioButtonProps> = ({
                 value={value}
                 onClick={(e) => {
                     updateActiveRadioButton(value);
-                    onRadioButtonClick(value, e);
+                    onRadioButtonClick?.(value, e);
                 }}
                 readOnly
             />

--- a/src/components/Selectors/Selectors.types.ts
+++ b/src/components/Selectors/Selectors.types.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { OcBaseProps } from '../OcBase';
 
 export type SelectRadioButtonEvent<E = HTMLElement> =
     | React.MouseEvent<E>
@@ -22,7 +23,7 @@ export interface IRadioButtonsContext {
     onRadioButtonClick: OnChangeHandler;
 }
 
-export interface CheckBoxProps {
+export interface CheckBoxProps extends OcBaseProps<HTMLInputElement> {
     /**
      * Allows focus on the checkbox when it's disabled.
      */
@@ -70,7 +71,8 @@ export interface CheckBoxProps {
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
-export interface RadioButtonProps {
+export interface RadioButtonProps
+    extends Omit<OcBaseProps<HTMLElement>, 'onChange'> {
     /**
      * The default radio button to select
      */


### PR DESCRIPTION
## SUMMARY:
Update Selectors to inherit from OcBaseProps
## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [x] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
