### PR TITLE
fix: slider: fixes slider onchange event hang in react 16

### DIFF
--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Stack } from '../Stack';
 
 import { Slider } from './';
 
@@ -8,9 +9,67 @@ export default {
     component: Slider,
 } as ComponentMeta<typeof Slider>;
 
-const Slider_Story: ComponentStory<typeof Slider> = (args) => (
-    <Slider {...args} />
-);
+const Slider_Story: ComponentStory<typeof Slider> = (args) => {
+    const [transientSlidingValue, setTransientSlidingValue] =
+        useState<number>(2);
+
+    const handleChange = (val: number): void => {
+        setTransientSlidingValue(val);
+    };
+
+    return (
+        <Stack direction="vertical" gap="xl" style={{ width: '100%' }}>
+            <Slider
+                {...args}
+                value={transientSlidingValue}
+                onChange={handleChange}
+            />
+            <Stack
+                direction="horizontal"
+                gap="xl"
+                justify="center"
+                style={{ width: '100%' }}
+            >
+                <div>{transientSlidingValue}</div>
+            </Stack>
+        </Stack>
+    );
+};
+
+const Range_Slider_Story: ComponentStory<typeof Slider> = (args) => {
+    const [transientSlidingValues, setTransientSlidingValues] = useState<
+        number[]
+    >([110, 150]);
+
+    const handleChange = (vals: number[]): void => {
+        setTransientSlidingValues(vals);
+    };
+
+    return (
+        <Stack
+            align="stretch"
+            direction="vertical"
+            gap="xl"
+            justify="center"
+            style={{ width: '100%' }}
+        >
+            <Slider
+                {...args}
+                value={transientSlidingValues}
+                onChange={handleChange}
+            />
+            <Stack
+                direction="horizontal"
+                gap="xl"
+                justify="center"
+                style={{ width: '100%' }}
+            >
+                <div>{transientSlidingValues[0]}</div>
+                <div>{transientSlidingValues[1]}</div>
+            </Stack>
+        </Stack>
+    );
+};
 
 const sliderArgs: Object = {
     ariaLabel: 'Slider',
@@ -22,7 +81,7 @@ const sliderArgs: Object = {
     max: 200,
     name: 'mySlider',
     onChange: () => {
-        // handle change.
+        console.log('changed');
     },
 };
 
@@ -32,11 +91,12 @@ StandardSlider.args = {
     autoFocus: true,
     min: 1,
     max: 5,
-    showLabels: false,
+    showLabels: true,
+    showMarkers: true,
     value: 2,
 };
 
-export const RangeSlider = Slider_Story.bind({});
+export const RangeSlider = Range_Slider_Story.bind({});
 RangeSlider.args = {
     ...sliderArgs,
     min: 0,

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -7,7 +7,6 @@ import React, {
     useState,
 } from 'react';
 
-import { useEffectOnlyOnUpdate } from '../../hooks/useEffectOnlyOnUpdate';
 import { ResizeObserver } from '../../shared/ResizeObserver/ResizeObserver';
 import { mergeClasses } from '../../shared/utilities';
 import { SliderMarker, SliderProps } from './Slider.types';
@@ -62,12 +61,18 @@ export const Slider: FC<SliderProps> = ({
     const [values, setValues] = useState<number[]>(
         Array.isArray(value) ? value.sort(asc) : [value]
     );
-    const railRef = useRef<HTMLDivElement>(null);
-    const lowerLabelRef = useRef<HTMLInputElement>(null);
-    const upperLabelRef = useRef<HTMLInputElement>(null);
-    const trackRef = useRef<HTMLDivElement>(null);
-    const minLabelRef = useRef<HTMLDivElement>(null);
-    const maxLabelRef = useRef<HTMLDivElement>(null);
+    const railRef: React.MutableRefObject<HTMLDivElement> =
+        useRef<HTMLDivElement>(null);
+    const lowerLabelRef: React.MutableRefObject<HTMLInputElement> =
+        useRef<HTMLInputElement>(null);
+    const upperLabelRef: React.MutableRefObject<HTMLInputElement> =
+        useRef<HTMLInputElement>(null);
+    const trackRef: React.MutableRefObject<HTMLDivElement> =
+        useRef<HTMLDivElement>(null);
+    const minLabelRef: React.MutableRefObject<HTMLDivElement> =
+        useRef<HTMLDivElement>(null);
+    const maxLabelRef: React.MutableRefObject<HTMLDivElement> =
+        useRef<HTMLDivElement>(null);
     let [markers, setMarkers] = useState<SliderMarker[]>(
         !showMarkers
             ? []
@@ -75,7 +80,8 @@ export const Slider: FC<SliderProps> = ({
                   (_, index) => ({ value: min + step * index })
               )
     );
-    const markerRefs = useRef<RefObject<HTMLDivElement>[]>(null);
+    const markerRefs: React.MutableRefObject<RefObject<HTMLDivElement>[]> =
+        useRef<RefObject<HTMLDivElement>[]>(null);
     markerRefs.current = markers.map(
         (_, i) => markerRefs.current?.[i] ?? createRef<HTMLDivElement>()
     );
@@ -107,14 +113,15 @@ export const Slider: FC<SliderProps> = ({
         );
     };
 
-    const handleChange = (newVal: number, index: number) => {
+    const handleChange = (newVal: number, index: number): void => {
         const newValues = [...values];
         newValues.splice(index, 1, newVal);
         newValues.sort(asc);
         setValues(newValues);
+        onChange?.(isRange ? [...newValues] : newValues[0]);
     };
 
-    const updateLayout = () => {
+    const updateLayout = (): void => {
         const inputWidth = railRef.current?.offsetWidth || 0;
 
         // Early exit if there is no ref available yet. The DOM has yet to initialize
@@ -123,45 +130,49 @@ export const Slider: FC<SliderProps> = ({
             return;
         }
 
-        markerRefs.current.forEach((ref, i) => {
-            if (ref.current) {
-                ref.current.style.left = `${getValueOffset(
-                    markers[i].value
-                )}px`;
+        markerRefs.current.forEach(
+            (ref: React.RefObject<HTMLDivElement>, i: number) => {
+                if (ref.current) {
+                    ref.current.style.left = `${getValueOffset(
+                        markers[i].value
+                    )}px`;
+                }
             }
-        });
+        );
 
-        const lowerThumbOffset = getValueOffset(values[0]);
-        const upperThumbOffset = getValueOffset(values[1]);
-        const rangeWidth = isRange
+        const lowerThumbOffset: number = getValueOffset(values[0]);
+        const upperThumbOffset: number = getValueOffset(values[1]);
+        const rangeWidth: number = isRange
             ? upperThumbOffset - lowerThumbOffset
             : lowerThumbOffset;
 
         // Hide the min/max markers if the value labels would collide.
-        const maxCollisionLabelRef = isRange ? upperLabelRef : lowerLabelRef;
-        const maxCollisionThumbOffset = isRange
+        const maxCollisionLabelRef: React.MutableRefObject<HTMLInputElement> =
+            isRange ? upperLabelRef : lowerLabelRef;
+        const maxCollisionThumbOffset: number = isRange
             ? upperThumbOffset
             : lowerThumbOffset;
 
-        const showMaxLabel =
+        const showMaxLabel: boolean =
             showLabels &&
             inputWidth - maxCollisionThumbOffset >
                 (maxCollisionLabelRef.current?.offsetWidth || 0) + 15;
         maxLabelRef.current.style.opacity = showMaxLabel ? '1' : '0';
 
-        const showMinLabel =
+        const showMinLabel: boolean =
             showLabels &&
             lowerThumbOffset > lowerLabelRef.current.offsetWidth + 15;
         minLabelRef.current.style.opacity = showMinLabel ? '1' : '0';
 
-        const lowerLabelOffset = lowerLabelRef.current.offsetWidth / 2;
+        const lowerLabelOffset: number = lowerLabelRef.current.offsetWidth / 2;
         lowerLabelRef.current.style.left = `${
             lowerThumbOffset - lowerLabelOffset
         }px`;
 
         // upper Label/thumb is only used in range mode.
         if (isRange) {
-            const upperLabelOffset = upperLabelRef.current.offsetWidth / 2;
+            const upperLabelOffset: number =
+                upperLabelRef.current.offsetWidth / 2;
             upperLabelRef.current.style.left = `${
                 upperThumbOffset - upperLabelOffset
             }px`;
@@ -170,10 +181,6 @@ export const Slider: FC<SliderProps> = ({
         trackRef.current.style.left = isRange ? `${lowerThumbOffset}px` : '0';
         trackRef.current.style.width = `${rangeWidth}px`;
     };
-
-    useEffectOnlyOnUpdate(() => {
-        onChange?.(isRange ? [...values] : values[0]);
-    }, [values]);
 
     // Set width of the range to decrease from the left side
     useLayoutEffect(() => {
@@ -190,7 +197,7 @@ export const Slider: FC<SliderProps> = ({
                 <div className={mergeClasses(styles.slider, classNames)}>
                     <div ref={railRef} className={styles.sliderRail} />
                     <div ref={trackRef} className={styles.sliderTrack} />
-                    {markers.map((mark, index) => {
+                    {markers.map((mark: SliderMarker, index: number) => {
                         // Hiding the first and last marker based on design.
                         const isFirstOrLast =
                             index === 0 || index === markers.length - 1;
@@ -208,7 +215,7 @@ export const Slider: FC<SliderProps> = ({
                             )
                         );
                     })}
-                    {values.map((val, index) => (
+                    {values.map((val: number, index: number) => (
                         <input
                             aria-label={ariaLabel}
                             autoFocus={autoFocus && index === 0}
@@ -216,9 +223,9 @@ export const Slider: FC<SliderProps> = ({
                             id={getIdentifier(id, index)}
                             key={index}
                             disabled={disabled}
-                            onChange={(event) =>
-                                handleChange(+event.target.value, index)
-                            }
+                            onChange={(
+                                event: React.ChangeEvent<HTMLInputElement>
+                            ) => handleChange(+event.target.value, index)}
                             min={min}
                             max={max}
                             name={getIdentifier(name, index)}

--- a/src/src/components/Slider/__snapshots__/Slider.stories.storyshot
+++ b/src/src/components/Slider/__snapshots__/Slider.stories.storyshot
@@ -2,168 +2,234 @@
 
 exports[`Storyshots Slider Range Slider 1`] = `
 <div
-  className="slider-container"
+  className="stack vertical xl"
+  style={
+    Object {
+      "alignItems": "stretch",
+      "flexWrap": undefined,
+      "justifyContent": "center",
+      "width": "100%",
+    }
+  }
 >
   <div
-    className="slider my-slider"
+    className="slider-container"
   >
     <div
-      className="slider-rail"
-    />
+      className="slider my-slider"
+    >
+      <div
+        className="slider-rail"
+      />
+      <div
+        className="slider-track"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker active"
+      />
+      <div
+        className="rail-marker active"
+      />
+      <div
+        className="rail-marker active"
+      />
+      <div
+        className="rail-marker active"
+      />
+      <div
+        className="rail-marker active"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <input
+        aria-label="Slider"
+        autoFocus={false}
+        className="thumb"
+        disabled={false}
+        id="mySliderId-0"
+        max={200}
+        min={0}
+        name="mySlider-0"
+        onChange={[Function]}
+        step={10}
+        type="range"
+        value={110}
+      />
+      <input
+        aria-label="Slider"
+        autoFocus={false}
+        className="thumb"
+        disabled={false}
+        id="mySliderId-1"
+        max={200}
+        min={0}
+        name="mySlider-1"
+        onChange={[Function]}
+        step={10}
+        type="range"
+        value={150}
+      />
+    </div>
     <div
-      className="slider-track"
-    />
+      className="slider-value label-visible"
+    >
+      110
+    </div>
     <div
-      className="rail-marker"
-    />
+      className="slider-value label-visible"
+    >
+      150
+    </div>
     <div
-      className="rail-marker"
-    />
+      className="extremity-label min-label"
+    >
+      0
+    </div>
     <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker active"
-    />
-    <div
-      className="rail-marker active"
-    />
-    <div
-      className="rail-marker active"
-    />
-    <div
-      className="rail-marker active"
-    />
-    <div
-      className="rail-marker active"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <div
-      className="rail-marker"
-    />
-    <input
-      aria-label="Slider"
-      autoFocus={false}
-      className="thumb"
-      disabled={false}
-      id="mySliderId-0"
-      max={200}
-      min={0}
-      name="mySlider-0"
-      onChange={[Function]}
-      step={10}
-      type="range"
-      value={110}
-    />
-    <input
-      aria-label="Slider"
-      autoFocus={false}
-      className="thumb"
-      disabled={false}
-      id="mySliderId-1"
-      max={200}
-      min={0}
-      name="mySlider-1"
-      onChange={[Function]}
-      step={10}
-      type="range"
-      value={150}
-    />
+      className="extremity-label max-label"
+    >
+      200
+    </div>
   </div>
   <div
-    className="slider-value label-visible"
+    className="stack horizontal xl"
+    style={
+      Object {
+        "alignItems": undefined,
+        "flexWrap": undefined,
+        "justifyContent": "center",
+        "width": "100%",
+      }
+    }
   >
-    110
-  </div>
-  <div
-    className="slider-value label-visible"
-  >
-    150
-  </div>
-  <div
-    className="extremity-label min-label"
-  >
-    0
-  </div>
-  <div
-    className="extremity-label max-label"
-  >
-    200
+    <div>
+      110
+    </div>
+    <div>
+      150
+    </div>
   </div>
 </div>
 `;
 
 exports[`Storyshots Slider Standard Slider 1`] = `
 <div
-  className="slider-container"
+  className="stack vertical xl"
+  style={
+    Object {
+      "alignItems": undefined,
+      "flexWrap": undefined,
+      "justifyContent": undefined,
+      "width": "100%",
+    }
+  }
 >
   <div
-    className="slider my-slider"
+    className="slider-container"
   >
     <div
-      className="slider-rail"
-    />
+      className="slider my-slider"
+    >
+      <div
+        className="slider-rail"
+      />
+      <div
+        className="slider-track"
+      />
+      <div
+        className="rail-marker active"
+      />
+      <div
+        className="rail-marker"
+      />
+      <div
+        className="rail-marker"
+      />
+      <input
+        aria-label="Slider"
+        autoFocus={true}
+        className="thumb"
+        disabled={false}
+        id="mySliderId"
+        max={5}
+        min={1}
+        name="mySlider"
+        onChange={[Function]}
+        step={1}
+        type="range"
+        value={2}
+      />
+    </div>
     <div
-      className="slider-track"
-    />
-    <input
-      aria-label="Slider"
-      autoFocus={true}
-      className="thumb"
-      disabled={false}
-      id="mySliderId"
-      max={5}
-      min={1}
-      name="mySlider"
-      onChange={[Function]}
-      step={1}
-      type="range"
-      value={2}
-    />
+      className="slider-value label-visible"
+    >
+      2
+    </div>
+    <div
+      className="extremity-label min-label"
+    >
+      1
+    </div>
+    <div
+      className="extremity-label max-label"
+    >
+      5
+    </div>
   </div>
   <div
-    className="slider-value"
+    className="stack horizontal xl"
+    style={
+      Object {
+        "alignItems": undefined,
+        "flexWrap": undefined,
+        "justifyContent": "center",
+        "width": "100%",
+      }
+    }
   >
-    2
-  </div>
-  <div
-    className="extremity-label min-label"
-  >
-    1
-  </div>
-  <div
-    className="extremity-label max-label"
-  >
-    5
+    <div>
+      2
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
## SUMMARY:
Moves onChange callback into the handler, removes `useEffectOnlyOnUpdate` reference and adds some typings

## JIRA TASK (Eightfold Employees Only):

ENG-25504

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull changes, downgrade React peer deps to React 16.14.0 deps and test Slider story

peer deps change -->

```
"peerDependencies": {
    "@types/react": "^16.9.49",
    "@types/react-dom": "^16.9.8",
    "react": "^16.14.0",
    "react-app-polyfill": "3.0.0",
    "react-dom": "^16.14.0"
},
```