### PR TITLE
fix: tooltip: allow pointer events when tooltip is disabled

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -68,7 +68,7 @@ export const Tooltip: FC<TooltipProps> = ({
     const toggle: Function =
         (show: boolean): Function =>
         (): void => {
-            if (!content) {
+            if (!content || disabled) {
                 return;
             }
             timeout && clearTimeout(timeout);

--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -5,7 +5,6 @@ $tooltip-arrow-shadow: 1px 1px 2px rgba(15, 20, 31, 0.12);
     cursor: pointer;
 
     &.disabled {
-        pointer-events: none;
         cursor: auto;
     }
 }


### PR DESCRIPTION
## SUMMARY:
allow pointer events when tooltip is disabled

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
