### PR TITLE
fix: pagination: enables page size and jumper controls and hides elements via total

### DIFF
--- a/src/__snapshots__/storybook.test.js.snap
+++ b/src/__snapshots__/storybook.test.js.snap
@@ -5797,99 +5797,7 @@ exports[`Storyshots Pagination All Combined 1`] = `
   className="my-pagination-class pagination"
   data-test-id="myPaginationTestId"
 >
-  <span
-    className="sizes"
-  >
-    <div
-      className="mainWrapper"
-    >
-      <button
-        aria-controls="dropdown-15"
-        aria-disabled={false}
-        aria-expanded={false}
-        aria-haspopup={true}
-        aria-label="Selected page size"
-        className="button buttonDefault buttonSize3 iconLeft"
-        defaultChecked={false}
-        disabled={false}
-        onClick={[Function]}
-        role="button"
-        tabIndex="0"
-      >
-        <span>
-          <span
-            aria-hidden={false}
-            className="icon iconWrapper"
-            role="presentation"
-          >
-            <svg
-              role="presentation"
-              style={
-                Object {
-                  "height": "16px",
-                  "width": "16px",
-                }
-              }
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
-                style={
-                  Object {
-                    "fill": "currentColor",
-                  }
-                }
-              />
-            </svg>
-          </span>
-          <span
-            className="buttonText3"
-          >
-            page / 100
-          </span>
-        </span>
-      </button>
-    </div>
-  </span>
-  <span
-    className="total"
-  >
-    400 Total
-  </span>
-  <button
-    aria-disabled={false}
-    aria-label="Previous"
-    className="paginationButton button buttonDefault buttonSize3 iconLeft"
-    defaultChecked={false}
-    disabled={false}
-    onClick={[Function]}
-  >
-    <span
-      aria-hidden={false}
-      className="icon iconWrapper"
-      role="presentation"
-    >
-      <svg
-        role="presentation"
-        style={
-          Object {
-            "height": "16px",
-            "width": "16px",
-          }
-        }
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
-          style={
-            Object {
-              "fill": "currentColor",
-            }
-          }
-        />
-      </svg>
-    </span>
-  </button>
+  <span />
   <ul
     className="pager"
   >
@@ -5927,80 +5835,7 @@ exports[`Storyshots Pagination All Combined 1`] = `
         </span>
       </button>
     </li>
-    <li>
-      <button
-        aria-checked={true}
-        aria-disabled={false}
-        aria-pressed={true}
-        className="paginationButton active button buttonDefault buttonSize3"
-        defaultChecked={true}
-        disabled={false}
-        onClick={[Function]}
-      >
-        <span
-          className="buttonText3"
-        >
-          4
-        </span>
-      </button>
-    </li>
   </ul>
-  <button
-    aria-disabled={false}
-    aria-label="Next"
-    className="paginationButton button buttonDefault buttonSize3 iconLeft disabled"
-    defaultChecked={false}
-    disabled={true}
-    onClick={[Function]}
-  >
-    <span
-      aria-hidden={false}
-      className="icon iconWrapper"
-      role="presentation"
-    >
-      <svg
-        role="presentation"
-        style={
-          Object {
-            "height": "16px",
-            "width": "16px",
-          }
-        }
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-          style={
-            Object {
-              "fill": "currentColor",
-            }
-          }
-        />
-      </svg>
-    </span>
-  </button>
-  <span
-    className="jump"
-  >
-    <div
-      className="inputWrapper"
-    >
-      <input
-        autoFocus={false}
-        className="editor"
-        defaultValue={4}
-        disabled={false}
-        id="input-16"
-        minLength={1}
-        onChange={[Function]}
-        readOnly={false}
-        required={false}
-        role="textbox"
-        tabIndex={0}
-        type="number"
-      />
-    </div>
-  </span>
 </div>
 `;
 
@@ -6320,7 +6155,7 @@ exports[`Storyshots Pagination Change Page Size 1`] = `
       className="mainWrapper"
     >
       <button
-        aria-controls="dropdown-17"
+        aria-controls="dropdown-15"
         aria-disabled={false}
         aria-expanded={false}
         aria-haspopup={true}
