### PR TITLE
chore: add indicator to distinguish octuple components

### DIFF
--- a/src/components/Atom/Atom.tsx
+++ b/src/components/Atom/Atom.tsx
@@ -4,7 +4,7 @@ import { AtomProps } from './Atom.types';
 
 export const Atom = React.forwardRef(
     ({ of, children, classes = [], ...props }, ref): JSX.Element => {
-        const computedClassName = mergeClasses(classes);
+        const computedClassName = mergeClasses([...classes, 'oct-component']);
         return React.createElement(
             of,
             { ...props, ref, className: computedClassName },

--- a/src/components/MatchScore/MatchScore.tsx
+++ b/src/components/MatchScore/MatchScore.tsx
@@ -2,6 +2,7 @@ import React, { FC, Ref } from 'react';
 import styles from './matchScore.module.scss';
 import { mergeClasses } from '../../shared/utilities';
 import { FillType, MatchScoreProps } from './MatchScore.types';
+import { Atom } from '../Atom';
 
 export const MatchScore: FC<MatchScoreProps> = React.forwardRef(
     (
@@ -21,10 +22,11 @@ export const MatchScore: FC<MatchScoreProps> = React.forwardRef(
             styles.matchScoreContainer
         );
         return (
-            <div
+            <Atom<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>
+                of="div"
                 {...rest}
                 ref={ref}
-                className={matchScoreClasses}
+                classes={[classNames, styles.matchScoreContainer]}
                 aria-label={ariaLabel}
             >
                 {getArrayOfSize(Math.min(Math.floor(score), absTotal)).map(
@@ -45,7 +47,7 @@ export const MatchScore: FC<MatchScoreProps> = React.forwardRef(
                         {score}/{absTotal}
                     </p>
                 )}
-            </div>
+            </Atom>
         );
     }
 );


### PR DESCRIPTION
## SUMMARY:
Surya has requested a way to determine if a component is an octuple component via dev tools inspector.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [X] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
