### PR TITLE
Aditya/component color corrections

### DIFF
--- a/src/components/Badge/badge.module.scss
+++ b/src/components/Badge/badge.module.scss
@@ -8,8 +8,8 @@
     padding: 0 $space-xxs;
 
     &.active {
-        --bg: var(--primary-color-20);
-        --label: var(--primary-color);
+        --bg: var(--accent-color-30);
+        --label: var(--primary-color-80);
 
         &.disruptive {
             --bg: var(--disruptive-color-20);

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -269,7 +269,7 @@
 .button-secondary {
     --outline: var(--accent-color-60);
     --bg: transparent;
-    --color: var(--primary-color);
+    --color: var(--primary-color-70);
     color: var(--color);
     background-color: var(--bg);
     outline: var(--outline) solid 1px;
@@ -317,9 +317,8 @@
 }
 
 .button-default {
-    --outline: var(--accent-color-60);
-    --bg: var(--accent-color-10);
-    --color: var(--primary-color);
+    --bg: var(--primary-color-10);
+    --color: var(--primary-color-70);
     color: var(--color);
     background-color: var(--bg);
     outline: transparent solid 2px;

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -100,9 +100,15 @@
             padding: $space-xs $space-m;
             border-radius: $corner-radius-xl;
 
+            &.active {
+                .badge {
+                    --bg: var(--primary-color-10);
+                }
+            }
             .tab-indicator {
                 display: none;
             }
+            
         }
     }
 }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -179,11 +179,11 @@
 
     /* ------ Tabs theme ------ */
     --tab-label: var(--text-secondary-color);
-    --tab-active-label: var(--primary-color);
+    --tab-active-label: var(--primary-color-70);
     --tab-active-background: transparent;
     --tab-hover-label: var(--primary-color);
     --tab-hover-background: transparent;
-    --tab-indicator-color: var(--primary-color);
+    --tab-indicator-color: var(--primary-color-70);
     --tab-small-active-background: transparent;
     --tab-small-hover-background: transparent;
     --tab-pill-label: var(--text-secondary-color);


### PR DESCRIPTION
## SUMMARY:
Few of the components( Tabs, Buttons) are not according to the proposed design in terms of colors. This PR addresses those. 

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

https://eightfoldai.atlassian.net/browse/ENG-23277

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

N/A

## TEST PLAN:
Verify if the colors in [Figma for Octuple theme 2](https://www.figma.com/file/SlKRC7oKF7XZyHMv2op4ch/Octuple-DS-(Theme-2)?node-id=292%3A711) are the same in this repository