### PR TITLE
fix: slider component not exported

### DIFF
--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -59,6 +59,8 @@ import { InfoBar, InfoBarType } from './components/InfoBar';
 
 import { Select } from './components/Select';
 
+import { Slider } from './components/Slider';
+
 import { SnackbarContainer, Snackbar, snack } from './components/Snackbar';
 
 import { Spinner, SpinnerSize } from './components/Spinner';
@@ -160,6 +162,7 @@ export {
     Select,
     SearchBox,
     SecondaryButton,
+    Slider,
     snack,
     Snackbar,
     SnackbarContainer,


### PR DESCRIPTION
## SUMMARY:
Slider component not exported

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
1. Skip for release