### PR TITLE
fix: select: fixes pills, filtering, empty text, and spinner position

### DIFF
--- a/src/__snapshots__/storybook.test.js.snap
+++ b/src/__snapshots__/storybook.test.js.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:923156f9eae569780cc6c70ac58f1292e10ca3e64065de377c54ce9c680003a7
-size 1901521
+oid sha256:705a7d4d57da645689e9554f62962f95a0d76e9f1d3b6963aefb3c3e654bfed2
+size 1902223

--- a/src/__snapshots__/storybook.test.js.snap
+++ b/src/__snapshots__/storybook.test.js.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ecba6c8210a58b22b3a88d00124f22717835ed4e9eac35199a83b9070739b6e0
-size 1895341
+oid sha256:b9b4bee04ba7b9462435265fa660f2ce0dd466ba85627f40c71fc207e256c4f7
+size 1900228

--- a/src/__snapshots__/storybook.test.js.snap
+++ b/src/__snapshots__/storybook.test.js.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9b4bee04ba7b9462435265fa660f2ce0dd466ba85627f40c71fc207e256c4f7
-size 1900228
+oid sha256:923156f9eae569780cc6c70ac58f1292e10ca3e64065de377c54ce9c680003a7
+size 1901521

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -163,6 +163,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
             { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
             { [styles.clearDisabled]: !clearable },
+            { [styles.clearNotVisible]: !clearButtonShown },
         ]);
 
         const textInputGroupClassNames: string = mergeClasses([

--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -3,6 +3,8 @@
     width: fit-content;
 
     input {
+        @include text-overflow;
+
         background-color: var(--background-color);
         border: 1px solid var(--border-color);
         border-radius: $corner-radius-s;
@@ -39,6 +41,12 @@
                     padding: $space-xs $space-xxl $space-xs $space-xs;
                 }
             }
+
+            &.clear-not-visible {
+                &.right-icon {
+                    padding: $space-xs $space-xxl $space-xs $space-xs;
+                }
+            }
         }
 
         &.with-icon-button {
@@ -54,6 +62,12 @@
                     padding: $space-xs $space-xs $space-xs $space-xl;
                 }
 
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xs;
+                }
+            }
+
+            &.clear-not-visible {
                 &.right-icon {
                     padding: $space-xs $space-xl $space-xs $space-xs;
                 }
@@ -76,6 +90,12 @@
                     padding: $space-xs $space-xs $space-xs 74px;
                 }
 
+                &.right-icon {
+                    padding: $space-xs 74px $space-xs $space-xs;
+                }
+            }
+
+            &.clear-not-visible {
                 &.right-icon {
                     padding: $space-xs 74px $space-xs $space-xs;
                 }
@@ -180,6 +200,12 @@
                     padding: $space-xs $space-xxl $space-xs $space-xs;
                 }
             }
+
+            &.clear-not-visible {
+                &.right-icon {
+                    padding: $space-xs $space-xxl $space-xs $space-xs;
+                }
+            }
         }
 
         &.pill-shape-with-icon-button {
@@ -195,6 +221,12 @@
                     padding: $space-xs $space-xs $space-xs $space-xl;
                 }
 
+                &.right-icon {
+                    padding: $space-xs $space-xl $space-xs $space-xs;
+                }
+            }
+
+            &.clear-not-visible {
                 &.right-icon {
                     padding: $space-xs $space-xl $space-xs $space-xs;
                 }
@@ -217,6 +249,12 @@
                     padding: $space-xs $space-xs $space-xs 74px;
                 }
 
+                &.right-icon {
+                    padding: $space-xs 74px $space-xs $space-xs;
+                }
+            }
+
+            &.clear-not-visible {
                 &.right-icon {
                     padding: $space-xs 74px $space-xs $space-xs;
                 }
@@ -288,6 +326,12 @@
                         padding: $space-xs 48px $space-xs $space-xs;
                     }
                 }
+
+                &.clear-not-visible {
+                    &.right-icon {
+                        padding: $space-xs 48px $space-xs $space-xs;
+                    }
+                }
             }
 
             &.with-icon-and-icon-button {
@@ -306,6 +350,12 @@
                         padding: $space-xs $space-xs $space-xs 84px;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs 84px $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs 84px $space-xs $space-xs;
                     }
