### PR TITLE
fix: prevent slider from firing onChange during init

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "details": "webpack --config webpack.dev.js --mode development --stats-error-details",
         "analyze": "webpack --config webpack.dev.js --mode production --json > stats.json",
         "prepublish": "yarn build",
-        "test": "jest",
+        "test": "jest --collectCoverage=true",
         "test:update": "jest -u",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "format": "prettier --write \"**/*.+(js|jsx|ts|tsx|json|css|scss|md)\"",
@@ -242,7 +242,7 @@
             "jest-watch-typeahead/testname"
         ],
         "resetMocks": false,
-        "collectCoverage": true,
+        "collectCoverage": false,
         "collectCoverageFrom": [
             "src/**/*.{js,jsx,ts,tsx}",
             "!src/**/*.d.ts",

--- a/src/__snapshots__/storybook.test.js.snap
+++ b/src/__snapshots__/storybook.test.js.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b81a4395f8942dbe0a5ece5bf4e2dac49f22710ae75fe36ffb2fdd373d0cd3f4
-size 1828649
+oid sha256:b1e0f9586256e9bad39350ca3b083e1c3f25419043acfd8507bea2fa1869e3f3
+size 1827177

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -51,6 +51,29 @@ describe('Slider', () => {
         expect(activeMarkers.length).toEqual(2);
     });
 
+    test('should not call onChanges on initial load', () => {
+        const testCtrl = {
+            handleChange: () => {},
+        };
+        const handleChangeSpy = jest
+            .spyOn(testCtrl, 'handleChange')
+            .mockImplementation(() => {});
+
+        wrapper = mount(
+            <Slider
+                min={20}
+                max={40}
+                value={30}
+                showMarkers={true}
+                onChange={testCtrl.handleChange}
+            />
+        );
+        let thumb1 = wrapper.find('input[type="range"]').at(0);
+        expect(handleChangeSpy).toHaveBeenCalledTimes(0);
+        thumb1.simulate('change', { target: { value: 29 } });
+        expect(handleChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
     test('should update values correctly', () => {
         let val = 1;
         wrapper = mount(

--- a/src/components/Slider/Slider.types.ts
+++ b/src/components/Slider/Slider.types.ts
@@ -5,10 +5,6 @@ export interface SliderMarker {
      * The step value of the marker.
      */
     value: number;
-    /**
-     * The left offset position for the marker. ex: "96px"
-     */
-    offset: string;
 }
 
 export interface SliderProps extends SliderInputProps {


### PR DESCRIPTION
## SUMMARY:
There were several setState calls in my layout logic which were triggering re-render. Eliminated these so that layout changes were done directly via ref updates. Also added ResizeObserver for triggering layout updates.

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-23989

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [X] I have added unittests for this change

## TEST PLAN:
Added a unit test to ensure onChange doesn't fire on initial render.