### PR TITLE
chore: change class name hash for theme2

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -27,7 +27,7 @@ module.exports = (_, { mode }) => ({
                         loader: 'css-loader',
                         options: {
                             modules: {
-                                localIdentName: '[local]_[hash:base64:6]',
+                                localIdentName: '[local]_[hash:base64:7]',
                                 exportLocalsConvention: 'camelCase',
                             },
                         },


### PR DESCRIPTION
## SUMMARY:
chore: change class name hash for theme2.
Change in theme2 octuple class name hash generation. theme2 will have a slightly longer hash and classes should no overlap in theme1 and theme 2


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