@@ -334,6 +384,12 @@
                         padding: $space-xs 48px $space-xs $space-xs;
                     }
                 }
+
+                &.clear-not-visible {
+                    &.right-icon {
+                        padding: $space-xs 48px $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-and-icon-button {
@@ -356,6 +412,12 @@
                         padding: $space-xs 84px $space-xs $space-xs;
                     }
                 }
+
+                &.clear-not-visible {
+                    &.right-icon {
+                        padding: $space-xs 84px $space-xs $space-xs;
+                    }
+                }
             }
         }
 
@@ -374,7 +436,7 @@
                 }
 
                 &.right-icon {
-                    padding: $space-xs $space-xxl $space-xs $space-xl;
+                    padding: $space-xs $space-xxl $space-xs $space-xxl;
                 }
 
                 &.clear-disabled {
@@ -382,6 +444,12 @@
                         padding: $space-xs $space-xs $space-xs $space-xxl;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs $space-xxl $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs $space-xxl $space-xs $space-xs;
                     }
@@ -405,6 +473,12 @@
                         padding: $space-xs $space-xl $space-xs $space-xs;
                     }
                 }
+
+                &.clear-not-visible {
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.with-icon-and-icon-button {
@@ -423,6 +497,12 @@
                         padding: $space-xs $space-xs $space-xs 74px;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs 74px $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs 74px $space-xs $space-xs;
                     }
@@ -450,6 +530,12 @@
                         padding: $space-xs $space-xxl $space-xs $space-xs;
                     }
                 }
+
+                &.clear-not-visible {
+                    &.right-icon {
+                        padding: $space-xs $space-xxl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-button {
@@ -465,6 +551,12 @@
                         padding: $space-xs $space-xs $space-xs $space-xl;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs $space-xl $space-xs $space-xs;
                     }
@@ -487,6 +579,12 @@
                         padding: $space-xs $space-xs $space-xs 74px;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs 74px $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs 74px $space-xs $space-xs;
                     }
@@ -524,6 +622,12 @@
                         padding: $space-xs $space-xl $space-xs $space-xs;
                     }
                 }
+
+                &.clear-not-visible {
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.with-icon-and-icon-button {
@@ -542,6 +646,12 @@
                         padding: $space-xs $space-xs $space-xs 60px;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs 60px $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs 60px $space-xs $space-xs;
                     }
@@ -571,6 +681,12 @@
                         padding: $space-xs $space-xl $space-xs $space-xs;
                     }
                 }
+
+                &.clear-not-visible {
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
             }
 
             &.pill-shape-with-icon-button {
@@ -586,6 +702,12 @@
                         padding: $space-xs $space-xs $space-xs $space-xl;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs $space-xl $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs $space-xl $space-xs $space-xs;
                     }
@@ -608,6 +730,12 @@
                         padding: $space-xs $space-xs $space-xs 60px;
                     }
 
