### PR TITLE
fix: select: Move chevron indicator to the right side

### DIFF
--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -5,6 +5,11 @@ import { LabelProps } from '../Label';
 import { TooltipTheme } from '../Tooltip';
 import { OcBaseProps } from '../OcBase';
 
+export enum TextInputIconAlign {
+    Left = 'left',
+    Right = 'right',
+}
+
 export enum TextInputSize {
     Flex = 'flex',
     Large = 'large',
@@ -147,7 +152,7 @@ export interface SearchBoxProps
 export interface TextAreaProps
     extends Omit<
         InputProps<HTMLTextAreaElement>,
-        'clearButtonAriaLabel' | 'iconProps' | 'iconButtonProps'
+        'clearButtonAriaLabel' | 'iconProps' | 'iconButtonProps' | 'alignIcon'
     > {
     /**
      * The text area is expandable.
@@ -176,12 +181,6 @@ export interface TextAreaProps
 }
 
 export interface TextInputProps extends InputProps<HTMLInputElement> {
-    /**
-     * option to show the clear input button.
-     * default is true for backward compatibility
-     * @default true
-     */
-    clearable?: boolean;
     /**
      * The input html type.
      * @default 'text'
@@ -212,6 +211,17 @@ export interface InputProps<T>
         OcBaseProps<T>,
         'onChange' | 'onFocus' | 'onBlur' | 'onKeyDown'
     > {
+    /**
+     * The input icon alignment.
+     * @default TextInputIconAlign.Left
+     */
+    alignIcon?: TextInputIconAlign;
+    /**
+     * option to show the clear input button.
+     * default is true for backward compatibility
+     * @default true
+     */
+    clearable?: boolean;
     /**
      * Allows focus on the input when it's disabled.
      * @default false

--- a/src/components/Inputs/SearchBox/SearchBox.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.tsx
@@ -14,11 +14,11 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
     (
         {
             alignIcon = TextInputIconAlign.Left,
-            clearable = true,
             allowDisabledFocus = false,
             ariaLabel,
             autoFocus = false,
             classNames,
+            clearable = true,
             clearButtonAriaLabel,
             disabled = false,
             iconProps,

--- a/src/components/Inputs/SearchBox/SearchBox.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.tsx
@@ -1,6 +1,7 @@
 import React, { FC, Ref } from 'react';
 import { IconName } from '../../Icon';
 import {
+    TextInputIconAlign,
     TextInputWidth,
     SearchBoxProps,
     TextInput,
@@ -12,6 +13,8 @@ import {
 export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
     (
         {
+            alignIcon = TextInputIconAlign.Left,
+            clearable = true,
             allowDisabledFocus = false,
             ariaLabel,
             autoFocus = false,
@@ -50,6 +53,8 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
                 <TextInput
                     {...rest}
                     ref={ref}
+                    alignIcon={alignIcon}
+                    clearable={clearable}
                     allowDisabledFocus={allowDisabledFocus}
                     ariaLabel={ariaLabel}
                     autoFocus={autoFocus}

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -3,6 +3,7 @@ import { ButtonSize, DefaultButton } from '../../Button';
 import { Icon, IconName, IconSize } from '../../Icon';
 import { Label, LabelSize } from '../../Label';
 import {
+    TextInputIconAlign,
     TextInputWidth,
     TextInputProps,
     TextInputShape,
@@ -18,10 +19,12 @@ import styles from '../input.module.scss';
 export const TextInput: FC<TextInputProps> = React.forwardRef(
     (
         {
+            alignIcon = TextInputIconAlign.Left,
             allowDisabledFocus = false,
             ariaLabel,
             autoFocus = false,
             classNames,
+            clearable = true,
             clearButtonAriaLabel,
             disabled = false,
             htmlType = 'text',
@@ -49,7 +52,6 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             theme = TextInputTheme.light,
             value,
             waitInterval = 10,
-            clearable = true,
             ...rest
         },
         ref: Ref<HTMLInputElement>
@@ -68,12 +70,20 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
 
         const iconClassNames: string = mergeClasses([
             styles.iconWrapper,
-            styles.leftIcon,
+            { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
+            { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
         ]);
 
         const iconButtonClassNames: string = mergeClasses([
             styles.iconButton,
-            styles.leftIcon,
+            { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
+            { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
+        ]);
+
+        const clearIconButtonClassNames: string = mergeClasses([
+            styles.clearIconButton,
+            { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
+            { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
         ]);
 
         const textInputClassNames: string = mergeClasses([
@@ -150,6 +160,9 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             {
                 [styles.inputStretch]: inputWidth === TextInputWidth.fill,
             },
+            { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
+            { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
+            { [styles.clearDisabled]: !clearable },
         ]);
 
         const textInputGroupClassNames: string = mergeClasses([
@@ -157,6 +170,8 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             {
                 [styles.inline]: inline,
             },
+            { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
+            { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
         ]);
 
         const textInputWrapperClassNames: string = mergeClasses([
@@ -189,6 +204,8 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             {
                 [styles.inputStretch]: inputWidth === TextInputWidth.fill,
             },
+            { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
+            { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
             {
                 [styles.disabled]: allowDisabledFocus || disabled,
             },
@@ -366,13 +383,14 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
                             htmlType={iconButtonProps.htmlType}
                         />
                     )}
-                    {clearButtonShown &&
+                    {clearable &&
+                        clearButtonShown &&
                         !numbersOnly &&
                         htmlType !== 'number' && (
                             <DefaultButton
                                 allowDisabledFocus={allowDisabledFocus}
                                 ariaLabel={clearButtonAriaLabel}
-                                classNames={styles.clearIconButton}
+                                classNames={clearIconButtonClassNames}
                                 disabled={disabled}
                                 iconProps={{ path: IconName.mdiClose }}
                                 onClick={

--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -11,27 +11,75 @@
         font-family: 'Source Sans Pro', sans-serif;
         font-size: $text-font-size-3;
         line-height: $text-line-height-1;
-        min-width: 320px;
+        min-width: 120px;
         padding: $space-xs $space-xl $space-xs $space-m;
 
         &::-webkit-search-cancel-button {
             -webkit-appearance: none;
         }
 
-        &.with-icon {
-            padding: $space-xs $space-xl $space-xs $space-xxl;
-        }
-
+        &.with-icon,
         &.with-image-icon {
             padding: $space-xs $space-xl $space-xs $space-xxl;
+
+            &.left-icon {
+                padding: $space-xs $space-xl $space-xs $space-xxl;
+            }
+
+            &.right-icon {
+                padding: $space-xs $space-xxl $space-xs $space-xl;
+            }
+
+            &.clear-disabled {
+                &.left-icon {
+                    padding: $space-xs $space-xs $space-xs $space-xxl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xxl $space-xs $space-xs;
+                }
+            }
         }
 
         &.with-icon-button {
             padding: $space-xs $space-xl $space-xs $space-xl;
+
+            &.left-icon,
+            &.right-icon {
+                padding: $space-xs $space-xl $space-xs $space-xl;
+            }
+
+            &.clear-disabled {
+                &.left-icon {
+                    padding: $space-xs $space-xs $space-xs $space-xl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xs;
+                }
+            }
         }
 
         &.with-icon-and-icon-button {
             padding: $space-xs $space-xxl $space-xs 74px;
+
+            &.left-icon {
+                padding: $space-xs $space-xxl $space-xs 74px;
+            }
+
+            &.right-icon {
+                padding: $space-xs 74px $space-xs $space-xxl;
+            }
+
+            &.clear-disabled {
+                &.left-icon {
+                    padding: $space-xs $space-xs $space-xs 74px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 74px $space-xs $space-xs;
+                }
+            }
         }
 
         &:hover {
@@ -102,10 +150,6 @@
             }
         }
 
-        &:disabled {
-            color: var(--grey-color-10);
-        }
-
         &:disabled::placeholder {
             color: var(--text-primary-color);
         }
@@ -115,20 +159,68 @@
             padding: $space-xs $space-s;
         }
 
-        &.pill-shape-with-icon {
-            padding: $space-xs $space-xl $space-xs $space-xxl;
-        }
-
+        &.pill-shape-with-icon,
         &.pill-shape-with-image-icon {
             padding: $space-xs $space-xl $space-xs $space-xxl;
+
+            &.left-icon {
+                padding: $space-xs $space-xl $space-xs $space-xxl;
+            }
+
+            &.right-icon {
+                padding: $space-xs $space-xxl $space-xs $space-xl;
+            }
+
+            &.clear-disabled {
+                &.left-icon {
+                    padding: $space-xs $space-xs $space-xs $space-xxl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xxl $space-xs $space-xs;
+                }
+            }
         }
 
         &.pill-shape-with-icon-button {
             padding: $space-xs $space-xl $space-xs $space-xl;
+
+            &.left-icon,
+            &.right-icon {
+                padding: $space-xs $space-xl $space-xs $space-xl;
+            }
+
+            &.clear-disabled {
+                &.left-icon {
+                    padding: $space-xs $space-xs $space-xs $space-xl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xs;
+                }
+            }
         }
 
         &.pill-shape-with-icon-and-icon-button {
             padding: $space-xs $space-xl $space-xs 74px;
+
+            &.left-icon {
+                padding: $space-xs $space-xl $space-xs 74px;
+            }
+
+            &.right-icon {
+                padding: $space-xs 74px $space-xs $space-xl;
+            }
+
+            &.clear-disabled {
+                &.left-icon {
+                    padding: $space-xs $space-xs $space-xs 74px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 74px $space-xs $space-xs;
+                }
+            }
         }
 
         &.pill-shape-with-icon-button ~ .icon-button {
@@ -174,36 +266,96 @@
             line-height: $text-line-height-5;
             padding: $space-xs $space-xxl $space-xs $space-m;
 
-            &.with-icon {
-                padding: $space-xs $space-xxl $space-xs 48px;
-            }
-
-            &.with-image-icon {
-                padding: $space-xs $space-xxl $space-xs 48px;
-            }
-
+            &.with-icon,
+            &.with-image-icon,
             &.with-icon-button {
                 padding: $space-xs $space-xxl $space-xs 48px;
+
+                &.left-icon {
+                    padding: $space-xs $space-xxl $space-xs 48px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 48px $space-xs $space-xxl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 48px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 48px $space-xs $space-xs;
+                    }
+                }
             }
 
             &.with-icon-and-icon-button {
                 padding: $space-xs $space-xxl $space-xs 84px;
+
+                &.left-icon {
+                    padding: $space-xs $space-xxl $space-xs 84px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 84px $space-xs $space-xxl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 84px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 84px $space-xs $space-xs;
+                    }
+                }
             }
 
-            &.pill-shape-with-icon {
-                padding: $space-xs $space-xxl $space-xs 48px;
-            }
-
-            &.pill-shape-with-image-icon {
-                padding: $space-xs $space-xxl $space-xs 48px;
-            }
-
+            &.pill-shape-with-icon,
+            &.pill-shape-with-image-icon,
             &.pill-shape-with-icon-button {
                 padding: $space-xs $space-xxl $space-xs 48px;
+
+                &.left-icon {
+                    padding: $space-xs $space-xxl $space-xs 48px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 48px $space-xs $space-xxl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 48px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 48px $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-and-icon-button {
                 padding: $space-xs $space-xxl $space-xs 84px;
+
+                &.left-icon {
+                    padding: $space-xs $space-xxl $space-xs 84px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 84px $space-xs $space-xxl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 84px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 84px $space-xs $space-xs;
+                    }
+                }
             }
         }
 
@@ -213,36 +365,132 @@
             line-height: $text-line-height-4;
             padding: $space-xs $space-xl $space-xs $space-m;
 
-            &.with-icon {
-                padding: $space-xs $space-xl $space-xs $space-xxl;
-            }
-
+            &.with-icon,
             &.with-image-icon {
                 padding: $space-xs $space-xl $space-xs $space-xxl;
+
+                &.left-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xxl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xxl $space-xs $space-xl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs $space-xxl;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs $space-xxl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.with-icon-button {
                 padding: $space-xs $space-xl $space-xs $space-xl;
+
+                &.left-icon,
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs $space-xl;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.with-icon-and-icon-button {
                 padding: $space-xs $space-xxl $space-xs 74px;
+
+                &.left-icon {
+                    padding: $space-xs $space-xxl $space-xs 74px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 74px $space-xs $space-xxl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 74px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 74px $space-xs $space-xs;
+                    }
+                }
             }
 
-            &.pill-shape-with-icon {
-                padding: $space-xs $space-xl $space-xs $space-xxl;
-            }
-
+            &.pill-shape-with-icon,
             &.pill-shape-with-image-icon {
                 padding: $space-xs $space-xl $space-xs $space-xxl;
+
+                &.left-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xxl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xxl $space-xs $space-xl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs $space-xxl;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs $space-xxl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-button {
                 padding: $space-xs $space-xl $space-xs $space-xl;
+
+                &.left-icon,
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs $space-xl;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-and-icon-button {
                 padding: $space-xs $space-xl $space-xs 74px;
+
+                &.left-icon {
+                    padding: $space-xs $space-xl $space-xs 74px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 74px $space-xs $space-xl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 74px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 74px $space-xs $space-xs;
+                    }
+                }
             }
         }
 
@@ -252,36 +500,118 @@
             line-height: $text-line-height-3;
             padding: $space-xs $space-l $space-xs $space-s;
 
-            &.with-icon {
-                padding: $space-xs calc(#{$space-l} + 4px) $space-xs $space-xl;
-            }
-
-            &.with-image-icon {
-                padding: $space-xs calc(#{$space-l} + 4px) $space-xs $space-xl;
-            }
-
+            &.with-icon,
+            &.with-image-icon,
             &.with-icon-button {
                 padding: $space-xs calc(#{$space-l} + 4px) $space-xs $space-xl;
+
+                &.left-icon {
+                    padding: $space-xs calc(#{$space-l} + 4px) $space-xs
+                        $space-xl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs
+                        calc(#{$space-l} + 4px);
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs $space-xl;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.with-icon-and-icon-button {
                 padding: $space-xs calc(#{$space-l} + 4px) $space-xs 60px;
+
+                &.left-icon {
+                    padding: $space-xs calc(#{$space-l} + 4px) $space-xs 60px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 60px $space-xs calc(#{$space-l} + 4px);
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 60px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 60px $space-xs $space-xs;
+                    }
+                }
             }
 
-            &.pill-shape-with-icon {
-                padding: $space-xs calc(#{$space-l} + 4px) $space-xs $space-xl;
-            }
-
+            &.pill-shape-with-icon,
             &.pill-shape-with-image-icon {
                 padding: $space-xs calc(#{$space-l} + 4px) $space-xs $space-xl;
+
+                &.left-icon {
+                    padding: $space-xs calc(#{$space-l} + 4px) $space-xs
+                        $space-xl;
+                }
+
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs
+                        calc(#{$space-l} + 4px);
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs $space-xl;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-button {
                 padding: $space-xs $space-xl $space-xs $space-xl;
+
+                &.left-icon,
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xl;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs $space-xl;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-and-icon-button {
                 padding: $space-xs 28px $space-xs 60px;
+
+                &.left-icon {
+                    padding: $space-xs 28px $space-xs 60px;
+                }
+
+                &.right-icon {
+                    padding: $space-xs 60px $space-xs 28px;
+                }
+
+                &.clear-disabled {
+                    &.left-icon {
+                        padding: $space-xs $space-xs $space-xs 60px;
+                    }
+
+                    &.right-icon {
+                        padding: $space-xs 60px $space-xs $space-xs;
+                    }
+                }
             }
         }
 
@@ -368,9 +698,17 @@
         color: var(--grey-color-60);
         height: 35px;
         position: absolute;
-        right: 1px;
+        right: 2px;
         transition: none;
         width: 35px;
+
+        &.left-icon {
+            right: 2px;
+        }
+
+        &.right-icon {
+            left: 2px;
+        }
 
         &:active,
         &:hover {
@@ -482,6 +820,7 @@
     .input-group,
     .text-area-group {
         position: relative;
+        width: fit-content;
 
         &.inline {
             display: flex;
@@ -628,11 +967,11 @@
             width: 36px;
 
             &.left-icon {
-                left: 8px;
+                left: 4px;
             }
 
             &.right-icon {
-                right: 8px;
+                right: 4px;
             }
 
             span {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -2,7 +2,12 @@ import React, { FC, useState, useRef } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { IconName } from '../Icon';
 import { Select } from './';
-import { SelectOption, SelectProps } from './Select.types';
+import {
+    SelectOption,
+    SelectProps,
+    SelectShape,
+    SelectSize,
+} from './Select.types';
 import { Stories } from '@storybook/addon-docs';
 
 const defaultOptions: SelectOption[] = [
@@ -81,6 +86,23 @@ export default {
         },
         onOptionsChange: {
             action: 'click',
+        },
+        shape: {
+            options: [
+                SelectShape.Rectangle,
+                SelectShape.Pill,
+                SelectShape.Underline,
+            ],
+            control: { type: 'inline-radio' },
+        },
+        size: {
+            options: [
+                SelectSize.Flex,
+                SelectSize.Large,
+                SelectSize.Medium,
+                SelectSize.Small,
+            ],
+            control: { type: 'radio' },
         },
     },
 } as ComponentMeta<typeof Select>;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -3,10 +3,22 @@ import React, { FC, useState, useEffect, Ref } from 'react';
 import { mergeClasses } from '../../shared/utilities';
 import { Dropdown } from '../Dropdown';
 import { Menu } from '../Menu';
-import { TextInput, TextInputProps, TextInputWidth } from '../Inputs';
+import {
+    TextInput,
+    TextInputIconAlign,
+    TextInputProps,
+    TextInputShape,
+    TextInputSize,
+    TextInputWidth,
+} from '../Inputs';
 import { Pill, PillSize } from '../Pills';
 import { IconName } from '../Icon';
-import { SelectOption, SelectProps } from './Select.types';
+import {
+    SelectOption,
+    SelectProps,
+    SelectShape,
+    SelectSize,
+} from './Select.types';
 
 import styles from './select.module.scss';
 import { Spinner, SpinnerSize } from '../Spinner';
@@ -16,6 +28,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         {
             options: _options = [],
             inputWidth = TextInputWidth.fill,
+            clearable = false,
             defaultValue,
             filterable = false,
             multiple = false,
@@ -27,6 +40,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
             isLoading,
             spinner = <Spinner size={SpinnerSize.Small} />,
             classNames,
+            shape = SelectShape.Rectangle,
+            size = SelectSize.Flex,
             style,
             placeholder = 'Select',
             onOptionsChange,
@@ -129,7 +144,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
             }
         };
 
-        const shopDropdown = (show: boolean) => {
+        const showDropdown = (show: boolean) => {
             if (multiple) {
                 return true;
             }
@@ -241,15 +256,34 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
         const selectInputProps: TextInputProps = {
             placeholder: placeholder,
-            clearable: false,
+            alignIcon: TextInputIconAlign.Right,
+            clearable: clearable,
             inputWidth: inputWidth,
             iconProps: {
-                path: IconName.mdiMenuDown,
+                path: IconName.mdiChevronDown,
                 rotate: dropdownVisible ? 180 : 0,
             },
             onClear: onInputClear,
             ...textInputProps,
         };
+
+        const selectShapeToTextInputShapeMap = new Map<
+            SelectShape,
+            TextInputShape
+        >([
+            [SelectShape.Rectangle, TextInputShape.Rectangle],
+            [SelectShape.Pill, TextInputShape.Pill],
+            [SelectShape.Underline, TextInputShape.Underline],
+        ]);
+
+        const selectSizeToTextInputSizeMap = new Map<SelectSize, TextInputSize>(
+            [
+                [SelectSize.Flex, TextInputSize.Flex],
+                [SelectSize.Large, TextInputSize.Large],
+                [SelectSize.Medium, TextInputSize.Medium],
+                [SelectSize.Small, TextInputSize.Small],
+            ]
+        );
 
         return (
             <div
@@ -264,7 +298,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                     onVisibleChange={(isVisible) =>
                         onDropdownVisibilityChange(isVisible)
                     }
-                    showDropdown={shopDropdown}
+                    showDropdown={showDropdown}
                     overlay={
                         isLoading ? spinner : <OptionMenu options={options} />
                     }
@@ -274,18 +308,21 @@ export const Select: FC<SelectProps> = React.forwardRef(
                     {filterable ? (
                         <TextInput
                             {...selectInputProps}
+                            shape={selectShapeToTextInputShapeMap.get(shape)}
+                            size={selectSizeToTextInputSizeMap.get(size)}
                             value={
                                 getSelectedOptionText() && !dropdownVisible
                                     ? getSelectedOptionText()
                                     : undefined
                             }
                             onChange={onInputChange}
-                            style={{ minWidth: 'unset' }}
                         />
                     ) : (
                         <TextInput
                             {...selectInputProps}
                             readonly
+                            shape={selectShapeToTextInputShapeMap.get(shape)}
+                            size={selectSizeToTextInputSizeMap.get(size)}
                             value={getSelectedOptionText()}
                             classNames={styles.selectInput}
                         />

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -6,6 +6,19 @@ import { OcBaseProps } from '../OcBase';
 import { PillProps } from '../Pills';
 import { MenuItemProps } from '../Menu/MenuItem/MenuItem.types';
 
+export enum SelectShape {
+    Rectangle = 'rectangle',
+    Pill = 'pill',
+    Underline = 'underline',
+}
+
+export enum SelectSize {
+    Flex = 'flex',
+    Large = 'large',
+    Medium = 'medium',
+    Small = 'small',
+}
+
 export interface SelectOption extends MenuItemProps {
     selected?: boolean;
     hideOption?: boolean;
@@ -89,6 +102,18 @@ export interface SelectProps extends OcBaseProps<HTMLSelectElement> {
      * @default {}
      */
     menuProps?: MenuProps;
+
+    /**
+     * Shape of the select.
+     * @default SelectShape.Rectangle
+     */
+    shape?: SelectShape;
+
+    /**
+     * The select size.
+     * @default Flex
+     */
+    size?: SelectSize;
 
     /**
      * loading spinner props.

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -5,12 +5,13 @@
     .select-dropdown-overlay {
         width: 400px;
     }
+
     .select-dropdown-main-wrapper {
         width: 100%;
     }
+
     .select-input {
         cursor: pointer;
-        min-width: unset !important;
     }
 
     .multi-select-pills {


### PR DESCRIPTION
## SUMMARY:
- adds select shapes and sizes mapped to input
- refines left and right icon layouts in input component

https://user-images.githubusercontent.com/99700808/179634323-e085f701-db88-4ae0-acdc-32cbcde635b7.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-22505

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:
TODO: Add UTs for Select and Input

## TEST PLAN:
Pull latest and run `yarn` and `yarn storybook`. Verify the following:

Select:
shape
size
Icon should now be on the right and correctly reflect the chevron in Figma Theme 1.
