### PR TITLE
fix: forward classNames to tab component

### DIFF
--- a/src/components/Tabs/Tab/Tab.tsx
+++ b/src/components/Tabs/Tab/Tab.tsx
@@ -12,7 +12,16 @@ import styles from '../tabs.module.scss';
 
 export const Tab: FC<TabProps> = React.forwardRef(
     (
-        { value, label, icon, disabled, ariaLabel, badgeContent, ...rest },
+        {
+            value,
+            label,
+            icon,
+            disabled,
+            ariaLabel,
+            badgeContent,
+            classNames,
+            ...rest
+        },
         ref: Ref<HTMLButtonElement>
     ) => {
         const { onTabClick, currentActiveTab } = useTabs();
@@ -27,6 +36,7 @@ export const Tab: FC<TabProps> = React.forwardRef(
             styles.tab,
             { [styles.active]: isActive },
             { [styles.inverse]: light },
+            classNames,
         ]);
 
         const getIcon = (): JSX.Element =>


### PR DESCRIPTION
## SUMMARY:
forward classNames to tab component

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
