### PR TITLE
fix: slider: fixes slider onresize event hang in react 16

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -181,7 +181,7 @@ export const Slider: FC<SliderProps> = ({
     }, [values]);
 
     return (
-        <ResizeObserver onResize={() => updateLayout()}>
+        <ResizeObserver onResize={updateLayout}>
             <div
                 className={mergeClasses(styles.sliderContainer, {
                     [styles.sliderDisabled]: disabled,


### PR DESCRIPTION
## SUMMARY:
Small change to fix component when host app uses react 16

## JIRA TASK (Eightfold Employees Only):
ENG-25504

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull changes, downgrade React peer deps to React 16.14.0 deps and test Slider story