### PR TITLE
chore: make ci builds run on main next

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - main-next
   pull_request:
     branches:
       - main
+      - main-next
 
 env:
   NODE_VERSION: 16.14.2


### PR DESCRIPTION
## SUMMARY:
Ci pipeline will run on prs created to main-next branch

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
