### PR TITLE
fix: tabs: allign first item to the left

### DIFF
--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -18,6 +18,13 @@
         transition: background-color $motion-duration-fast
             $motion-easing-easeout 0s;
 
+        &:first-child {
+            padding-left: 0;
+            .tab-indicator {
+                width: calc(100% - #{$space-xl / 2});
+            }
+        }
+
         &:hover,
         &:focus {
             color: var(--tab-hover-label);


### PR DESCRIPTION
## SUMMARY:
fix: tabs: allign first item to the left

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-22845

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
