### PR TITLE
feat: eng-22373: enable floating buttons

### DIFF
--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -40,6 +40,7 @@ export const BaseButton: FC<InternalButtonProps> = React.forwardRef(
             split,
             splitButtonChecked = false,
             splitButtonProps,
+            floatingButtonProps,
             style,
             text,
             theme,
@@ -82,6 +83,7 @@ export const BaseButton: FC<InternalButtonProps> = React.forwardRef(
             { [styles.pillShape]: shape === ButtonShape.Pill },
             { [styles.dropShadow]: dropShadow },
             { [styles.dark]: theme === ButtonTheme.dark },
+            { [styles.floating]: floatingButtonProps?.enabled },
         ]);
 
         const buttonBaseClassNames: string = mergeClasses([

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -30,6 +30,7 @@ export const BaseButton: FC<InternalButtonProps> = React.forwardRef(
             disabled = false,
             disruptive = false,
             dropShadow = false,
+            floatingButtonProps,
             htmlType,
             iconProps,
             id,
@@ -40,7 +41,6 @@ export const BaseButton: FC<InternalButtonProps> = React.forwardRef(
             split,
             splitButtonChecked = false,
             splitButtonProps,
-            floatingButtonProps,
             style,
             text,
             theme,
@@ -81,7 +81,10 @@ export const BaseButton: FC<InternalButtonProps> = React.forwardRef(
             { [styles.buttonSize2]: size === ButtonSize.Medium },
             { [styles.buttonSize3]: size === ButtonSize.Small },
             { [styles.pillShape]: shape === ButtonShape.Pill },
-            { [styles.roundShape]: shape === ButtonShape.Round },
+            {
+                [styles.roundShape]:
+                    shape === ButtonShape.Round && !split && !textExists,
+            },
             { [styles.dropShadow]: dropShadow },
             { [styles.dark]: theme === ButtonTheme.dark },
             { [styles.floating]: floatingButtonProps?.enabled },

--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -81,6 +81,7 @@ export const BaseButton: FC<InternalButtonProps> = React.forwardRef(
             { [styles.buttonSize2]: size === ButtonSize.Medium },
             { [styles.buttonSize3]: size === ButtonSize.Small },
             { [styles.pillShape]: shape === ButtonShape.Pill },
+            { [styles.roundShape]: shape === ButtonShape.Round },
             { [styles.dropShadow]: dropShadow },
             { [styles.dark]: theme === ButtonTheme.dark },
             { [styles.floating]: floatingButtonProps?.enabled },

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -212,6 +212,9 @@ const buttonArgs: Object = {
     disabled: false,
     disruptive: false,
     dropShadow: false,
+    floatingButtonProps: {
+        enabled: false,
+    },
     htmlType: 'button',
     iconProps: {
         path: IconName.mdiCardsHeart,

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -142,7 +142,11 @@ export default {
             action: 'contextmenu',
         },
         shape: {
-            options: [ButtonShape.Rectangle, ButtonShape.Pill],
+            options: [
+                ButtonShape.Rectangle,
+                ButtonShape.Pill,
+                ButtonShape.Round,
+            ],
             control: { type: 'inline-radio' },
         },
         size: {

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -28,6 +28,7 @@ export enum ButtonWidth {
 export enum ButtonShape {
     Rectangle = 'rectangle',
     Pill = 'pill',
+    Round = 'round',
 }
 
 export enum ButtonTheme {

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -53,6 +53,14 @@ export interface InternalButtonProps extends ButtonProps {
     ref?: Ref<HTMLButtonElement>;
 }
 
+export interface FloatingButtonProps {
+    /**
+     * Determines if the button is floating.
+     * @default false
+     */
+    enabled?: boolean;
+}
+
 export type NativeButtonProps = Omit<OcBaseProps<HTMLButtonElement>, 'type'>;
 
 export interface SplitButtonProps
@@ -193,4 +201,8 @@ export interface ButtonProps extends NativeButtonProps {
      * The button is a toggle button with distinct on and off states.
      */
     toggle?: boolean;
+    /**
+     * The button is always floating on bottom right corner.
+     */
+    floatingButtonProps?: FloatingButtonProps;
 }

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -143,6 +143,10 @@ export interface ButtonProps extends NativeButtonProps {
      */
     dropShadow?: boolean;
     /**
+     * The button is always floating on bottom right corner.
+     */
+    floatingButtonProps?: FloatingButtonProps;
+    /**
      * The button html type.
      */
     htmlType?: 'button' | 'submit' | 'reset';
@@ -202,8 +206,4 @@ export interface ButtonProps extends NativeButtonProps {
      * The button is a toggle button with distinct on and off states.
      */
     toggle?: boolean;
-    /**
-     * The button is always floating on bottom right corner.
-     */
-    floatingButtonProps?: FloatingButtonProps;
 }

--- a/src/components/Button/DefaultButton/DefaultButton.tsx
+++ b/src/components/Button/DefaultButton/DefaultButton.tsx
@@ -24,6 +24,7 @@ export const DefaultButton: FC<ButtonProps> = React.forwardRef(
             counter,
             disabled = false,
             dropShadow = false,
+            floatingButtonProps,
             htmlType,
             iconProps,
             onClick,
@@ -62,6 +63,7 @@ export const DefaultButton: FC<ButtonProps> = React.forwardRef(
                 counter={counter}
                 disabled={disabled}
                 dropShadow={dropShadow}
+                floatingButtonProps={floatingButtonProps}
                 htmlType={htmlType}
                 iconProps={iconProps}
                 onClick={onClick}
@@ -73,8 +75,8 @@ export const DefaultButton: FC<ButtonProps> = React.forwardRef(
                 style={style}
                 text={text}
                 theme={theme}
-                type={ButtonType.Default}
                 toggle={toggle}
+                type={ButtonType.Default}
                 buttonWidth={buttonWidth}
             />
         );

--- a/src/components/Button/NeutralButton/NeutralButton.tsx
+++ b/src/components/Button/NeutralButton/NeutralButton.tsx
@@ -24,6 +24,7 @@ export const NeutralButton: FC<ButtonProps> = React.forwardRef(
             counter,
             disabled = false,
             dropShadow = false,
+            floatingButtonProps,
             htmlType,
             iconProps,
             onClick,
@@ -60,6 +61,7 @@ export const NeutralButton: FC<ButtonProps> = React.forwardRef(
                 counter={counter}
                 disabled={disabled}
                 dropShadow={dropShadow}
+                floatingButtonProps={floatingButtonProps}
                 htmlType={htmlType}
                 iconProps={iconProps}
                 onClick={onClick}
@@ -71,8 +73,8 @@ export const NeutralButton: FC<ButtonProps> = React.forwardRef(
                 style={style}
                 text={text}
                 theme={theme}
-                type={ButtonType.Neutral}
                 toggle={toggle}
+                type={ButtonType.Neutral}
                 buttonWidth={buttonWidth}
             />
         );

--- a/src/components/Button/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton/PrimaryButton.tsx
@@ -25,6 +25,7 @@ export const PrimaryButton: FC<ButtonProps> = React.forwardRef(
             disabled = false,
             disruptive = false,
             dropShadow = false,
+            floatingButtonProps,
             htmlType,
             iconProps,
             onClick,
@@ -61,10 +62,10 @@ export const PrimaryButton: FC<ButtonProps> = React.forwardRef(
                 checked={checked}
                 classNames={buttonClassNames}
                 counter={counter}
-                splitButtonChecked={splitButtonChecked}
                 disabled={disabled}
                 disruptive={disruptive}
                 dropShadow={dropShadow}
+                floatingButtonProps={floatingButtonProps}
                 htmlType={htmlType}
                 iconProps={iconProps}
                 onClick={onClick}
@@ -72,12 +73,13 @@ export const PrimaryButton: FC<ButtonProps> = React.forwardRef(
                 shape={shape}
                 size={size}
                 split={split}
+                splitButtonChecked={splitButtonChecked}
                 splitButtonProps={splitButtonProps}
                 style={style}
                 text={text}
                 theme={theme}
-                type={ButtonType.Primary}
                 toggle={toggle}
+                type={ButtonType.Primary}
                 buttonWidth={buttonWidth}
             />
         );

--- a/src/components/Button/SecondaryButton/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton/SecondaryButton.tsx
@@ -25,6 +25,7 @@ export const SecondaryButton: FC<ButtonProps> = React.forwardRef(
             disabled = false,
             disruptive = false,
             dropShadow = false,
+            floatingButtonProps,
             htmlType,
             iconProps,
             onClick,
@@ -63,6 +64,7 @@ export const SecondaryButton: FC<ButtonProps> = React.forwardRef(
                 disabled={disabled}
                 disruptive={disruptive}
                 dropShadow={dropShadow}
+                floatingButtonProps={floatingButtonProps}
                 htmlType={htmlType}
                 iconProps={iconProps}
                 onClick={onClick}
@@ -74,8 +76,8 @@ export const SecondaryButton: FC<ButtonProps> = React.forwardRef(
                 style={style}
                 text={text}
                 theme={theme}
-                type={ButtonType.Secondary}
                 toggle={toggle}
+                type={ButtonType.Secondary}
                 buttonWidth={buttonWidth}
             />
         );

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -163,6 +163,13 @@
         width: fit-content;
     }
 
+    &.floating {
+        position: fixed;
+        bottom: 40px;
+        right: 40px;
+        z-index: $z-index-400;
+    }
+
     &:disabled,
     &.disabled {
         opacity: $disabled-alpha-value;

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -81,6 +81,20 @@
         border-radius: $corner-radius-xl;
     }
 
+    &.round-shape {
+        border-radius: 50%;
+
+        &.button-size-1 {
+            padding: $button-padding-vertical-large;
+        }
+        &.button-size-2 {
+            padding: $button-padding-vertical-medium;
+        }
+        &.button-size-3 {
+            padding: $button-padding-vertical-small;
+        }
+    }
+
     &.drop-shadow {
         box-shadow: 0 1px 2px rgba(15, 20, 31, 0.12),
             0 2px 8px rgba(15, 20, 31, 0.16);


### PR DESCRIPTION
## SUMMARY:
Adding floatingButtonProps in BaseButton to enable it floating in botton right corner


## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-22373

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [x] Feature Pull Request

## TEST PLAN:
In story book there should be an option to make button floating
<img width="1636" alt="image" src="https://user-images.githubusercontent.com/60897218/176538699-2abe6548-f5ae-413d-bd83-e01768c0c658.png">

also try "round" shape and different size, should always work
<img width="888" alt="image" src="https://user-images.githubusercontent.com/60897218/176780089-a6a4b0b5-d6ab-449c-b397-7649a5cff427.png">
