### PR TITLE
fix: remove classname prop from CheckBoxProps

### DIFF
--- a/src/components/Selectors/Selectors.types.ts
+++ b/src/components/Selectors/Selectors.types.ts
@@ -37,10 +37,6 @@ export interface CheckBoxProps extends OcBaseProps<HTMLInputElement> {
      */
     checked?: boolean;
     /**
-     * The checkbox class names.
-     */
-    className?: string;
-    /**
      * The input checkbox default checked value.
      */
     defaultChecked?: boolean;


### PR DESCRIPTION
## SUMMARY:
Remove classname prop from CheckBoxProps
## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [x] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
