### PR TITLE
fix: usematchmedia: implement addlistener fallback for older browsers

### DIFF
--- a/src/components/DateTimePicker/Internal/ocpicker.module.scss
+++ b/src/components/DateTimePicker/Internal/ocpicker.module.scss
@@ -72,9 +72,8 @@
     }
 
     &-focused {
-        outline: $focus-visible-outline-width $focus-visible-outline-style
-            $focus-visible-outline-color;
-        outline-offset: $focus-visible-outline-offset-inner;
+        outline: 1px $focus-visible-outline-style $focus-visible-outline-color;
+        outline-offset: -1px;
     }
 
     &-disabled {
@@ -1088,10 +1087,10 @@
 
         .picker-active-bar {
             bottom: 0;
-            height: 4px;
+            height: 2px;
             background: $picker-input-active-bar-color;
             border: 1px solid transparent;
-            border-radius: 4px;
+            border-radius: 2px;
             opacity: 0;
             transition: all 0.3s;
             pointer-events: none;

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -16,7 +16,8 @@
     .multi-select-pills {
         position: absolute;
         z-index: 1;
-        left: 26px;
+        left: $space-xs;
+        right: $space-xxl;
         top: 6px;
         display: flex;
         flex-direction: row;
@@ -24,15 +25,19 @@
     }
 
     .multi-select-pill {
-        @include text-overflow;
-        width: 80px;
+        max-width: 64px;
         text-align: center;
         display: flex;
         justify-content: center;
+
+        span {
+            @include text-overflow;
+            max-width: 64px;
+        }
     }
 
     .multi-select-count {
-        margin-left: 2.5px;
+        margin-left: $space-xs;
     }
 
     .selected-option {

--- a/src/hooks/useMatchMedia.ts
+++ b/src/hooks/useMatchMedia.ts
@@ -20,12 +20,18 @@ export const useMatchMedia = (breakpoint: Breakpoints): boolean => {
         setThreshold(e.matches);
     }, []);
     useEffect((): void => {
-        window
-            .matchMedia(breakpoint)
-            .addEventListener('change', handleMatchMedia);
-        return window
-            .matchMedia(breakpoint)
-            .removeEventListener('change', handleMatchMedia);
+        if (window.matchMedia(breakpoint)?.addEventListener) {
+            window
+                .matchMedia(breakpoint)
+                .addEventListener('change', handleMatchMedia);
+        } else {
+            window.matchMedia(breakpoint).addListener(handleMatchMedia);
+        }
+        return window.matchMedia(breakpoint)?.removeEventListener
+            ? window
+                  .matchMedia(breakpoint)
+                  .removeEventListener('change', handleMatchMedia)
+            : window.matchMedia(breakpoint).removeListener(handleMatchMedia);
     }, [handleMatchMedia]);
     return threshold;
 };

--- a/src/styles/themes/_definitions-light.scss
+++ b/src/styles/themes/_definitions-light.scss
@@ -556,7 +556,7 @@ $picker-line-height-m: $text-line-height-4;
 $picker-line-height-s: $text-line-height-3;
 $picker-outline-blur: 0;
 $picker-outline-style: solid;
-$picker-outline-width: 2px;
+$picker-outline-width: 1px;
 $picker-outline-color: var(--picker-outline-color);
 $picker-partial-cell-width: 32px;
 


### PR DESCRIPTION
implement addlistener fallback for older browsers and pixel push datepicker and select

see: https://www.designcise.com/web/tutorial/how-to-fix-the-javascript-typeerror-matchmedia-addeventlistener-is-not-a-function#:~:text=If%20you're%20getting%20the,which%20is%20returned%20by%20window.

## SUMMARY:
Some older and specific browser versions don't support `window.matchMedia(e).addEventListener`, this change adds an `addListener` fallback to this hook.

## JIRA TASK (Eightfold Employees Only):
ENG-24869

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the latest Octuple and `yarn` and then `yarn storybook` using node 16. Then verify the button component still resizes as expected in flex mode. If you're running MacOS version Version 12.1.2 (14607.3.9), verify the same.
