### PR TITLE
fix: button: removes focus outline and border style when not in keyboard mode

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -6,7 +6,6 @@
     --button-visited-foreground-color: var(--primary-color-80);
     --button-default-outline-color: var(--primary-color);
     --button-hover-outline-color: var(--primary-color-60);
-    --button-focus-outline-color: var(--primary-color-80);
     --button-active-outline-color: var(--primary-color-80);
     --button-visited-outline-color: var(--primary-color-80);
     --button-focus-outline-color: var(--primary-color-40);

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -535,18 +535,72 @@
                     var(--button-primary-focus-border-color);
             }
         }
+
+        &.button-primary-disruptive {
+            &:focus-visible {
+                outline: $focus-visible-outline-width solid
+                    var(--disruptive-color-80);
+            }
+        }
+
+        &.button-secondary {
+            &:focus-visible {
+                background-color: var(--button-focus-background-color);
+                color: var(--button-focus-foreground-color);
+            }
+        }
+
+        &.button-secondary-disruptive {
+            &:focus-visible {
+                color: var(--disruptive-color-80);
+                outline-color: var(--disruptive-color-80);
+            }
+        }
+
+        &.button-default {
+            &:focus-visible {
+                background-color: var(--button-focus-background-color);
+                color: var(--button-focus-foreground-color);
+            }
+        }
+
+        &.button-disruptive {
+            &:focus-visible {
+                background-color: var(--disruptive-color-10);
+                color: var(--disruptive-color-80);
+                outline-color: var(--disruptive-color-80);
+            }
+        }
+
+        &.button-neutral {
+            &:focus-visible {
+                background-color: var(--grey-color-10);
+                color: var(--text-secondary-color);
+                outline-color: var(--grey-color-80);
+            }
+        }
     }
 
     .two-state-button {
         &:focus-visible {
+            background-color: var(--button-two-state-focus-background-color);
+            color: var(--button-two-state-focus-foreground-color);
             outline-width: $focus-visible-outline-width;
             outline-offset: $focus-visible-outline-offset-inner;
             outline-color: var(--button-focus-outline-color);
 
             &.checked {
+                background-color: var(
+                    --button-two-state-checked-background-color
+                );
+                color: var(--button-two-state-checked-foreground-color);
                 outline-width: $focus-visible-outline-width;
                 outline-offset: $focus-visible-outline-offset-inner;
                 outline-color: var(--button-focus-outline-color);
+            }
+
+            .counter {
+                background-color: var(--button-counter-focus-background-color);
             }
         }
     }

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -9,6 +9,7 @@
     --button-focus-outline-color: var(--primary-color-80);
     --button-active-outline-color: var(--primary-color-80);
     --button-visited-outline-color: var(--primary-color-80);
+    --button-focus-outline-color: var(--primary-color-40);
     --button-primary-default-background-color: var(--primary-color);
     --button-primary-hover-background-color: var(--primary-color-60);
     --button-primary-focus-background-color: var(--primary-color-80);
@@ -176,17 +177,11 @@
     }
 
     &:active {
-        .counter {
-            background-color: var(--button-counter-active-background-color);
-        }
-    }
-
-    &:focus {
         outline: 1px solid var(--button-focus-outline-color);
         outline-offset: -1px;
 
         .counter {
-            background-color: var(--button-counter-focus-background-color);
+            background-color: var(--button-counter-active-background-color);
         }
     }
 }
@@ -279,10 +274,6 @@
         border-color: var(--button-primary-active-border-color);
         color: var(--text-inverse-color);
     }
-
-    &:focus-visible {
-        outline-color: var(--button-primary-focus-border-color);
-    }
 }
 
 .button-secondary {
@@ -302,12 +293,6 @@
         color: var(--button-active-foreground-color);
         outline-color: var(--button-active-outline-color);
     }
-
-    &:focus {
-        background-color: var(--button-focus-background-color);
-        color: var(--button-focus-foreground-color);
-        outline-color: var(--button-focus-outline-color);
-    }
 }
 
 .button-primary-disruptive {
@@ -324,10 +309,6 @@
         background-color: var(--disruptive-color-80);
         border-color: var(--disruptive-color-80);
     }
-
-    &:focus {
-        outline-color: var(--disruptive-color-80);
-    }
 }
 
 .button-secondary-disruptive {
@@ -343,11 +324,6 @@
     }
 
     &:active {
-        color: var(--disruptive-color-80);
-        outline-color: var(--disruptive-color-80);
-    }
-
-    &:focus {
         color: var(--disruptive-color-80);
         outline-color: var(--disruptive-color-80);
     }
@@ -370,12 +346,6 @@
         color: var(--button-active-foreground-color);
         outline-color: var(--button-active-background-color);
     }