+                    &.right-icon {
+                        padding: $space-xs 60px $space-xs $space-xs;
+                    }
+                }
+
+                &.clear-not-visible {
                     &.right-icon {
                         padding: $space-xs 60px $space-xs $space-xs;
                     }
@@ -820,7 +948,6 @@
     .input-group,
     .text-area-group {
         position: relative;
-        width: fit-content;
 
         &.inline {
             display: flex;

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -27,16 +27,19 @@ export const Pill: FC<PillProps> = React.forwardRef(
             [PillSize.Large, ButtonSize.Medium],
             [PillSize.Medium, ButtonSize.Small],
             [PillSize.Small, ButtonSize.Small],
+            [PillSize.XSmall, ButtonSize.Small],
         ]);
         const pillSizeToIconSizeMap = new Map<PillSize, IconSize>([
             [PillSize.Large, IconSize.Medium],
             [PillSize.Medium, IconSize.Small],
             [PillSize.Small, IconSize.XSmall],
+            [PillSize.XSmall, IconSize.XSmall],
         ]);
         const labelClassName: string = mergeClasses([
             styles.label,
             { [styles.medium]: size === PillSize.Medium },
             { [styles.small]: size === PillSize.Small },
+            { [styles.xsmall]: size === PillSize.XSmall },
         ]);
         const tagClassName: string = mergeClasses([
             styles.tagPills,
@@ -49,6 +52,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
             { [styles.blue]: theme === 'blue' },
             { [styles.violet]: theme === 'violet' },
             { [styles.grey]: theme === 'grey' },
+            { [styles.xsmall]: size === PillSize.XSmall },
         ]);
         return (
             <div {...rest} className={tagClassName} style={{ color }} ref={ref}>

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -37,7 +37,12 @@ export default {
             action: 'close',
         },
         size: {
-            options: [PillSize.Large, PillSize.Medium, PillSize.Small],
+            options: [
+                PillSize.Large,
+                PillSize.Medium,
+                PillSize.Small,
+                PillSize.XSmall,
+            ],
             control: { type: 'radio' },
         },
         type: {

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -14,6 +14,7 @@ export enum PillSize {
     Large = 'large',
     Medium = 'medium',
     Small = 'small',
+    XSmall = 'xsmall',
 }
 
 /**

--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -22,9 +22,15 @@
             font-size: $text-font-size-3;
         }
 
-        &.small {
+        &.small,
+        &.xsmall {
             font-size: $text-font-size-2;
         }
+    }
+
+    &.xsmall {
+        background: none;
+        border: none;
     }
 
     &.red {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -314,7 +314,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                 );
             } else {
                 return (
-                    <span className={styles.selectMenuEmpty}>{emptyText}</span>
+                    <div className={styles.selectMenuEmpty}>{emptyText}</div>
                 );
             }
         };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -11,7 +11,7 @@ import {
     TextInputSize,
     TextInputWidth,
 } from '../Inputs';
-import { Pill, PillSize } from '../Pills';
+import { Pill, PillSize, PillType } from '../Pills';
 import { IconName } from '../Icon';
 import {
     SelectOption,
@@ -19,42 +19,56 @@ import {
     SelectShape,
     SelectSize,
 } from './Select.types';
+import { Spinner, SpinnerSize } from '../Spinner';
+import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
+import { Tooltip, TooltipTheme } from '../Tooltip';
 
 import styles from './select.module.scss';
-import { Spinner, SpinnerSize } from '../Spinner';
 
 export const Select: FC<SelectProps> = React.forwardRef(
     (
         {
-            options: _options = [],
-            inputWidth = TextInputWidth.fill,
+            classNames,
             clearable = false,
             defaultValue,
+            dropdownProps = {},
+            emptyText = 'No match found.',
             filterable = false,
+            inputWidth = TextInputWidth.fill,
+            isLoading,
+            loadOptions,
+            menuProps = {},
             multiple = false,
             textInputProps = {},
-            dropdownProps = {},
+            onOptionsChange,
+            options: _options = [],
             pillProps = {},
-            menuProps = {},
-            loadOptions,
-            isLoading,
-            spinner = <Spinner size={SpinnerSize.Small} />,
-            classNames,
+            placeholder = 'Select',
             shape = SelectShape.Rectangle,
             size = SelectSize.Flex,
+            spinner = (
+                <Spinner
+                    classNames={styles.selectSpinner}
+                    size={SpinnerSize.Small}
+                />
+            ),
             style,
-            placeholder = 'Select',
-            onOptionsChange,
             'data-test-id': dataTestId,
         },
         ref: Ref<HTMLDivElement>
     ) => {
+        const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
+        const mediumScreenActive: boolean = useMatchMedia(Breakpoints.Medium);
+        const smallScreenActive: boolean = useMatchMedia(Breakpoints.Small);
+        const xSmallScreenActive: boolean = useMatchMedia(Breakpoints.XSmall);
+
         const [dropdownVisible, setDropdownVisibility] =
             useState<boolean>(false);
         const [options, setOptions] = useState<SelectOption[]>(
-            _options.map((option) => ({
+            _options.map((option: SelectOption, index: number) => ({
                 selected: false,
                 hideOption: false,
+                id: option.text + '-' + index,
                 ...option,
             }))
         );
@@ -62,18 +76,19 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
         const getSelectedOptions = (): SelectOption['value'][] => {
             return options
-                .filter((option) => option.selected)
-                .map((option) => option.value);
+                .filter((option: SelectOption) => option.selected)
+                .map((option: SelectOption) => option.value);
         };
 
         useEffect(() => {
             const selected = options.filter((option) => option.selected);
             setOptions(
-                _options.map((option) => ({
+                _options.map((option: SelectOption, index: number) => ({
                     selected: !!selected.find(
                         (opt) => opt.value === option.value
                     ),
                     hideOption: false,
+                    id: option.text + index,
                     ...option,
                 }))
             );
@@ -173,6 +188,25 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
         const componentClasses: string = mergeClasses([
             styles.selectWrapper,
+            {
+                [styles.selectSize3]:
+                    size === SelectSize.Flex && largeScreenActive,
+            },
+            {
+                [styles.selectSize2]:
+                    size === SelectSize.Flex && mediumScreenActive,
+            },
+            {
+                [styles.selectSize2]:
+                    size === SelectSize.Flex && smallScreenActive,
+            },
+            {
+                [styles.selectSize1]:
+                    size === SelectSize.Flex && xSmallScreenActive,
+            },
+            { [styles.selectSize1]: size === SelectSize.Large },
+            { [styles.selectSize2]: size === SelectSize.Medium },
+            { [styles.selectSize3]: size === SelectSize.Small },
             classNames,
         ]);
 
@@ -186,25 +220,58 @@ export const Select: FC<SelectProps> = React.forwardRef(
             );
         };
 
+        const getPillSize = (): PillSize => {
+            let pillSize: PillSize;
+            if (largeScreenActive) {
+                pillSize = PillSize.Small;
+            } else if (mediumScreenActive) {
+                pillSize = PillSize.Medium;
+            } else if (smallScreenActive) {
+                pillSize = PillSize.Medium;
+            } else if (xSmallScreenActive) {
+                pillSize = PillSize.Large;
+            }
+            return pillSize;
+        };
+
+        const selectSizeToPillSizeMap = new Map<SelectSize, PillSize>([
+            [SelectSize.Flex, getPillSize()],
+            [SelectSize.Large, PillSize.Large],
+            [SelectSize.Medium, PillSize.Medium],
+            [SelectSize.Small, PillSize.Small],
+        ]);
+
+        // TODO: Use ConditionalWrapper using a custom hook to determine when ellipsis is active
+        // Because the option will not yet be rendered this may need to be spoofed in the hook
+        // Also need a better way to determine the number of Pills shown before moreOptionsCount.
         const getPills = () => {
             const selected = options.filter((opt) => opt.selected);
             const selectedCount = selected.length;
             const moreOptionsCount = selectedCount - 1;
             return (
                 <div className={styles.multiSelectPills}>
-                    <Pill
-                        label={selected[0].text}
-                        classNames={pillClasses}
-                        theme={'bluegreen'}
-                        size={PillSize.Small}
-                        {...pillProps}
-                    />
+                    <Tooltip
+                        classNames={styles.selectTooltip}
+                        content={selected[0].text}
+                        theme={TooltipTheme.dark}
+                    >
+                        <Pill
+                            id={selected[0].id}
+                            classNames={pillClasses}
+                            label={selected[0].text}
+                            onClose={() => toggleOption(selected[0])}
+                            size={selectSizeToPillSizeMap.get(size)}
+                            theme={'bluegreen'}
+                            type={PillType.closable}
+                            {...pillProps}
+                        />
+                    </Tooltip>
                     {moreOptionsCount ? (
                         <Pill
-                            label={'+' + moreOptionsCount}
                             classNames={countPillClasses}
+                            label={'+' + moreOptionsCount}
+                            size={selectSizeToPillSizeMap.get(size)}
                             theme={'bluegreen'}
-                            size={PillSize.Small}
                             {...pillProps}
                         />
                     ) : null}
@@ -232,18 +299,24 @@ export const Select: FC<SelectProps> = React.forwardRef(
                     ]),
                 })
             );
-            return (
-                <Menu
-                    {...menuProps}
-                    items={updatedItems}
-                    onChange={(value) => {
-                        const option = updatedItems.find(
-                            (option) => option.value === value
-                        );
-                        toggleOption(option);
-                    }}
-                />
-            );
+            if (filteredOptions.length > 0) {
+                return (
+                    <Menu
+                        {...menuProps}
+                        items={updatedItems}
+                        onChange={(value) => {
+                            const option = updatedItems.find(
+                                (option) => option.value === value
+                            );
+                            toggleOption(option);
+                        }}
+                    />
+                );
+            } else {
+                return (
+                    <span className={styles.selectMenuEmpty}>{emptyText}</span>
+                );
+            }
         };
 
         const getSelectedOptionText = () => {
@@ -255,7 +328,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         };
 
         const selectInputProps: TextInputProps = {
-            placeholder: placeholder,
+            placeholder: showPills() ? '' : placeholder,
             alignIcon: TextInputIconAlign.Right,
             clearable: clearable,
             inputWidth: inputWidth,

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -22,6 +22,7 @@ export enum SelectSize {
 export interface SelectOption extends MenuItemProps {
     selected?: boolean;
     hideOption?: boolean;
+    id?: string;
 }
 
 export interface SelectProps extends OcBaseProps<HTMLSelectElement> {
@@ -78,6 +79,11 @@ export interface SelectProps extends OcBaseProps<HTMLSelectElement> {
      * @default false
      */
     isLoading?: boolean;
+
+    /**
+     * display text when there are no filtered results.
+     */
+    emptyText?: string;
 
     /**
      * select input props.

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -6,7 +6,7 @@
         width: 400px;
 
         .select-spinner {
-            margin: 8px auto;
+            margin: 4px auto;
             position: relative;
         }
     }
@@ -79,6 +79,8 @@
 
 .select-menu-empty {
     color: var(--grey-color-60);
+    margin: 8px auto;
+    position: relative;
 }
 
 .select-tooltip {

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -1,9 +1,14 @@
 .select-wrapper {
-    width: 100%;
     position: relative;
+    width: 100%;
 
     .select-dropdown-overlay {
         width: 400px;
+
+        .select-spinner {
+            margin: 8px auto;
+            position: relative;
+        }
     }
 
     .select-dropdown-main-wrapper {
@@ -15,25 +20,27 @@
     }
 
     .multi-select-pills {
-        position: absolute;
-        z-index: 1;
-        left: $space-xs;
-        right: $space-xxl;
-        top: 6px;
+        align-items: center;
         display: flex;
         flex-direction: row;
-        align-items: center;
+        left: $space-xs;
+        right: $space-xxl;
+        pointer-events: none;
+        position: absolute;
+        top: 6px;
+        z-index: 1;
     }
 
     .multi-select-pill {
-        max-width: 64px;
+        max-width: 96px;
         text-align: center;
         display: flex;
         justify-content: center;
+        pointer-events: all;
 
         span {
             @include text-overflow;
-            max-width: 64px;
+            max-width: 80px;
         }
     }
 
@@ -45,4 +52,35 @@
         background-color: var(--primary-color-10);
         color: var(--primary-color-80);
     }
+
+    &.select-size-1 {
+        .multi-select-pills {
+            top: 7px;
+        }
+    }
+
+    &.select-size-2 {
+        .multi-select-pills {
+            top: 5px;
+        }
+    }
+
+    &.select-size-3 {
+        .multi-select-pills {
+            top: 4px;
+
+            .multi-select-count,
+            .multi-select-pill {
+                padding: 2px 12px;
+            }
+        }
+    }
+}
+
+.select-menu-empty {
+    color: var(--grey-color-60);
+}
+
+.select-tooltip {
+    max-width: unset;
 }

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -79,7 +79,7 @@
 
 .select-menu-empty {
     color: var(--grey-color-60);
-    margin: 8px auto;
+    margin: 10px auto;
     position: relative;
 }
 


### PR DESCRIPTION
## SUMMARY:

- Adds XSmall Pill size
- Fixes Select Pills so they truncate with an ellipses and look like Pills
- Adds close button to Select Pills so they may be edited on the fly
- Adds empty state text to Select Dropdown
- Centers Select Dropdown Spinner
- Fixes right icon Text Input padding when clear button isn't shown

https://user-images.githubusercontent.com/99700808/179865168-a573931b-5241-48cb-8265-cb49b16c0cb5.mp4

## JIRA TASK (Eightfold Employees Only):
ENG-22497
ENG-22511
ENG-22510
ENG-22507

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:
TODO: Add UTs for Select and Input components

## TEST PLAN:
Pull the latest and run `yarn` and `yarn install` then verify the following components:

Select
TextInput