@@ -6361,7 +6196,7 @@ exports[`Storyshots Pagination Change Page Size 1`] = `
           <span
             className="buttonText3"
           >
-            page / 100
+            page / 1000
           </span>
         </span>
       </button>
@@ -6439,30 +6274,13 @@ exports[`Storyshots Pagination Change Page Size 1`] = `
         </span>
       </button>
     </li>
-    <li>
-      <button
-        aria-checked={false}
-        aria-disabled={false}
-        aria-pressed={false}
-        className="paginationButton button buttonDefault buttonSize3"
-        defaultChecked={false}
-        disabled={false}
-        onClick={[Function]}
-      >
-        <span
-          className="buttonText3"
-        >
-          10
-        </span>
-      </button>
-    </li>
   </ul>
   <button
     aria-disabled={false}
     aria-label="Next"
-    className="paginationButton button buttonDefault buttonSize3 iconLeft"
+    className="paginationButton button buttonDefault buttonSize3 iconLeft disabled"
     defaultChecked={false}
-    disabled={false}
+    disabled={true}
     onClick={[Function]}
   >
     <span
@@ -6766,7 +6584,7 @@ exports[`Storyshots Pagination Jump To 1`] = `
         className="editor"
         defaultValue={5}
         disabled={false}
-        id="input-18"
+        id="input-16"
         minLength={1}
         onChange={[Function]}
         readOnly={false}
@@ -8503,13 +8321,13 @@ exports[`Storyshots Select Basic 1`] = `
         className="inputWrapper inputStretch"
       >
         <input
-          aria-controls="dropdown-19"
+          aria-controls="dropdown-17"
           aria-expanded={false}
           aria-haspopup={true}
           autoFocus={false}
           className="selectInput withIcon inputStretch"
           disabled={false}
-          id="input-20"
+          id="input-18"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"
@@ -8574,13 +8392,13 @@ exports[`Storyshots Select Disabled 1`] = `
         className="inputWrapper inputStretch"
       >
         <input
-          aria-controls="dropdown-21"
+          aria-controls="dropdown-19"
           aria-expanded={false}
           aria-haspopup={true}
           autoFocus={false}
           className="selectInput withIcon inputStretch"
           disabled={true}
-          id="input-22"
+          id="input-20"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"
@@ -8635,6 +8453,82 @@ exports[`Storyshots Select Dynamic 1`] = `
 >
   <div
     className="selectWrapper"
+  >
+    <div
+      className="selectDropdownMainWrapper mainWrapper"
+    >
+      <div
+        className="inputWrapper inputStretch"
+      >
+        <input
+          aria-controls="dropdown-21"
+          aria-expanded={false}
+          aria-haspopup={true}
+          autoFocus={false}
+          className="withIcon inputStretch"
+          disabled={false}
+          id="input-22"
+          onChange={[Function]}
+          onClick={[Function]}
+          placeholder="Select"
+          readOnly={false}
+          required={false}
+          role="textbox"
+          style={
+            Object {
+              "minWidth": "unset",
+            }
+          }
+          tabIndex={0}
+          type="text"
+        />
+        <div
+          className="iconWrapper leftIcon"
+        >
+          <span
+            aria-hidden={false}
+            className="iconWrapper"
+            role="presentation"
+          >
+            <svg
+              role="presentation"
+              style={
+                Object {
+                  "height": "20px",
+                  "width": "20px",
+                }
+              }
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7,10L12,15L17,10H7Z"
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Select Filterable 1`] = `
+<div
+  style={
+    Object {
+      "width": "200px",
+    }
+  }
+>
+  <div
+    className="selectWrapper octuple-select-class"
+    data-test-id="octuple-select-test-id"
+    style={Object {}}
   >
     <div
       className="selectDropdownMainWrapper mainWrapper"
