### PR TITLE
fix: textarea: event persist issue in react 16

### DIFF
--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -55,21 +55,22 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
             },
         ]);
 
-        const handleChange = useDebounce<
+        const debouncedChange = useDebounce<
             React.ChangeEvent<HTMLTextAreaElement>
         >(
             (
                 _event?: React.ChangeEvent<
                     HTMLTextAreaElement | HTMLInputElement
                 >
-            ) => triggerChange(_event),
+            ) => onChange?.(_event),
             waitInterval
         );
 
-        const triggerChange = (
-            _event?: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-        ) => {
-            onChange && onChange(_event);
+        // We need to persist the syntheticevent object, as useDebounce uses a timeout function internally
+        // Reference: https://reactjs.org/docs/legacy-event-pooling.html
+        const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            e.persist();
+            debouncedChange(e);
         };
 
         return (


### PR DESCRIPTION
## SUMMARY:
fix: textarea: event persist issue in react 16

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-22443

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