-
-    &:focus {
-        background-color: var(--button-focus-background-color);
-        color: var(--button-focus-foreground-color);
-        outline-color: var(--button-focus-outline-color);
-    }
 }
 
 .button-disruptive {
@@ -395,12 +365,6 @@
         color: var(--disruptive-color-80);
         outline-color: var(--disruptive-color-10);
     }
-
-    &:focus {
-        background-color: var(--disruptive-color-10);
-        color: var(--disruptive-color-80);
-        outline-color: var(--disruptive-color-80);
-    }
 }
 
 .button-neutral {
@@ -419,12 +383,6 @@
         background-color: var(--grey-color-20);
         color: var(--text-secondary-color);
         outline-color: var(--grey-color-10);
-    }
-
-    &:focus {
-        background-color: var(--grey-color-10);
-        color: var(--text-secondary-color);
-        outline-color: var(--grey-color-80);
     }
 }
 
@@ -560,22 +518,6 @@
             background-color: var(--button-counter-checked-background-color);
         }
     }
-
-    &:focus {
-        background-color: var(--button-two-state-focus-background-color);
-        color: var(--button-two-state-focus-foreground-color);
-        outline: 1px solid var(--button-two-state-focus-outline-color);
-
-        &.checked {
-            background-color: var(--button-two-state-checked-background-color);
-            color: var(--button-two-state-checked-foreground-color);
-            outline: 1px solid var(--button-two-state-focus-outline-color);
-        }
-
-        .counter {
-            background-color: var(--button-counter-focus-background-color);
-        }
-    }
 }
 
 :global(.focus-visible) {
@@ -583,7 +525,15 @@
         &:focus-visible {
             outline-width: $focus-visible-outline-width;
             outline-offset: $focus-visible-outline-offset-inner;
-            outline-color: var(--primary-color-40);
+            outline-color: var(--button-focus-outline-color);
+        }
+
+        // Primary button doesn't have an outline. Add one for keyboard focus modality.
+        &.button-primary {
+            &:focus-visible {
+                outline: $focus-visible-outline-width solid
+                    var(--button-primary-focus-border-color);
+            }
         }
     }
 
@@ -591,12 +541,12 @@
         &:focus-visible {
             outline-width: $focus-visible-outline-width;
             outline-offset: $focus-visible-outline-offset-inner;
-            outline-color: var(--primary-color-40);
+            outline-color: var(--button-focus-outline-color);
 
             &.checked {
                 outline-width: $focus-visible-outline-width;
                 outline-offset: $focus-visible-outline-offset-inner;
-                outline-color: var(--primary-color-40);
+                outline-color: var(--button-focus-outline-color);
             }
         }
     }

--- a/src/shared/variables.ts
+++ b/src/shared/variables.ts
@@ -170,5 +170,7 @@ export interface CSSVariables extends React.CSSProperties {
     '--button-active-outline-color'?: string;
     '--button-visited-outline-color'?: string;
 
+    '--button-focus-outline-color'?: string;
+
     '--font-size'?: string;
 }

--- a/src/shared/variables.ts
+++ b/src/shared/variables.ts
@@ -166,7 +166,6 @@ export interface CSSVariables extends React.CSSProperties {
 
     '--button-default-outline-color'?: string;
     '--button-hover-outline-color'?: string;
-    '--button-focus-outline-color'?: string;
     '--button-active-outline-color'?: string;
     '--button-visited-outline-color'?: string;
 

--- a/src/styles/themes/_definitions-light.scss
+++ b/src/styles/themes/_definitions-light.scss
@@ -163,6 +163,7 @@ $button-hover-outline-color: var(--button-hover-outline-color);
 $button-focus-outline-color: var(--button-focus-outline-color);
 $button-active-outline-color: var(--button-active-outline-color);
 $button-visited-outline-color: var(--button-visited-outline-color);
+$button-focus-outline-color: var(--button-focus-outline-color);
 
 $text-color-primary: var(--grey-color-90);
 $text-color-secondary: var(--grey-color-80);

--- a/src/styles/themes/_definitions-light.scss
+++ b/src/styles/themes/_definitions-light.scss
@@ -296,8 +296,8 @@ $corner-radius-xl: 24px;
 
 // Focus visible Definitions
 
-$focus-visible-outline-width: 4px;
-$focus-visible-outline-offset-inner: -4px;
+$focus-visible-outline-width: 2px;
+$focus-visible-outline-offset-inner: -2px;
 $focus-visible-outline-offset-outer: 2px;
 
 // Speed / Duration Definitions


### PR DESCRIPTION
## SUMMARY:
The `:focus` selector property is not needed. It was reported that the buttons appeared to be stuck in an active state after click. This change removes `:focus` and defers to `.focus-visible:focus-visible`, only showing the focused state when using keyboard via the ConfigProvider.

## JIRA TASK (Eightfold Employees Only):
ENG-22620

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:
NA

## TEST PLAN:
Pull the PR changes, build storybook and verify focus styles and that they only appear when using keyboard in the ConfigProvider story view.