@@ -8699,7 +8593,7 @@ exports[`Storyshots Select Dynamic 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Filterable 1`] = `
+exports[`Storyshots Select Multiple 1`] = `
 <div
   style={
     Object {
@@ -8775,7 +8669,7 @@ exports[`Storyshots Select Filterable 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Multiple 1`] = `
+exports[`Storyshots Select Multiple With No Filter 1`] = `
 <div
   style={
     Object {
@@ -8799,20 +8693,15 @@ exports[`Storyshots Select Multiple 1`] = `
           aria-expanded={false}
           aria-haspopup={true}
           autoFocus={false}
-          className="withIcon inputStretch"
+          className="selectInput withIcon inputStretch"
           disabled={false}
           id="input-28"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"
-          readOnly={false}
+          readOnly={true}
           required={false}
           role="textbox"
-          style={
-            Object {
-              "minWidth": "unset",
-            }
-          }
           tabIndex={0}
           type="text"
         />
@@ -8851,7 +8740,7 @@ exports[`Storyshots Select Multiple 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Multiple With No Filter 1`] = `
+exports[`Storyshots Select Options Disabled 1`] = `
 <div
   style={
     Object {
@@ -8922,7 +8811,7 @@ exports[`Storyshots Select Multiple With No Filter 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Options Disabled 1`] = `
+exports[`Storyshots Select With Clear 1`] = `
 <div
   style={
     Object {
@@ -8993,7 +8882,7 @@ exports[`Storyshots Select Options Disabled 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select With Clear 1`] = `
+exports[`Storyshots Select With Default Value 1`] = `
 <div
   style={
     Object {
@@ -9020,77 +8909,6 @@ exports[`Storyshots Select With Clear 1`] = `
           className="selectInput withIcon inputStretch"
           disabled={false}
           id="input-34"
-          onChange={[Function]}
-          onClick={[Function]}
-          placeholder="Select"
-          readOnly={true}
-          required={false}
-          role="textbox"
-          tabIndex={0}
-          type="text"
-        />
-        <div
-          className="iconWrapper leftIcon"
-        >
-          <span
-            aria-hidden={false}
-            className="iconWrapper"
-            role="presentation"
-          >
-            <svg
-              role="presentation"
-              style={
-                Object {
-                  "height": "20px",
-                  "width": "20px",
-                }
-              }
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M7,10L12,15L17,10H7Z"
-                style={
-                  Object {
-                    "fill": "currentColor",
-                  }
-                }
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Select With Default Value 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
-  <div
-    className="selectWrapper octuple-select-class"
-    data-test-id="octuple-select-test-id"
-    style={Object {}}
-  >
-    <div
-      className="selectDropdownMainWrapper mainWrapper"
-    >
-      <div
-        className="inputWrapper inputStretch"
-      >
-        <input
-          aria-controls="dropdown-35"
-          aria-expanded={false}
-          aria-haspopup={true}
-          autoFocus={false}
-          className="selectInput withIcon inputStretch"
-          disabled={false}
-          id="input-36"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"

--- a/src/__snapshots__/storybook.test.js.snap
+++ b/src/__snapshots__/storybook.test.js.snap
@@ -5797,7 +5797,99 @@ exports[`Storyshots Pagination All Combined 1`] = `
   className="my-pagination-class pagination"
   data-test-id="myPaginationTestId"
 >
-  <span />
+  <span
+    className="sizes"
+  >
+    <div
+      className="mainWrapper"
+    >
+      <button
+        aria-controls="dropdown-15"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-haspopup={true}
+        aria-label="Selected page size"
+        className="button buttonDefault buttonSize3 iconLeft"
+        defaultChecked={false}
+        disabled={false}
+        onClick={[Function]}
+        role="button"
+        tabIndex="0"
+      >
+        <span>
+          <span
+            aria-hidden={false}
+            className="icon iconWrapper"
+            role="presentation"
+          >
+            <svg
+              role="presentation"
+              style={
+                Object {
+                  "height": "16px",
+                  "width": "16px",
+                }
+              }
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </svg>
+          </span>
+          <span
+            className="buttonText3"
+          >
+            page / 100
+          </span>
+        </span>
+      </button>
+    </div>
+  </span>
+  <span
+    className="total"
+  >
+    400 Total
+  </span>
+  <button
+    aria-disabled={false}
+    aria-label="Previous"
+    className="paginationButton button buttonDefault buttonSize3 iconLeft"
+    defaultChecked={false}
+    disabled={false}
+    onClick={[Function]}
+  >
+    <span
+      aria-hidden={false}
+      className="icon iconWrapper"
+      role="presentation"
+    >
+      <svg
+        role="presentation"
+        style={
+          Object {
+            "height": "16px",
+            "width": "16px",
+          }
+        }
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+          style={
+            Object {
+              "fill": "currentColor",
+            }
+          }
+        />
+      </svg>
+    </span>
+  </button>
   <ul
     className="pager"
   >
@@ -5835,7 +5927,80 @@ exports[`Storyshots Pagination All Combined 1`] = `
         </span>
       </button>
     </li>
+    <li>
+      <button
+        aria-checked={true}
+        aria-disabled={false}
+        aria-pressed={true}
+        className="paginationButton active button buttonDefault buttonSize3"
+        defaultChecked={true}
+        disabled={false}
+        onClick={[Function]}
+      >
+        <span
+          className="buttonText3"
+        >
+          4
+        </span>
+      </button>
+    </li>
   </ul>
+  <button
+    aria-disabled={false}
+    aria-label="Next"
+    className="paginationButton button buttonDefault buttonSize3 iconLeft disabled"
+    defaultChecked={false}
+    disabled={true}
+    onClick={[Function]}
+  >
+    <span
+      aria-hidden={false}
+      className="icon iconWrapper"
+      role="presentation"
+    >
+      <svg
+        role="presentation"
+        style={
+          Object {
+            "height": "16px",
+            "width": "16px",
+          }
+        }
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+          style={
+            Object {
+              "fill": "currentColor",
+            }
+          }
+        />
+      </svg>
+    </span>
+  </button>
+  <span
+    className="jump"
+  >
+    <div
+      className="inputWrapper"
+    >
+      <input
+        autoFocus={false}
+        className="editor"
+        defaultValue={4}
+        disabled={false}
+        id="input-16"
+        minLength={1}
+        onChange={[Function]}
+        readOnly={false}
+        required={false}
+        role="textbox"
+        tabIndex={0}
+        type="number"
+      />
+    </div>
+  </span>
 </div>
 `;
 
@@ -6155,7 +6320,7 @@ exports[`Storyshots Pagination Change Page Size 1`] = `
       className="mainWrapper"
     >
       <button
-        aria-controls="dropdown-15"
+        aria-controls="dropdown-17"
         aria-disabled={false}
         aria-expanded={false}
         aria-haspopup={true}
@@ -6584,7 +6749,7 @@ exports[`Storyshots Pagination Jump To 1`] = `
         className="editor"
         defaultValue={5}
         disabled={false}
-        id="input-16"
+        id="input-18"
         minLength={1}
         onChange={[Function]}
         readOnly={false}
@@ -8321,13 +8486,13 @@ exports[`Storyshots Select Basic 1`] = `
         className="inputWrapper inputStretch"
       >
         <input
-          aria-controls="dropdown-17"
+          aria-controls="dropdown-19"
           aria-expanded={false}
           aria-haspopup={true}
           autoFocus={false}
           className="selectInput withIcon inputStretch"
           disabled={false}
-          id="input-18"
+          id="input-20"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"
@@ -8392,13 +8557,13 @@ exports[`Storyshots Select Disabled 1`] = `
         className="inputWrapper inputStretch"
       >
         <input
-          aria-controls="dropdown-19"
+          aria-controls="dropdown-21"
           aria-expanded={false}
           aria-haspopup={true}
           autoFocus={false}
           className="selectInput withIcon inputStretch"
           disabled={true}
-          id="input-20"
+          id="input-22"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"
@@ -8453,82 +8618,6 @@ exports[`Storyshots Select Dynamic 1`] = `
 >
   <div
     className="selectWrapper"
-  >
-    <div
-      className="selectDropdownMainWrapper mainWrapper"
-    >
-      <div
-        className="inputWrapper inputStretch"
-      >
-        <input
-          aria-controls="dropdown-21"
-          aria-expanded={false}
-          aria-haspopup={true}
-          autoFocus={false}
-          className="withIcon inputStretch"
-          disabled={false}
-          id="input-22"
-          onChange={[Function]}
-          onClick={[Function]}
-          placeholder="Select"
-          readOnly={false}
-          required={false}
-          role="textbox"
-          style={
-            Object {
-              "minWidth": "unset",
-            }
-          }
-          tabIndex={0}
-          type="text"
-        />
-        <div
-          className="iconWrapper leftIcon"
-        >
-          <span
-            aria-hidden={false}
-            className="iconWrapper"
-            role="presentation"
-          >
-            <svg
-              role="presentation"
-              style={
-                Object {
-                  "height": "20px",
-                  "width": "20px",
-                }
-              }
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M7,10L12,15L17,10H7Z"
-                style={
-                  Object {
-                    "fill": "currentColor",
-                  }
-                }
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Select Filterable 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
-  <div
-    className="selectWrapper octuple-select-class"
-    data-test-id="octuple-select-test-id"
-    style={Object {}}
   >
     <div
       className="selectDropdownMainWrapper mainWrapper"
@@ -8593,7 +8682,7 @@ exports[`Storyshots Select Filterable 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Multiple 1`] = `
+exports[`Storyshots Select Filterable 1`] = `
 <div
   style={
     Object {
@@ -8669,7 +8758,7 @@ exports[`Storyshots Select Multiple 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Multiple With No Filter 1`] = `
+exports[`Storyshots Select Multiple 1`] = `
 <div
   style={
     Object {
@@ -8693,15 +8782,20 @@ exports[`Storyshots Select Multiple With No Filter 1`] = `
           aria-expanded={false}
           aria-haspopup={true}
           autoFocus={false}
-          className="selectInput withIcon inputStretch"
+          className="withIcon inputStretch"
           disabled={false}
           id="input-28"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"
-          readOnly={true}
+          readOnly={false}
           required={false}
           role="textbox"
+          style={
+            Object {
+              "minWidth": "unset",
+            }
+          }
           tabIndex={0}
           type="text"
         />
@@ -8740,7 +8834,7 @@ exports[`Storyshots Select Multiple With No Filter 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Options Disabled 1`] = `
+exports[`Storyshots Select Multiple With No Filter 1`] = `
 <div
   style={
     Object {
@@ -8811,7 +8905,7 @@ exports[`Storyshots Select Options Disabled 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select With Clear 1`] = `
+exports[`Storyshots Select Options Disabled 1`] = `
 <div
   style={
     Object {
@@ -8882,7 +8976,7 @@ exports[`Storyshots Select With Clear 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select With Default Value 1`] = `
+exports[`Storyshots Select With Clear 1`] = `
 <div
   style={
     Object {
@@ -8909,6 +9003,77 @@ exports[`Storyshots Select With Default Value 1`] = `
           className="selectInput withIcon inputStretch"
           disabled={false}
           id="input-34"
+          onChange={[Function]}
+          onClick={[Function]}
+          placeholder="Select"
+          readOnly={true}
+          required={false}
+          role="textbox"
+          tabIndex={0}
+          type="text"
+        />
+        <div
+          className="iconWrapper leftIcon"
+        >
+          <span
+            aria-hidden={false}
+            className="iconWrapper"
+            role="presentation"
+          >
+            <svg
+              role="presentation"
+              style={
+                Object {
+                  "height": "20px",
+                  "width": "20px",
+                }
+              }
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M7,10L12,15L17,10H7Z"
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Select With Default Value 1`] = `
+<div
+  style={
+    Object {
+      "width": "200px",
+    }
+  }
+>
+  <div
+    className="selectWrapper octuple-select-class"
+    data-test-id="octuple-select-test-id"
+    style={Object {}}
+  >
+    <div
+      className="selectDropdownMainWrapper mainWrapper"
+    >
+      <div
+        className="inputWrapper inputStretch"
+      >
+        <input
+          aria-controls="dropdown-35"
+          aria-expanded={false}
+          aria-haspopup={true}
+          autoFocus={false}
+          className="selectInput withIcon inputStretch"
+          disabled={false}
+          id="input-36"
           onChange={[Function]}
           onClick={[Function]}
           placeholder="Select"

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -16,6 +16,14 @@ export default {
                                 If you have too much data to display in one
                                 page, use pagination.
                             </p>
+                            <p>
+                                The total number of pages is a required prop as
+                                it's used to determine the visibility of the
+                                paginaiton and its elements. Be sure to track
+                                the total number of pages at any given time and
+                                send this information dynamically to the
+                                component.
+                            </p>
                         </section>
                         <section>
                             <Stories includePrimary title="" />
@@ -169,5 +177,5 @@ All_Combined.args = {
     ],
     pageSize: 100,
     pageSizes: [100, 200, 300, 400],
-    total: 400,
+    total: 1,
 };

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -177,5 +177,5 @@ All_Combined.args = {
     ],
     pageSize: 100,
     pageSizes: [100, 200, 300, 400],
-    total: 1,
+    total: 400,
 };

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Ref, useState } from 'react';
+import React, { FC, Ref, useEffect, useState } from 'react';
 import { Pager, PaginationLayoutOptions, PaginationProps } from './index';
 import { ButtonIconAlign, ButtonSize, DefaultButton } from '../Button';
 import { Dropdown } from '../Dropdown';
@@ -8,7 +8,6 @@ import { TextInput } from '../Inputs';
 import { mergeClasses } from '../../shared/utilities';
 import { useBoolean } from '../../octuple';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
-import { useSingleton } from '../../hooks/useSingleton';
 
 import styles from './pagination.module.scss';
 
@@ -35,7 +34,7 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
             previousIconButtonAriaLabel = 'Previous',
             quickNextIconButtonAriaLabel = 'Next 5',
             quickPreviousIconButtonAriaLabel = 'Previous 5',
-            total,
+            total = 1,
             totalText = 'Total',
             'data-test-id': dataTestId,
             ...rest
@@ -51,17 +50,15 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
         const [_pageSizes, setPageSizes] = useState<number[]>(pageSizes);
         const [_total, setTotal] = useState<number>(total);
 
-        useSingleton((): void => {
-            if (pageSizes) {
-                setPageSize(
-                    pageSizes.indexOf(pageSize) > -1 ? pageSize : pageSizes[0]
-                );
-            }
+        const inputRef = React.createRef<HTMLInputElement>();
 
+        useEffect((): void => {
             setTotal(total);
-
-            setCurrentPage(_currentPage || 1);
-        });
+            onSizeChangeHandler?.(
+                pageSizes.indexOf(pageSize) > -1 ? pageSize : pageSizes[0]
+            );
+            jumpToPage?.(currentPage);
+        }, []);
 
         const previous = (): void => {
             const oldVal: number = _currentPage;
@@ -71,6 +68,11 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
 
             if (newVal !== oldVal) {
                 onCurrentChange?.(newVal);
+                const inputVal: string = newVal.toString();
+
+                if (inputRef.current) {
+                    inputRef.current.value = inputVal;
+                }
             }
         };
 
@@ -82,6 +84,11 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
 
             if (newVal !== oldVal) {
                 onCurrentChange?.(newVal);
+                const inputVal: string = newVal.toString();
+
+                if (inputRef.current) {
+                    inputRef.current.value = inputVal;
+                }
             }
         };
 
@@ -114,6 +121,11 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
 
             if (oldVal !== val) {
                 onCurrentChange?.(val);
+                const inputVal: string = val.toString();
+
+                if (inputRef.current) {
+                    inputRef.current.value = inputVal;
+                }
             }
         };
 
@@ -133,7 +145,8 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
             if (
                 !target?.value ||
                 isNaN(parseInt(target?.value, 10)) ||
-                parseInt(target?.value, 10) > getPageCount()
+                parseInt(target?.value, 10) > getPageCount() ||
+                parseInt(target?.value, 10) < 1
             ) {
                 jumpToPage(1);
             } else {
@@ -155,6 +168,8 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
             return <Menu onChange={onSizeChangeHandler} items={getItems()} />;
         };
 
+        const moreThanOnePage: boolean = _total > 1;
+
         const paginationWrapperClassNames: string = mergeClasses([
             classNames,
             styles.pagination,
@@ -168,107 +183,118 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
                 className={paginationWrapperClassNames}
                 data-test-id={dataTestId}
             >
-                {layout.includes(PaginationLayoutOptions.Sizes) && (
-                    <span className={styles.sizes} key="sizes">
-                        {/** TODO: Replace with Select component when available */}
-                        <Dropdown
-                            overlay={Overlay(_pageSizes)}
-                            onVisibleChange={setToggle}
-                        >
-                            <DefaultButton
-                                alignIcon={
-                                    htmlDir === 'ltr'
-                                        ? ButtonIconAlign.Right
-                                        : ButtonIconAlign.Left
+                {_total > 0 && (
+                    <>
+                        {layout.includes(PaginationLayoutOptions.Sizes) &&
+                            moreThanOnePage && (
+                                <span className={styles.sizes} key="sizes">
+                                    {/** TODO: Replace with Select component when available */}
+                                    <Dropdown
+                                        overlay={Overlay(_pageSizes)}
+                                        onVisibleChange={setToggle}
+                                    >
+                                        <DefaultButton
+                                            alignIcon={
+                                                htmlDir === 'ltr'
+                                                    ? ButtonIconAlign.Right
+                                                    : ButtonIconAlign.Left
+                                            }
+                                            ariaLabel={pageSizeButtonAriaLabel}
+                                            iconProps={{
+                                                role: 'presentation',
+                                                path: _toggle
+                                                    ? IconName.mdiChevronDown
+                                                    : IconName.mdiChevronUp,
+                                            }}
+                                            size={ButtonSize.Small}
+                                            text={
+                                                htmlDir === 'ltr'
+                                                    ? `${_pageSize} / ${pageSizeText}`
+                                                    : `${pageSizeText} / ${_pageSize}`
+                                            }
+                                        />
+                                    </Dropdown>
+                                </span>
+                            )}
+                        {layout.includes(PaginationLayoutOptions.Total) &&
+                        moreThanOnePage ? (
+                            <span className={styles.total} key="total">
+                                {htmlDir === 'ltr'
+                                    ? `${totalText} ${total}`
+                                    : `${total} ${totalText}`}
+                            </span>
+                        ) : (
+                            <span />
+                        )}
+                        {layout.includes(PaginationLayoutOptions.Previous) &&
+                            moreThanOnePage && (
+                                <DefaultButton
+                                    ariaLabel={previousIconButtonAriaLabel}
+                                    classNames={styles.paginationButton}
+                                    key="previous"
+                                    disabled={_currentPage <= 1}
+                                    iconProps={{
+                                        role: 'presentation',
+                                        path: IconName.mdiChevronLeft,
+                                    }}
+                                    onClick={previous}
+                                    size={ButtonSize.Small}
+                                />
+                            )}
+                        {layout.includes(PaginationLayoutOptions.Pager) && (
+                            <Pager
+                                currentPage={_currentPage}
+                                key="pager"
+                                onCurrentChange={handleCurrentChange}
+                                pageCount={getPageCount()}
+                                quickNextIconButtonAriaLabel={
+                                    quickNextIconButtonAriaLabel
                                 }
-                                ariaLabel={pageSizeButtonAriaLabel}
-                                iconProps={{
-                                    role: 'presentation',
-                                    path: _toggle
-                                        ? IconName.mdiChevronDown
-                                        : IconName.mdiChevronUp,
-                                }}
-                                size={ButtonSize.Small}
-                                text={
-                                    htmlDir === 'ltr'
-                                        ? `${_pageSize} / ${pageSizeText}`
-                                        : `${pageSizeText} / ${_pageSize}`
+                                quickPreviousIconButtonAriaLabel={
+                                    quickPreviousIconButtonAriaLabel
                                 }
                             />
-                        </Dropdown>
-                    </span>
-                )}
-                {layout.includes(PaginationLayoutOptions.Total) && total > 0 ? (
-                    <span className={styles.total} key="total">
-                        {htmlDir === 'ltr'
-                            ? `${totalText} ${total}`
-                            : `${total} ${totalText}`}
-                    </span>
-                ) : (
-                    <span />
-                )}
-                {layout.includes(PaginationLayoutOptions.Previous) && (
-                    <DefaultButton
-                        ariaLabel={previousIconButtonAriaLabel}
-                        classNames={styles.paginationButton}
-                        key="previous"
-                        disabled={_currentPage <= 1}
-                        iconProps={{
-                            role: 'presentation',
-                            path: IconName.mdiChevronLeft,
-                        }}
-                        onClick={previous}
-                        size={ButtonSize.Small}
-                    />
-                )}
-                {layout.includes(PaginationLayoutOptions.Pager) && (
-                    <Pager
-                        currentPage={_currentPage}
-                        key="pager"
-                        onCurrentChange={handleCurrentChange}
-                        pageCount={getPageCount()}
-                        quickNextIconButtonAriaLabel={
-                            quickNextIconButtonAriaLabel
-                        }
-                        quickPreviousIconButtonAriaLabel={
-                            quickPreviousIconButtonAriaLabel
-                        }
-                    />
-                )}
-                {layout.includes(PaginationLayoutOptions.Next) && (
-                    <DefaultButton
-                        ariaLabel={nextIconButtonAriaLabel}
-                        classNames={styles.paginationButton}
-                        key="next"
-                        disabled={
-                            _currentPage === getPageCount() || _pageCount === 0
-                        }
-                        iconProps={{
-                            role: 'presentation',
-                            path: IconName.mdiChevronRight,
-                        }}
-                        onClick={() => next()}
-                        size={ButtonSize.Small}
-                    />
-                )}
-                {layout.includes(PaginationLayoutOptions.Jumper) && (
-                    <span className={styles.jump} key="jumper">
-                        {htmlDir === 'ltr' && goToText}
-                        <TextInput
-                            classNames={styles.editor}
-                            minlength={1}
-                            maxlength={_pageCount}
-                            numbersOnly
-                            defaultValue={
-                                _currentPage > getPageCount() ||
-                                _currentPage <= 0
-                                    ? 1
-                                    : _currentPage
-                            }
-                            onChange={handleJumpOnChange}
-                        />
-                        {htmlDir === 'rtl' && goToText}
-                    </span>
+                        )}
+                        {layout.includes(PaginationLayoutOptions.Next) &&
+                            moreThanOnePage && (
+                                <DefaultButton
+                                    ariaLabel={nextIconButtonAriaLabel}
+                                    classNames={styles.paginationButton}
+                                    key="next"
+                                    disabled={
+                                        _currentPage === getPageCount() ||
+                                        _pageCount === 0
+                                    }
+                                    iconProps={{
+                                        role: 'presentation',
+                                        path: IconName.mdiChevronRight,
+                                    }}
+                                    onClick={() => next()}
+                                    size={ButtonSize.Small}
+                                />
+                            )}
+                        {layout.includes(PaginationLayoutOptions.Jumper) &&
+                            moreThanOnePage && (
+                                <span className={styles.jump} key="jumper">
+                                    {htmlDir === 'ltr' && goToText}
+                                    <TextInput
+                                        ref={inputRef}
+                                        classNames={styles.editor}
+                                        minlength={1}
+                                        maxlength={_pageCount}
+                                        numbersOnly
+                                        defaultValue={
+                                            _currentPage > getPageCount() ||
+                                            _currentPage <= 0
+                                                ? 1
+                                                : _currentPage
+                                        }
+                                        onChange={handleJumpOnChange}
+                                    />
+                                    {htmlDir === 'rtl' && goToText}
+                                </span>
+                            )}
+                    </>
                 )}
             </div>
         );

--- a/src/components/Pagination/Pagination.types.ts
+++ b/src/components/Pagination/Pagination.types.ts
@@ -98,8 +98,9 @@ export interface PaginationProps extends OcBaseProps<HTMLElement> {
     quickPreviousIconButtonAriaLabel?: string;
     /**
      * The Pagination total number of pages.
+     * @default 1
      */
-    total?: number;
+    total: number;
     /**
      * The 'Total' text string.
      * @default 'Total'


### PR DESCRIPTION
## SUMMARY:
Previously, the page size and jumper didn't work because they only were set when the component rendered, this updates those to useEffect and update dynamically. Also adds a variable to track the total number of pages is greater than 1 to determine the visibility of certain elements that are only relevant when there are more than 1 page. Adds a wrpper to check if there are more than 0 pages, if not hide all elements.

## JIRA TASK (Eightfold Employees Only):
ENG-13961

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Test by setting to total to 0, 1 and 100 dynamically via a query.