### PR TITLE
fix: selectors: adds size prop, fixes styles to match the latest

### DIFF
--- a/src/components/Button/BaseButton.tsx
+++ b/src/components/Button/BaseButton.tsx
@@ -181,11 +181,11 @@ export const BaseButton: FC<InternalButtonProps> = React.forwardRef(
                     ref={ref}
                     {...rest}
                     aria-checked={toggle ? !!checked : undefined}
-                    aria-disabled={allowDisabledFocus}
+                    aria-disabled={disabled}
                     aria-label={ariaLabel}
                     aria-pressed={toggle ? !!checked : undefined}
                     defaultChecked={checked}
-                    disabled={disabled}
+                    disabled={!allowDisabledFocus && disabled}
                     className={buttonBaseClassNames}
                     id={id}
                     onClick={!allowDisabledFocus ? onClick : null}

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
+import { ButtonSize } from './Button.types';
 import { PrimaryButton } from './PrimaryButton/PrimaryButton';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -12,17 +13,17 @@ describe('Button', () => {
     beforeAll(() => {
         matchMedia = new MatchMediaMock();
     });
+
     afterEach(() => {
         matchMedia.clear();
     });
-    /*
-     * Functionality Tests
-     */
-    test('simulate click on button', () => {
+
+    it('simulate click on button', () => {
         const wrapper = mount(<PrimaryButton text="test Button" />);
         wrapper.find('.button').at(0).simulate('click');
     });
-    test('simulate click on enabled button', () => {
+
+    it('simulate click on enabled button', () => {
         let testCounter = 0;
         const disabled = false;
         const wrapper = mount(
@@ -37,7 +38,7 @@ describe('Button', () => {
         expect(testCounter).toEqual(2);
     });
 
-    test('simulate click on disabled button', () => {
+    it('simulate click on disabled button', () => {
         let testCounter = 0;
         const disabled = true;
         const wrapper = mount(
@@ -50,5 +51,26 @@ describe('Button', () => {
         wrapper.find('.button').at(0).simulate('click');
         wrapper.find('.button').at(0).simulate('click');
         expect(testCounter).toEqual(0);
+    });
+
+    it('Button is large', () => {
+        const wrapper = mount(
+            <PrimaryButton size={ButtonSize.Large} text="test" />
+        );
+        expect(wrapper.find('.button-large')).toBeTruthy();
+    });
+
+    it('Button is medium', () => {
+        const wrapper = mount(
+            <PrimaryButton size={ButtonSize.Medium} text="test" />
+        );
+        expect(wrapper.find('.button-medium')).toBeTruthy();
+    });
+
+    it('Button is small', () => {
+        const wrapper = mount(
+            <PrimaryButton size={ButtonSize.Small} text="test" />
+        );
+        expect(wrapper.find('.button-small')).toBeTruthy();
     });
 });

--- a/src/components/Button/SplitButton/SplitButton.tsx
+++ b/src/components/Button/SplitButton/SplitButton.tsx
@@ -151,11 +151,11 @@ export const SplitButton: FC<SplitButtonProps> = React.forwardRef(
                 {...rest}
                 ref={ref}
                 aria-checked={split ? !!checked : undefined}
-                aria-disabled={allowDisabledFocus}
+                aria-disabled={disabled}
                 aria-label={ariaLabel}
                 aria-pressed={split ? !!checked : undefined}
                 defaultChecked={checked}
-                disabled={disabled}
+                disabled={!allowDisabledFocus && disabled}
                 className={splitButtonClassNames}
                 id={id}
                 onClick={!allowDisabledFocus ? onClick : null}

--- a/src/components/Button/TwoStateButton/TwoStateButton.tsx
+++ b/src/components/Button/TwoStateButton/TwoStateButton.tsx
@@ -155,11 +155,11 @@ export const TwoStateButton: FC<TwoStateButtonProps> = React.forwardRef(
                 {...rest}
                 ref={ref}
                 aria-checked={toggle ? !!checked : undefined}
-                aria-disabled={allowDisabledFocus}
+                aria-disabled={disabled}
                 aria-label={ariaLabel}
                 aria-pressed={toggle ? !!checked : undefined}
                 defaultChecked={checked}
-                disabled={disabled}
+                disabled={!allowDisabledFocus && disabled}
                 className={twoStateButtonClassNames}
                 id={id}
                 onClick={!allowDisabledFocus ? onClick : null}

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -301,7 +301,8 @@
     }
 
     &:active {
-        --bg: var(--accent-color-20);
+        --bg: var(--primary-color-20);
+        color: var(--primary-color-80);
     }
 }
 
@@ -343,15 +344,15 @@
         width: 1px;
 
         &.split-divider-primary {
-            background-color: var(--text-inverse-color);
+            background-color: var(--primary-color-80);
         }
 
         &.split-divider-secondary {
-            background-color: var(--primary-color);
+            background-color: var(--primary-color-70);
         }
 
         &.split-divider-primary-disruptive {
-            background-color: var(--text-inverse-color);
+            background-color: var(--disruptive-color-80);
         }
 
         &.split-divider-secondary-disruptive {
@@ -359,7 +360,7 @@
         }
 
         &.split-divider-default {
-            background-color: var(--primary-color);
+            background-color: var(--primary-color-70);
         }
 
         &.split-divider-disruptive {
@@ -367,7 +368,7 @@
         }
 
         &.split-divider-neutral {
-            background-color: var(--primary-color);
+            background-color: var(--grey-color-70);
         }
     }
 

--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -170,4 +170,5 @@ Check_Box_Group.args = {
         },
     ],
     layout: 'vertical',
+    size: SelectorSize.Medium,
 };

--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { CheckBox, CheckBoxGroup, CheckboxValueType, LabelPosition } from './';
+import {
+    CheckBox,
+    CheckBoxGroup,
+    CheckboxValueType,
+    LabelPosition,
+    SelectorSize,
+} from './';
 
 export default {
     title: 'Check Box',
@@ -85,6 +91,15 @@ export default {
             options: ['vertical', 'horizontal'],
             control: { type: 'inline-radio' },
         },
+        size: {
+            options: [
+                SelectorSize.Flex,
+                SelectorSize.Large,
+                SelectorSize.Medium,
+                SelectorSize.Small,
+            ],
+            control: { type: 'radio' },
+        },
     },
 } as ComponentMeta<typeof CheckBox>;
 
@@ -121,6 +136,7 @@ const checkBoxArgs: Object = {
     labelPosition: LabelPosition.End,
     id: 'myCheckBoxId',
     defaultChecked: false,
+    size: SelectorSize.Medium,
     toggle: false,
 };
 
@@ -129,8 +145,10 @@ Check_Box.args = {
 };
 
 Check_Box_Group.args = {
+    allowDisabledFocus: false,
     value: ['First'],
     defaultChecked: ['First'],
+    disabled: false,
     items: [
         {
             name: 'group',

--- a/src/components/CheckBox/CheckBox.test.tsx
+++ b/src/components/CheckBox/CheckBox.test.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
-import { CheckBox } from './';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { CheckBox, SelectorSize } from './';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+let matchMedia: any;
+
 describe('RadioButton', () => {
-    it('Checkbox renders', () => {
+    beforeAll(() => {
+        matchMedia = new MatchMediaMock();
+    });
+
+    afterEach(() => {
+        matchMedia.clear();
+    });
+
+    it('CheckBox renders', () => {
         const wrapper = mount(<CheckBox checked={true} />);
         expect(
             wrapper.containsMatchingElement(<CheckBox checked={true} />)
@@ -16,5 +27,31 @@ describe('RadioButton', () => {
     it('Checkbox renders as toggle switch', () => {
         const wrapper = mount(<CheckBox checked={true} toggle />);
         expect(wrapper.find('.toggle')).toBeTruthy();
+    });
+
+    it('simulate disabled CheckBox', () => {
+        const wrapper = mount(<CheckBox disabled label="test label" />);
+        wrapper.find('input').html().includes('disabled=""');
+    });
+
+    it('CheckBox is large', () => {
+        const wrapper = mount(
+            <CheckBox size={SelectorSize.Large} label="test label" />
+        );
+        expect(wrapper.find('.selector-large')).toBeTruthy();
+    });
+
+    it('CheckBox is medium', () => {
+        const wrapper = mount(
+            <CheckBox size={SelectorSize.Medium} label="test label" />
+        );
+        expect(wrapper.find('.selector-medium')).toBeTruthy();
+    });
+
+    it('CheckBox is small', () => {
+        const wrapper = mount(
+            <CheckBox size={SelectorSize.Small} label="test label" />
+        );
+        expect(wrapper.find('.selector-small')).toBeTruthy();
     });
 });

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -99,10 +99,10 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
             >
                 <input
                     ref={ref}
-                    aria-disabled={allowDisabledFocus}
+                    aria-disabled={disabled}
                     aria-label={ariaLabel}
                     checked={isChecked}
-                    disabled={disabled}
+                    disabled={!allowDisabledFocus && disabled}
                     id={checkBoxId.current}
                     onChange={!allowDisabledFocus ? toggleChecked : null}
                     name={name}

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,12 +1,14 @@
 import React, { FC, Ref, useEffect, useRef, useState } from 'react';
 import { generateId, mergeClasses } from '../../shared/utilities';
-import { CheckboxProps, LabelPosition } from './';
+import { CheckboxProps, LabelPosition, SelectorSize } from './';
+import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
 
 import styles from './checkbox.module.scss';
 
 export const CheckBox: FC<CheckboxProps> = React.forwardRef(
     (
         {
+            allowDisabledFocus = false,
             ariaLabel,
             checked = false,
             classNames,
@@ -17,6 +19,7 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
             labelPosition = LabelPosition.End,
             name,
             onChange,
+            size = SelectorSize.Medium,
             style,
             toggle = false,
             value,
@@ -24,6 +27,11 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
         },
         ref: Ref<HTMLInputElement>
     ) => {
+        const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
+        const mediumScreenActive: boolean = useMatchMedia(Breakpoints.Medium);
+        const smallScreenActive: boolean = useMatchMedia(Breakpoints.Small);
+        const xSmallScreenActive: boolean = useMatchMedia(Breakpoints.XSmall);
+
         const checkBoxId = useRef<string>(id || generateId());
         const [isChecked, setIsChecked] = useState<boolean>(
             defaultChecked || checked
@@ -35,7 +43,27 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
 
         const checkboxWrapperClassNames: string = mergeClasses([
             styles.selector,
+            {
+                [styles.selectorSmall]:
+                    size === SelectorSize.Flex && largeScreenActive,
+            },
+            {
+                [styles.selectorMedium]:
+                    size === SelectorSize.Flex && mediumScreenActive,
+            },
+            {
+                [styles.selectorMedium]:
+                    size === SelectorSize.Flex && smallScreenActive,
+            },
+            {
+                [styles.selectorLarge]:
+                    size === SelectorSize.Flex && xSmallScreenActive,
+            },
+            { [styles.selectorLarge]: size === SelectorSize.Large },
+            { [styles.selectorMedium]: size === SelectorSize.Medium },
+            { [styles.selectorSmall]: size === SelectorSize.Small },
             classNames,
+            { [styles.disabled]: allowDisabledFocus || disabled },
         ]);
 
         const checkBoxCheckClassNames: string = mergeClasses([
@@ -71,11 +99,12 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
             >
                 <input
                     ref={ref}
+                    aria-disabled={allowDisabledFocus}
                     aria-label={ariaLabel}
                     checked={isChecked}
                     disabled={disabled}
                     id={checkBoxId.current}
-                    onChange={toggleChecked}
+                    onChange={!allowDisabledFocus ? toggleChecked : null}
                     name={name}
                     type={'checkbox'}
                     value={value}

--- a/src/components/CheckBox/CheckBoxGroup.tsx
+++ b/src/components/CheckBox/CheckBoxGroup.tsx
@@ -1,28 +1,56 @@
 import React, { FC, Ref } from 'react';
 import { mergeClasses } from '../../shared/utilities';
-import { CheckBox, CheckboxGroupProps, LabelPosition } from './';
+import { CheckBox, CheckboxGroupProps, LabelPosition, SelectorSize } from './';
+import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
 
 import styles from './checkbox.module.scss';
 
 export const CheckBoxGroup: FC<CheckboxGroupProps> = React.forwardRef(
     (
         {
+            allowDisabledFocus = false,
             ariaLabel,
             classNames,
+            disabled = false,
             items = [],
             labelPosition = LabelPosition.End,
             layout = 'vertical',
             onChange,
+            size = SelectorSize.Medium,
             style,
             value,
             ...rest
         },
         ref: Ref<HTMLDivElement>
     ) => {
+        const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
+        const mediumScreenActive: boolean = useMatchMedia(Breakpoints.Medium);
+        const smallScreenActive: boolean = useMatchMedia(Breakpoints.Small);
+        const xSmallScreenActive: boolean = useMatchMedia(Breakpoints.XSmall);
+
         const checkboxGroupClassNames = mergeClasses([
             styles.checkboxGroup,
             { [styles.vertical]: layout === 'vertical' },
             { [styles.horizontal]: layout === 'horizontal' },
+            {
+                [styles.checkboxGroupSmall]:
+                    size === SelectorSize.Flex && largeScreenActive,
+            },
+            {
+                [styles.checkboxGroupMedium]:
+                    size === SelectorSize.Flex && mediumScreenActive,
+            },
+            {
+                [styles.checkboxGroupMedium]:
+                    size === SelectorSize.Flex && smallScreenActive,
+            },
+            {
+                [styles.checkboxGroupLarge]:
+                    size === SelectorSize.Flex && xSmallScreenActive,
+            },
+            { [styles.checkboxGroupLarge]: size === SelectorSize.Large },
+            { [styles.checkboxGroupMedium]: size === SelectorSize.Medium },
+            { [styles.checkboxGroupSmall]: size === SelectorSize.Small },
             classNames,
         ]);
 
@@ -37,10 +65,12 @@ export const CheckBoxGroup: FC<CheckboxGroupProps> = React.forwardRef(
             >
                 {items.map((item) => (
                     <CheckBox
+                        allowDisabledFocus={allowDisabledFocus}
+                        disabled={disabled}
+                        labelPosition={labelPosition}
                         {...item}
                         checked={value?.includes(item.value)}
                         key={item.value}
-                        labelPosition={labelPosition}
                         onChange={() => {
                             const optionIndex = value?.indexOf(item.value);
                             const newValue = [...value];
@@ -51,6 +81,7 @@ export const CheckBoxGroup: FC<CheckboxGroupProps> = React.forwardRef(
                             }
                             onChange?.(newValue);
                         }}
+                        size={size}
                     />
                 ))}
             </div>

--- a/src/components/CheckBox/Checkbox.types.ts
+++ b/src/components/CheckBox/Checkbox.types.ts
@@ -8,6 +8,13 @@ export enum LabelPosition {
     Start = 'start',
 }
 
+export enum SelectorSize {
+    Flex = 'flex',
+    Large = 'large',
+    Medium = 'medium',
+    Small = 'small',
+}
+
 export interface CheckboxProps extends OcBaseProps<HTMLInputElement> {
     /**
      * Allows focus on the checkbox when it's disabled.
@@ -48,6 +55,11 @@ export interface CheckboxProps extends OcBaseProps<HTMLInputElement> {
      */
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
     /**
+     * The checkbox size.
+     * @default SelectorSize.Medium
+     */
+    size?: SelectorSize;
+    /**
      * The Checkbox UI is toggle.
      * @default false
      */
@@ -61,9 +73,18 @@ export interface CheckboxProps extends OcBaseProps<HTMLInputElement> {
 export interface CheckboxGroupProps
     extends Omit<OcBaseProps<HTMLInputElement>, 'defaultChecked' | 'onChange'> {
     /**
+     * Allows focus on the checkbox group when it's disabled.
+     */
+    allowDisabledFocus?: boolean;
+    /**
      * Aria label for the checkbox group.
      */
     ariaLabel?: string;
+    /**
+     * The checkbox group disabled state.
+     * @default false
+     */
+    disabled?: boolean;
     /**
      * The array of items for the radio group.
      */
@@ -83,6 +104,11 @@ export interface CheckboxGroupProps
      * @param checkedValue
      */
     onChange?: (checkedValue: CheckboxValueType[]) => void;
+    /**
+     * The checkbox size.
+     * @default SelectorSize.Medium
+     */
+    size?: SelectorSize;
     /**
      * The checkbox value.
      */

--- a/src/components/CheckBox/ToggleSwitch.stories.tsx
+++ b/src/components/CheckBox/ToggleSwitch.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { CheckBox, LabelPosition } from '.';
+import { CheckBox, LabelPosition, SelectorSize } from '.';
 
 export default {
     title: 'Toggle Switch',
@@ -45,6 +45,15 @@ export default {
             options: ['vertical', 'horizontal'],
             control: { type: 'inline-radio' },
         },
+        size: {
+            options: [
+                SelectorSize.Flex,
+                SelectorSize.Large,
+                SelectorSize.Medium,
+                SelectorSize.Small,
+            ],
+            control: { type: 'radio' },
+        },
     },
 } as ComponentMeta<typeof CheckBox>;
 
@@ -65,6 +74,7 @@ const checkBoxArgs: Object = {
     labelPosition: LabelPosition.End,
     id: 'myToggleId',
     defaultChecked: false,
+    size: SelectorSize.Medium,
     toggle: false,
 };
 

--- a/src/components/CheckBox/checkbox.module.scss
+++ b/src/components/CheckBox/checkbox.module.scss
@@ -23,36 +23,6 @@
                     }
                 }
             }
-
-            &:hover + label {
-                .checkmark {
-                    border: $space-xxxs solid var(--grey-color-70);
-
-                    &.toggle {
-                        border: $space-xxxs solid var(--grey-color-70);
-
-                        &:after {
-                            background-color: var(--grey-color-70);
-                            border-color: var(--grey-color-70);
-                        }
-                    }
-                }
-            }
-
-            &:active + label {
-                .checkmark {
-                    border: $space-xxxs solid var(--grey-color-70);
-
-                    &.toggle {
-                        border: $space-xxxs solid var(--grey-color-70);
-
-                        &:after {
-                            background-color: var(--grey-color-70);
-                            border-color: var(--grey-color-70);
-                        }
-                    }
-                }
-            }
         }
 
         & + label {
@@ -115,14 +85,14 @@
             }
         }
 
-        &:hover + label {
+        &:not(.disabled):not([disabled]):active + label {
             .checkmark {
                 border: $space-xxxs solid var(--primary-color-70);
-                background-color: var(--accent-color-10);
+                background-color: var(--accent-color-30);
 
                 &.toggle {
                     border: $space-xxxs solid var(--primary-color-70);
-                    background-color: var(--accent-color-10);
+                    background-color: var(--accent-color-30);
 
                     &:after {
                         background-color: var(--primary-color-70);
@@ -132,14 +102,14 @@
             }
         }
 
-        &:active + label {
+        &:not(.disabled):not([disabled]):hover + label {
             .checkmark {
                 border: $space-xxxs solid var(--primary-color-70);
-                background-color: var(--accent-color-30);
+                background-color: var(--accent-color-10);
 
                 &.toggle {
                     border: $space-xxxs solid var(--primary-color-70);
-                    background-color: var(--accent-color-30);
+                    background-color: var(--accent-color-10);
 
                     &:after {
                         background-color: var(--primary-color-70);
@@ -197,7 +167,7 @@
             }
         }
 
-        &:active + label {
+        &:not(.disabled):not([disabled]):active + label {
             .checkmark {
                 transform: scale(0.98);
                 background-color: var(--accent-color-10);
@@ -216,7 +186,7 @@
             }
         }
 
-        &:hover + label {
+        &:not(.disabled):not([disabled]):hover + label {
             .checkmark {
                 background-color: var(--accent-color-20);
                 border: $space-xxxs solid var(--primary-color-70);
@@ -436,36 +406,6 @@
 
                     &.toggle {
                         opacity: 50%;
-                    }
-                }
-            }
-
-            &:hover + label {
-                .checkmark {
-                    border: $space-xxxs solid var(--grey-color-70);
-
-                    &.toggle {
-                        border: $space-xxxs solid var(--grey-color-70);
-
-                        &:after {
-                            background-color: var(--grey-color-70);
-                            border-color: var(--grey-color-70);
-                        }
-                    }
-                }
-            }
-
-            &:active + label {
-                .checkmark {
-                    border: $space-xxxs solid var(--grey-color-70);
-
-                    &.toggle {
-                        border: $space-xxxs solid var(--grey-color-70);
-
-                        &:after {
-                            background-color: var(--grey-color-70);
-                            border-color: var(--grey-color-70);
-                        }
                     }
                 }
             }

--- a/src/components/CheckBox/checkbox.module.scss
+++ b/src/components/CheckBox/checkbox.module.scss
@@ -12,7 +12,7 @@
         z-index: 1;
 
         &[disabled] {
-            cursor: default;
+            cursor: not-allowed;
 
             & + label {
                 .checkmark {
@@ -58,41 +58,41 @@
         & + label {
             .checkmark {
                 border: $space-xxxs solid var(--grey-color-70);
-                border-radius: $corner-radius-s;
-                height: $checkmark-height;
+                border-radius: $corner-radius-xs;
+                height: $checkmark-medium-height;
                 left: 0;
                 position: relative;
                 top: 0;
                 transition: all $motion-duration-extra-fast $motion-ease-in-back
                     $motion-delay-s;
-                width: $checkmark-width;
+                width: $checkmark-medium-width;
 
                 &:after {
                     border: solid var(--primary-color);
                     border-width: 0 $space-xxxs $space-xxxs 0;
                     content: '';
                     display: block;
-                    height: $checkmark-after-height;
-                    left: $checkmark-after-left;
+                    height: $checkmark-medium-after-height;
+                    left: $checkmark-medium-after-left;
                     opacity: 0;
                     position: absolute;
-                    top: $checkmark-after-top;
+                    top: $checkmark-medium-after-top;
                     transform: rotate(45deg) scale(0);
                     transition: all $motion-duration-extra-fast
                         $motion-ease-in-back $motion-delay-s;
-                    width: $checkmark-after-width;
+                    width: $checkmark-medium-after-width;
                 }
 
                 &.toggle {
                     border: $space-xxxs solid var(--grey-color-70);
-                    border-radius: 20px;
-                    height: $toggle-height;
+                    border-radius: $toggle-medium-height;
+                    height: $toggle-medium-height;
                     left: 0;
                     position: relative;
                     top: 0;
                     transition: all $motion-duration-extra-fast
                         $motion-ease-in-back $motion-delay-s;
-                    width: $toggle-width;
+                    width: $toggle-medium-width;
 
                     &:after {
                         background-color: var(--grey-color-70);
@@ -101,15 +101,15 @@
                         border-width: $space-xxxs;
                         content: '';
                         display: block;
-                        height: $toggle-after-height;
-                        left: $toggle-after-left;
+                        height: $toggle-medium-after-height;
+                        left: $toggle-medium-after-left;
                         opacity: 1;
                         position: absolute;
-                        top: $toggle-after-top;
+                        top: $toggle-medium-after-top;
                         transform: none;
                         transition: all $motion-duration-extra-fast
                             $motion-ease-in-back $motion-delay-s;
-                        width: $toggle-after-width;
+                        width: $toggle-medium-after-width;
                     }
                 }
             }
@@ -152,7 +152,7 @@
 
     input:checked {
         &[disabled] {
-            cursor: default;
+            cursor: not-allowed;
         }
 
         & + label {
@@ -178,7 +178,7 @@
                 &:after {
                     border-color: var(--primary-color-70);
                     opacity: 1;
-                    transform: rotate(45deg) scale(1);
+                    transform: rotate(45deg) scale(0.7);
                     transition: all $motion-duration-extra-fast
                         $motion-ease-out-back $motion-delay-s;
                 }
@@ -187,7 +187,7 @@
                     &:after {
                         background-color: var(--primary-color-70);
                         border-color: var(--primary-color-70);
-                        left: $toggle-after-left-checked;
+                        left: $toggle-medium-after-left-checked;
                         opacity: 1;
                         transform: none;
                         transition: all $motion-duration-extra-fast
@@ -242,14 +242,237 @@
     }
 
     .selector-label {
-        font-size: $text-font-weight-regular;
+        font-size: $text-font-size-2;
 
         &-end {
-            margin-left: $space-xs;
+            margin-left: $space-xxs;
         }
 
         &-start {
-            margin-right: $space-xs;
+            margin-right: $space-xxs;
+        }
+    }
+
+    &-large {
+        input {
+            & + label {
+                .checkmark {
+                    height: $checkmark-large-height;
+                    width: $checkmark-large-width;
+
+                    &:after {
+                        height: $checkmark-large-after-height;
+                        left: $checkmark-large-after-left;
+                        top: $checkmark-large-after-top;
+                        width: $checkmark-large-after-width;
+                    }
+
+                    &.toggle {
+                        border-radius: $toggle-large-height;
+                        height: $toggle-large-height;
+                        width: $toggle-large-width;
+
+                        &:after {
+                            height: $toggle-large-after-height;
+                            left: $toggle-large-after-left;
+                            top: $toggle-large-after-top;
+                            width: $toggle-large-after-width;
+                        }
+                    }
+                }
+            }
+        }
+
+        input:checked {
+            & + label {
+                .checkmark {
+                    &:after {
+                        transform: rotate(45deg) scale(0.76);
+                    }
+
+                    &.toggle {
+                        &:after {
+                            left: $toggle-large-after-left-checked;
+                        }
+                    }
+                }
+            }
+        }
+
+        .selector-label {
+            font-size: $text-font-size-3;
+
+            &-end {
+                margin-left: $space-xs;
+            }
+
+            &-start {
+                margin-right: $space-xs;
+            }
+        }
+    }
+
+    &-medium {
+        input {
+            & + label {
+                .checkmark {
+                    height: $checkmark-medium-height;
+                    width: $checkmark-medium-width;
+
+                    &:after {
+                        height: $checkmark-medium-after-height;
+                        left: $checkmark-medium-after-left;
+                        top: $checkmark-medium-after-top;
+                        width: $checkmark-medium-after-width;
+                    }
+
+                    &.toggle {
+                        border-radius: $toggle-medium-height;
+                        height: $toggle-medium-height;
+                        width: $toggle-medium-width;
+
+                        &:after {
+                            height: $toggle-medium-after-height;
+                            left: $toggle-medium-after-left;
+                            top: $toggle-medium-after-top;
+                            width: $toggle-medium-after-width;
+                        }
+                    }
+                }
+            }
+        }
+
+        input:checked {
+            & + label {
+                .checkmark {
+                    &:after {
+                        transform: rotate(45deg) scale(0.7);
+                    }
+
+                    &.toggle {
+                        &:after {
+                            left: $toggle-medium-after-left-checked;
+                        }
+                    }
+                }
+            }
+        }
+
+        .selector-label {
+            font-size: $text-font-size-2;
+
+            &-end {
+                margin-left: $space-xxs;
+            }
+
+            &-start {
+                margin-right: $space-xxs;
+            }
+        }
+    }
+
+    &-small {
+        input {
+            & + label {
+                .checkmark {
+                    height: $checkmark-small-height;
+                    width: $checkmark-small-width;
+
+                    &:after {
+                        height: $checkmark-small-after-height;
+                        left: $checkmark-small-after-left;
+                        top: $checkmark-small-after-top;
+                        width: $checkmark-small-after-width;
+                    }
+
+                    &.toggle {
+                        border-radius: $toggle-small-height;
+                        height: $toggle-small-height;
+                        width: $toggle-small-width;
+
+                        &:after {
+                            height: $toggle-small-after-height;
+                            left: $toggle-small-after-left;
+                            top: $toggle-small-after-top;
+                            width: $toggle-small-after-width;
+                        }
+                    }
+                }
+            }
+        }
+
+        input:checked {
+            & + label {
+                .checkmark {
+                    &.toggle {
+                        &:after {
+                            left: $toggle-small-after-left-checked;
+                        }
+                    }
+                }
+            }
+        }
+
+        .selector-label {
+            font-size: $text-font-size-1;
+
+            &-end {
+                margin-left: $space-xxs;
+            }
+
+            &-start {
+                margin-right: $space-xxs;
+            }
+        }
+    }
+
+    &.disabled {
+        input {
+            cursor: not-allowed;
+
+            & + label {
+                .checkmark {
+                    opacity: 50%;
+
+                    &.toggle {
+                        opacity: 50%;
+                    }
+                }
+            }
+
+            &:hover + label {
+                .checkmark {
+                    border: $space-xxxs solid var(--grey-color-70);
+
+                    &.toggle {
+                        border: $space-xxxs solid var(--grey-color-70);
+
+                        &:after {
+                            background-color: var(--grey-color-70);
+                            border-color: var(--grey-color-70);
+                        }
+                    }
+                }
+            }
+
+            &:active + label {
+                .checkmark {
+                    border: $space-xxxs solid var(--grey-color-70);
+
+                    &.toggle {
+                        border: $space-xxxs solid var(--grey-color-70);
+
+                        &:after {
+                            background-color: var(--grey-color-70);
+                            border-color: var(--grey-color-70);
+                        }
+                    }
+                }
+            }
+        }
+
+        input:checked {
+            cursor: not-allowed;
         }
     }
 }
@@ -320,11 +543,46 @@
             }
         }
     }
+
+    .selector {
+        &.disabled {
+            input {
+                &:checked {
+                    &:focus-visible + label {
+                        .checkmark {
+                            outline: none;
+
+                            &.toggle {
+                                outline: none;
+                            }
+                        }
+                    }
+                }
+
+                &:focus-visible + label {
+                    .checkmark {
+                        outline: none;
+                        border: $space-xxxs solid var(--grey-color-70);
+
+                        &.toggle {
+                            outline: none;
+                            border: $space-xxxs solid var(--grey-color-70);
+
+                            &:after {
+                                background-color: var(--primary-color-70);
+                                border-color: var(--primary-color-70);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 .checkbox-group {
     display: flex;
-    gap: $space-m;
+    gap: $space-s;
 
     &.vertical {
         flex-direction: column;
@@ -332,6 +590,18 @@
 
     &.horizontal {
         flex-direction: row;
+    }
+
+    &-large {
+        gap: $space-m;
+    }
+
+    &-medium {
+        gap: $space-s;
+    }
+
+    &-small {
+        gap: $space-xs;
     }
 }
 

--- a/src/components/Dialog/BaseDialog/base-dialog.module.scss
+++ b/src/components/Dialog/BaseDialog/base-dialog.module.scss
@@ -6,7 +6,7 @@
 
     .dialog {
         position: absolute;
-        padding: $space-l-fitted;
+        padding: $space-ml;
         background: var(--background-color);
         border-radius: $corner-radius-xl;
         box-shadow: $shadow-object-l;

--- a/src/components/Dialog/Dialog.test.tsx
+++ b/src/components/Dialog/Dialog.test.tsx
@@ -63,8 +63,8 @@ describe('Dialog', () => {
             onCancel,
             onClose,
         });
-        wrapper.find('.button-primary').at(0).simulate('click');
-        wrapper.find('.button-default').at(0).simulate('click');
+        wrapper.find('.actions .button-primary').at(0).simulate('click');
+        wrapper.find('.actions .button-neutral').at(0).simulate('click');
         wrapper.find('.button-neutral').at(0).simulate('click');
         wrapper.find('.dialog-backdrop').at(0).simulate('click');
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,7 +1,7 @@
 import React, { FC, Ref } from 'react';
 import { DialogProps, DialogSize } from './Dialog.types';
 import { mergeClasses } from '../../shared/utilities';
-import { DefaultButton, PrimaryButton } from '../Button';
+import { NeutralButton, PrimaryButton } from '../Button';
 import { BaseDialog } from './BaseDialog/BaseDialog';
 
 import styles from './dialog.module.scss';
@@ -63,7 +63,7 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
                 actions={
                     <>
                         {cancelButtonProps && (
-                            <DefaultButton
+                            <NeutralButton
                                 {...cancelButtonProps}
                                 onClick={onCancel}
                             />

--- a/src/components/Dialog/dialog.module.scss
+++ b/src/components/Dialog/dialog.module.scss
@@ -23,7 +23,7 @@
     }
 
     .body {
-        padding-bottom: $space-l-fitted;
+        padding-bottom: $space-ml;
         font-size: $text-font-size-3;
         font-weight: $text-font-weight-regular;
         line-height: $text-line-height-3;

--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -60,13 +60,19 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
             >
                 <Icon path={getIconName()} classNames={styles.icon} />
                 <div className={messageClasses}>{content}</div>
-                {actionButtonProps && <NeutralButton {...actionButtonProps} />}
+                {actionButtonProps && (
+                    <NeutralButton
+                        {...actionButtonProps}
+                        disruptive={type === InfoBarType.disruptive}
+                    />
+                )}
                 {closable && (
                     <NeutralButton
                         iconProps={{ path: closeIcon }}
                         ariaLabel={'Close'}
                         onClick={onClose}
                         {...closeButtonProps}
+                        disruptive={type === InfoBarType.disruptive}
                     />
                 )}
             </div>

--- a/src/components/InfoBar/infoBar.module.scss
+++ b/src/components/InfoBar/infoBar.module.scss
@@ -3,7 +3,7 @@
     --bg-color: var(--grey-color-70);
     display: flex;
     border-radius: $corner-radius-xl;
-    padding: $space-l-fitted;
+    padding: $space-ml;
     width: 100%;
     color: var(--info-color);
     background-color: var(--bg-color);

--- a/src/components/InfoBar/infoBar.module.scss
+++ b/src/components/InfoBar/infoBar.module.scss
@@ -3,7 +3,7 @@
     --bg-color: var(--grey-color-70);
     display: flex;
     border-radius: $corner-radius-xl;
-    padding: $space-m;
+    padding: $space-l-fitted;
     width: 100%;
     color: var(--info-color);
     background-color: var(--bg-color);

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -173,12 +173,12 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
                     <textarea
                         {...rest}
                         ref={ref}
-                        aria-disabled={allowDisabledFocus}
+                        aria-disabled={disabled}
                         aria-label={ariaLabel}
                         autoFocus={autoFocus}
                         className={textAreaClassNames}
                         cols={textAreaCols}
-                        disabled={disabled}
+                        disabled={!allowDisabledFocus && disabled}
                         id={textAreaId}
                         maxLength={maxlength}
                         minLength={minlength}

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -328,10 +328,11 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
                     <input
                         {...rest}
                         ref={ref}
+                        aria-disabled={disabled}
                         aria-label={ariaLabel}
                         autoFocus={autoFocus}
                         className={textInputClassNames}
-                        disabled={disabled}
+                        disabled={!allowDisabledFocus && disabled}
                         id={inputId}
                         maxLength={maxlength}
                         minLength={minlength}

--- a/src/components/Modal/modal.module.scss
+++ b/src/components/Modal/modal.module.scss
@@ -47,7 +47,7 @@
     .header {
         display: flex;
         flex-direction: row;
-        margin-bottom: $space-l-fitted;
+        margin-bottom: $space-ml;
     }
 
     .body {

--- a/src/components/Navbar/navbar.module.scss
+++ b/src/components/Navbar/navbar.module.scss
@@ -6,7 +6,7 @@
     flex-direction: row;
     height: 60px;
     justify-content: space-between;
-    padding: 0 $space-l-fitted;
+    padding: 0 $space-ml;
     width: 100%;
 
     .navbar-content {

--- a/src/components/RadioButton/Radio.types.ts
+++ b/src/components/RadioButton/Radio.types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { OcBaseProps } from '../OcBase';
-import { LabelPosition } from '../CheckBox';
+import { LabelPosition, SelectorSize } from '../CheckBox';
 
 export type RadioButtonValue = string | number;
 
@@ -16,6 +16,10 @@ export interface IRadioButtonsContext {
 }
 
 export interface RadioButtonProps extends OcBaseProps<HTMLInputElement> {
+    /**
+     * Allows focus on the radio button when it's disabled.
+     */
+    allowDisabledFocus?: boolean;
     /**
      * The input aria label text.
      */
@@ -49,17 +53,26 @@ export interface RadioButtonProps extends OcBaseProps<HTMLInputElement> {
      * The radio button onChange event handler.
      */
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    /**
+     * The radio button size.
+     * @default SelectorSize.Medium
+     */
+    size?: SelectorSize;
 }
 
 export interface RadioGroupProps extends OcBaseProps<HTMLDivElement> {
+    /**
+     * Allows focus on the radio group when it's disabled.
+     */
+    allowDisabledFocus?: boolean;
     /**
      * The group aria label text.
      */
     ariaLabel?: string;
     /**
-     * The input radio default selected value.
+     * The boolean for disabling the radio group.
      */
-    value?: RadioButtonValue;
+    disabled?: boolean;
     /**
      * The array of items for the radio group.
      */
@@ -78,4 +91,13 @@ export interface RadioGroupProps extends OcBaseProps<HTMLDivElement> {
      * The radio button onChange event handler.
      */
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
+    /**
+     * The radio group size.
+     * @default SelectorSize.Medium
+     */
+    size?: SelectorSize;
+    /**
+     * The input radio default selected value.
+     */
+    value?: RadioButtonValue;
 }

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { RadioButton, RadioButtonValue, RadioGroup } from './';
-import { LabelPosition } from '../CheckBox';
+import { LabelPosition, SelectorSize } from '../CheckBox';
 import { Stack } from '../Stack';
 
 export default {
@@ -109,6 +109,15 @@ export default {
             options: ['vertical', 'horizontal'],
             control: { type: 'inline-radio' },
         },
+        size: {
+            options: [
+                SelectorSize.Flex,
+                SelectorSize.Large,
+                SelectorSize.Medium,
+                SelectorSize.Small,
+            ],
+            control: { type: 'radio' },
+        },
     },
 } as ComponentMeta<typeof RadioButton>;
 
@@ -203,6 +212,7 @@ const radioButtonArgs: Object = {
     name: 'myRadioButtonName',
     value: 'Label1',
     id: 'myRadioButtonId',
+    size: SelectorSize.Medium,
 };
 
 Radio_Button.args = {
@@ -210,7 +220,9 @@ Radio_Button.args = {
 };
 
 Radio_Group.args = {
+    allowDisabledFocus: false,
     ariaLabel: 'Radio Group',
+    disabled: false,
     value: 'Radio1',
     items: [1, 2, 3].map((i) => ({
         value: `Radio${i}`,
@@ -219,6 +231,7 @@ Radio_Group.args = {
         id: `oea2exk-${i}`,
     })),
     layout: 'vertical',
+    size: SelectorSize.Medium,
 };
 
 Bespoke_Radio_Group.args = {

--- a/src/components/RadioButton/RadioButton.test.tsx
+++ b/src/components/RadioButton/RadioButton.test.tsx
@@ -1,18 +1,53 @@
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
 import { RadioButton } from './';
+import { SelectorSize } from '../CheckBox';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+let matchMedia: any;
+
 describe('RadioButton', () => {
-    /*
-     * Functionality Tests
-     */
-    test('Radio button renders', () => {
+    beforeAll(() => {
+        matchMedia = new MatchMediaMock();
+    });
+
+    afterEach(() => {
+        matchMedia.clear();
+    });
+
+    it('Radio button renders', () => {
         const wrapper = mount(<RadioButton checked={true} />);
         expect(
             wrapper.containsMatchingElement(<RadioButton checked={true} />)
         ).toEqual(true);
+    });
+
+    it('simulate disabled RadioButton', () => {
+        const wrapper = mount(<RadioButton disabled label="test label" />);
+        wrapper.find('input').html().includes('disabled=""');
+    });
+
+    it('RadioButton is large', () => {
+        const wrapper = mount(
+            <RadioButton size={SelectorSize.Large} label="test label" />
+        );
+        expect(wrapper.find('.selector-large')).toBeTruthy();
+    });
+
+    it('RadioButton is medium', () => {
+        const wrapper = mount(
+            <RadioButton size={SelectorSize.Medium} label="test label" />
+        );
+        expect(wrapper.find('.selector-medium')).toBeTruthy();
+    });
+
+    it('RadioButton is small', () => {
+        const wrapper = mount(
+            <RadioButton size={SelectorSize.Small} label="test label" />
+        );
+        expect(wrapper.find('.selector-small')).toBeTruthy();
     });
 });

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -110,14 +110,14 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
             >
                 <input
                     ref={ref}
-                    aria-disabled={allowDisabledFocus}
+                    aria-disabled={disabled}
                     aria-label={ariaLabel}
                     checked={
                         radioGroupContext
                             ? isActive
                             : selectedValue === value && checked
                     }
-                    disabled={disabled}
+                    disabled={!allowDisabledFocus && disabled}
                     id={radioButtonId.current}
                     name={name}
                     type={'radio'}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,14 +1,16 @@
 import React, { FC, Ref, useEffect, useRef, useState } from 'react';
 import { RadioButtonProps, RadioButtonValue } from './';
-import { LabelPosition } from '../CheckBox';
+import { LabelPosition, SelectorSize } from '../CheckBox';
 import { mergeClasses, generateId } from '../../shared/utilities';
 import { useRadioGroup } from './RadioGroup.context';
+import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
 
 import styles from './radio.module.scss';
 
 export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
     (
         {
+            allowDisabledFocus = false,
             ariaLabel,
             checked = false,
             classNames,
@@ -18,12 +20,18 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
             label,
             labelPosition = LabelPosition.End,
             onChange,
+            size = SelectorSize.Medium,
             style,
             value = '',
             'data-test-id': dataTestId,
         },
         ref: Ref<HTMLInputElement>
     ) => {
+        const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
+        const mediumScreenActive: boolean = useMatchMedia(Breakpoints.Medium);
+        const smallScreenActive: boolean = useMatchMedia(Breakpoints.Small);
+        const xSmallScreenActive: boolean = useMatchMedia(Breakpoints.XSmall);
+
         const radioButtonId = useRef<string>(id || generateId());
         const radioGroupContext = useRadioGroup();
         const [isActive, setIsActive] = useState<boolean>(
@@ -38,7 +46,27 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
 
         const selectorClassNames: string = mergeClasses([
             styles.selector,
+            {
+                [styles.selectorSmall]:
+                    size === SelectorSize.Flex && largeScreenActive,
+            },
+            {
+                [styles.selectorMedium]:
+                    size === SelectorSize.Flex && mediumScreenActive,
+            },
+            {
+                [styles.selectorMedium]:
+                    size === SelectorSize.Flex && smallScreenActive,
+            },
+            {
+                [styles.selectorLarge]:
+                    size === SelectorSize.Flex && xSmallScreenActive,
+            },
+            { [styles.selectorLarge]: size === SelectorSize.Large },
+            { [styles.selectorMedium]: size === SelectorSize.Medium },
+            { [styles.selectorSmall]: size === SelectorSize.Small },
             classNames,
+            { [styles.disabled]: allowDisabledFocus || disabled },
         ]);
 
         const labelClassNames: string = mergeClasses([
@@ -49,7 +77,8 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
             styles.selectorLabel,
             {
                 [styles.selectorLabelEnd]: labelPosition === LabelPosition.End,
-                [styles.selectorLabelStart]: labelPosition === LabelPosition.Start,
+                [styles.selectorLabelStart]:
+                    labelPosition === LabelPosition.Start,
             },
         ]);
 
@@ -65,7 +94,7 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
             e: React.ChangeEvent<HTMLInputElement>
         ): void => {
             if (!radioGroupContext) {
-                setSelectedValue(e.currentTarget.value as RadioButtonValue);
+                setSelectedValue(e.currentTarget?.value as RadioButtonValue);
             } else {
                 radioGroupContext?.onChange?.(e);
             }
@@ -81,6 +110,7 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
             >
                 <input
                     ref={ref}
+                    aria-disabled={allowDisabledFocus}
                     aria-label={ariaLabel}
                     checked={
                         radioGroupContext
@@ -92,7 +122,7 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
                     name={name}
                     type={'radio'}
                     value={value}
-                    onChange={toggleChecked}
+                    onChange={!allowDisabledFocus ? toggleChecked : null}
                     readOnly
                 />
                 <label

--- a/src/components/RadioButton/RadioGroup.tsx
+++ b/src/components/RadioButton/RadioGroup.tsx
@@ -1,30 +1,58 @@
 import React, { FC, Ref } from 'react';
 import { RadioButtonProps, RadioGroupProps, RadioButton } from './';
-import { LabelPosition } from '../CheckBox';
+import { LabelPosition, SelectorSize } from '../CheckBox';
 import { RadioGroupProvider } from './RadioGroup.context';
 import { mergeClasses } from '../../shared/utilities';
+import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
 
 import styles from './radio.module.scss';
 
 export const RadioGroup: FC<RadioGroupProps> = React.forwardRef(
     (
         {
+            allowDisabledFocus = false,
             ariaLabel,
             classNames,
+            disabled = false,
             items,
             labelPosition = LabelPosition.End,
             layout = 'vertical',
             onChange,
+            size = SelectorSize.Medium,
             style,
             value,
             ...rest
         },
         ref: Ref<HTMLDivElement>
     ) => {
+        const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
+        const mediumScreenActive: boolean = useMatchMedia(Breakpoints.Medium);
+        const smallScreenActive: boolean = useMatchMedia(Breakpoints.Small);
+        const xSmallScreenActive: boolean = useMatchMedia(Breakpoints.XSmall);
+
         const radioGroupClasses: string = mergeClasses([
             styles.radioGroup,
             { [styles.vertical]: layout === 'vertical' },
             { [styles.horizontal]: layout === 'horizontal' },
+            {
+                [styles.radioGroupSmall]:
+                    size === SelectorSize.Flex && largeScreenActive,
+            },
+            {
+                [styles.radioGroupMedium]:
+                    size === SelectorSize.Flex && mediumScreenActive,
+            },
+            {
+                [styles.radioGroupMedium]:
+                    size === SelectorSize.Flex && smallScreenActive,
+            },
+            {
+                [styles.radioGroupLarge]:
+                    size === SelectorSize.Flex && xSmallScreenActive,
+            },
+            { [styles.radioGroupLarge]: size === SelectorSize.Large },
+            { [styles.radioGroupMedium]: size === SelectorSize.Medium },
+            { [styles.radioGroupSmall]: size === SelectorSize.Small },
             classNames,
         ]);
 
@@ -41,8 +69,11 @@ export const RadioGroup: FC<RadioGroupProps> = React.forwardRef(
                     {items.map((item: RadioButtonProps) => (
                         <RadioButton
                             key={item.value}
-                            labelPosition={labelPosition}
+                            allowDisabledFocus={allowDisabledFocus}
+                            disabled={disabled}
                             {...item}
+                            labelPosition={labelPosition}
+                            size={size}
                         />
                     ))}
                 </div>

--- a/src/components/RadioButton/radio.module.scss
+++ b/src/components/RadioButton/radio.module.scss
@@ -19,18 +19,6 @@
                     opacity: 50%;
                 }
             }
-
-            &:hover + label {
-                .radio-button {
-                    border: $space-xxxs solid var(--grey-color-70);
-                }
-            }
-
-            &:active + label {
-                .radio-button {
-                    border: $space-xxxs solid var(--grey-color-70);
-                }
-            }
         }
 
         & + label {
@@ -65,14 +53,14 @@
             }
         }
 
-        &:hover + label {
+        &:not(.disabled):not([disabled]):hover + label {
             .radio-button {
                 background-color: var(--accent-color-20);
                 border: $space-xxxs solid var(--primary-color-70);
             }
         }
 
-        &:active + label {
+        &:not(.disabled):not([disabled]):active + label {
             .radio-button {
                 background-color: var(--accent-color-30);
                 border: $space-xxxs solid var(--primary-color-70);
@@ -105,14 +93,14 @@
             }
         }
 
-        &:hover + label {
+        &:not(.disabled):not([disabled]):hover + label {
             .radio-button {
                 background-color: var(--accent-color-20);
                 border: $space-xxxs solid var(--primary-color-70);
             }
         }
 
-        &:active + label {
+        &:not(.disabled):not([disabled]):active + label {
             .radio-button {
                 transform: scale(0.98);
                 background-color: var(--accent-color-10);
@@ -261,18 +249,6 @@
             & + label {
                 .radio-button {
                     opacity: 50%;
-                }
-            }
-
-            &:hover + label {
-                .radio-button {
-                    border: $space-xxxs solid var(--grey-color-70);
-                }
-            }
-
-            &:active + label {
-                .radio-button {
-                    border: $space-xxxs solid var(--grey-color-70);
                 }
             }
         }

--- a/src/components/RadioButton/radio.module.scss
+++ b/src/components/RadioButton/radio.module.scss
@@ -12,7 +12,7 @@
         z-index: 1;
 
         &[disabled] {
-            cursor: default;
+            cursor: not-allowed;
 
             & + label {
                 .radio-button {
@@ -36,27 +36,31 @@
         & + label {
             .radio-button {
                 position: relative;
-                height: $radio-height;
-                width: $radio-width;
+                height: $radio-medium-height;
+                width: $radio-medium-width;
                 border-radius: 50%;
                 border: $space-xxxs solid var(--grey-color-70);
                 transition: all $motion-duration-extra-fast $motion-ease-in-back
                     $motion-delay-s;
 
                 &:after {
-                    top: $radio-after-top;
-                    left: $radio-after-left;
-                    width: $radio-after-width;
-                    height: $radio-after-height;
+                    top: $radio-medium-after-top;
+                    left: $radio-medium-after-left;
+                    width: $radio-medium-after-width;
+                    height: $radio-medium-after-height;
+                    background-color: var(--primary-color-70);
                     border-radius: 50%;
-                    border: solid 2px var(--primary-color);
+                    border: solid 1px var(--primary-color-70);
                     content: '';
                     position: absolute;
                     transform: scale(0);
                     opacity: 0;
                     display: block;
-                    transition: all $motion-duration-extra-fast
-                        $motion-ease-in-back $motion-delay-s;
+                    transition-delay: $motion-delay-s;
+                    transition-duration: $motion-duration-extra-fast;
+                    transition-property: opacity;
+                    transition-property: transform;
+                    transition-timing-function: $motion-ease-in-back;
                 }
             }
         }
@@ -64,21 +68,21 @@
         &:hover + label {
             .radio-button {
                 background-color: var(--accent-color-20);
-                border: $space-xxxs solid var(--primary-color);
+                border: $space-xxxs solid var(--primary-color-70);
             }
         }
 
         &:active + label {
             .radio-button {
                 background-color: var(--accent-color-30);
-                border: $space-xxxs solid var(--primary-color);
+                border: $space-xxxs solid var(--primary-color-70);
             }
         }
     }
 
     input:checked {
         &[disabled] {
-            cursor: default;
+            cursor: not-allowed;
         }
 
         & + label {
@@ -87,21 +91,24 @@
 
             .radio-button {
                 background-color: var(--accent-color-30);
-                border: $space-xxxs solid var(--primary-color);
+                border: $space-xxxs solid var(--primary-color-70);
             }
 
             .radio-button:after {
                 opacity: 1;
-                transform: scale(1);
-                transition: all $motion-duration-extra-fast
-                    $motion-ease-out-back $motion-delay-s;
+                transform: scale(0.8);
+                transition-delay: $motion-delay-s;
+                transition-duration: $motion-duration-extra-fast;
+                transition-property: opacity;
+                transition-property: transform;
+                transition-timing-function: $motion-ease-out-back;
             }
         }
 
         &:hover + label {
             .radio-button {
                 background-color: var(--accent-color-20);
-                border: $space-xxxs solid var(--primary-color);
+                border: $space-xxxs solid var(--primary-color-70);
             }
         }
 
@@ -109,7 +116,7 @@
             .radio-button {
                 transform: scale(0.98);
                 background-color: var(--accent-color-10);
-                border: $space-xxxs solid var(--primary-color);
+                border: $space-xxxs solid var(--primary-color-70);
             }
         }
     }
@@ -122,14 +129,156 @@
     }
 
     .selector-label {
-        font-size: $text-font-weight-regular;
+        font-size: $text-font-size-2;
 
         &-end {
-            margin-left: $space-xs;
+            margin-left: $space-xxs;
         }
 
         &-start {
-            margin-right: $space-xs;
+            margin-right: $space-xxs;
+        }
+    }
+
+    &-large {
+        input {
+            & + label {
+                .radio-button {
+                    height: $radio-large-height;
+                    width: $radio-large-width;
+
+                    &:after {
+                        top: $radio-large-after-top;
+                        left: $radio-large-after-left;
+                        width: $radio-large-after-width;
+                        height: $radio-large-after-height;
+                    }
+                }
+            }
+        }
+
+        input:checked {
+            & + label {
+                .radio-button:after {
+                    transform: scale(0.8);
+                }
+            }
+        }
+
+        .selector-label {
+            font-size: $text-font-size-3;
+
+            &-end {
+                margin-left: $space-xs;
+            }
+
+            &-start {
+                margin-right: $space-xs;
+            }
+        }
+    }
+
+    &-medium {
+        input {
+            & + label {
+                .radio-button {
+                    height: $radio-medium-height;
+                    width: $radio-medium-width;
+
+                    &:after {
+                        top: $radio-medium-after-top;
+                        left: $radio-medium-after-left;
+                        width: $radio-medium-after-width;
+                        height: $radio-medium-after-height;
+                    }
+                }
+            }
+        }
+
+        input:checked {
+            & + label {
+                .radio-button:after {
+                    transform: scale(0.8);
+                }
+            }
+        }
+
+        .selector-label {
+            font-size: $text-font-size-2;
+
+            &-end {
+                margin-left: $space-xxs;
+            }
+
+            &-start {
+                margin-right: $space-xxs;
+            }
+        }
+    }
+
+    &-small {
+        input {
+            & + label {
+                .radio-button {
+                    height: $radio-small-height;
+                    width: $radio-small-width;
+
+                    &:after {
+                        top: $radio-small-after-top;
+                        left: $radio-small-after-left;
+                        width: $radio-small-after-width;
+                        height: $radio-small-after-height;
+                    }
+                }
+            }
+        }
+
+        input:checked {
+            & + label {
+                .radio-button:after {
+                    transform: scale(0.8);
+                }
+            }
+        }
+
+        .selector-label {
+            font-size: $text-font-size-1;
+
+            &-end {
+                margin-left: $space-xxs;
+            }
+
+            &-start {
+                margin-right: $space-xxs;
+            }
+        }
+    }
+
+    &.disabled {
+        input {
+            cursor: not-allowed;
+
+            & + label {
+                .radio-button {
+                    opacity: 50%;
+                }
+            }
+
+            &:hover + label {
+                .radio-button {
+                    border: $space-xxxs solid var(--grey-color-70);
+                }
+            }
+
+            &:active + label {
+                .radio-button {
+                    border: $space-xxxs solid var(--grey-color-70);
+                }
+            }
+        }
+
+        input:checked {
+            cursor: not-allowed;
         }
     }
 }
@@ -147,7 +296,7 @@
         &:focus-visible + label {
             .radio-button {
                 outline: $space-xxxs solid var(--primary-color-50);
-                border: $space-xxxs solid var(--primary-color);
+                border: $space-xxxs solid var(--primary-color-70);
             }
         }
 
@@ -168,11 +317,32 @@
             }
         }
     }
+
+    .selector {
+        &.disabled {
+            input {
+                &:checked {
+                    &:focus-visible + label {
+                        .radio-button {
+                            outline: none;
+                        }
+                    }
+                }
+
+                &:focus-visible + label {
+                    .radio-button {
+                        outline: none;
+                        border: $space-xxxs solid var(--grey-color-70);
+                    }
+                }
+            }
+        }
+    }
 }
 
 .radio-group {
     display: flex;
-    gap: $space-m;
+    gap: $space-s;
 
     &.vertical {
         flex-direction: column;
@@ -180,6 +350,18 @@
 
     &.horizontal {
         flex-direction: row;
+    }
+
+    &-large {
+        gap: $space-m;
+    }
+
+    &-medium {
+        gap: $space-s;
+    }
+
+    &-small {
+        gap: $space-xs;
     }
 }
 

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionexpandonleft.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionexpandonleft.shot
@@ -73,11 +73,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -182,12 +183,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -277,6 +280,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -290,12 +294,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -411,11 +417,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -520,12 +527,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -615,6 +624,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -628,12 +638,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -922,11 +934,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -1031,12 +1044,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -1126,6 +1141,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1139,12 +1155,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1241,11 +1259,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1350,12 +1369,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1445,6 +1466,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1458,12 +1480,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -1535,11 +1559,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1644,12 +1669,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1739,6 +1766,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1752,12 +1780,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -1854,11 +1884,12 @@ LoadedCheerio {
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
-                                                "class": "selector selection-checkbox",
+                                                "class": "selector selector-medium selection-checkbox",
                                               },
                                               "children": Array [
                                                 Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1963,12 +1994,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -2058,6 +2091,7 @@ LoadedCheerio {
                                                   "parent": [Circular],
                                                   "prev": Node {
                                                     "attribs": Object {
+                                                      "aria-disabled": "false",
                                                       "id": "selectCheckBox",
                                                       "readonly": "",
                                                       "type": "checkbox",
@@ -2071,12 +2105,14 @@ LoadedCheerio {
                                                     "prev": null,
                                                     "type": "tag",
                                                     "x-attribsNamespace": Object {
+                                                      "aria-disabled": undefined,
                                                       "id": undefined,
                                                       "readonly": undefined,
                                                       "type": undefined,
                                                       "value": undefined,
                                                     },
                                                     "x-attribsPrefix": Object {
+                                                      "aria-disabled": undefined,
                                                       "id": undefined,
                                                       "readonly": undefined,
                                                       "type": undefined,
@@ -2187,11 +2223,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -2296,12 +2333,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -2391,6 +2430,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2404,12 +2444,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2506,11 +2548,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2615,12 +2658,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2710,6 +2755,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -2723,12 +2769,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -2800,11 +2848,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2909,12 +2958,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3004,6 +3055,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -3017,12 +3069,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3119,11 +3173,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -3228,12 +3283,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3323,6 +3380,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -3336,12 +3394,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -3640,11 +3700,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -3749,12 +3810,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -3844,6 +3907,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -3857,12 +3921,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3959,11 +4025,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4068,12 +4135,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4163,6 +4232,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4176,12 +4246,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4255,11 +4327,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4364,12 +4437,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4459,6 +4534,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4472,12 +4548,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4574,11 +4652,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4683,12 +4762,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4778,6 +4859,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -4791,12 +4873,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -5130,11 +5214,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -5239,12 +5324,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -5334,6 +5421,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5347,12 +5435,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5468,11 +5558,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5577,12 +5668,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5672,6 +5765,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -5685,12 +5779,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -5979,11 +6075,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -6088,12 +6185,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -6183,6 +6282,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6196,12 +6296,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6298,11 +6400,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6407,12 +6510,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6502,6 +6607,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -6515,12 +6621,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6592,11 +6700,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6701,12 +6810,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6796,6 +6907,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -6809,12 +6921,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6911,11 +7025,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -7020,12 +7135,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -7115,6 +7232,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -7128,12 +7246,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -7244,11 +7364,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -7353,12 +7474,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -7448,6 +7571,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7461,12 +7585,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7563,11 +7689,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7672,12 +7799,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7767,6 +7896,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -7780,12 +7910,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -7857,11 +7989,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7966,12 +8099,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -8061,6 +8196,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -8074,12 +8210,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -8176,11 +8314,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -8285,12 +8424,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -8380,6 +8521,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -8393,12 +8535,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -8697,11 +8841,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -8806,12 +8951,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -8901,6 +9048,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -8914,12 +9062,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9016,11 +9166,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -9125,12 +9276,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9220,6 +9373,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9233,12 +9387,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9312,11 +9468,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -9421,12 +9578,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9516,6 +9675,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9529,12 +9689,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9631,11 +9793,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9740,12 +9903,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9835,6 +10000,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -9848,12 +10014,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -10397,11 +10565,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -10506,12 +10675,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -10601,6 +10772,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -10614,12 +10786,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -10716,11 +10890,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -10825,12 +11000,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -10920,6 +11097,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -10933,12 +11111,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11010,11 +11190,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -11119,12 +11300,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -11214,6 +11397,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -11227,12 +11411,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11329,11 +11515,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -11438,12 +11625,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11533,6 +11722,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -11546,12 +11736,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -11662,11 +11854,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -11771,12 +11964,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -11866,6 +12061,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -11879,12 +12075,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -11981,11 +12179,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -12090,12 +12289,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -12185,6 +12386,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12198,12 +12400,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12275,11 +12479,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -12384,12 +12589,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -12479,6 +12686,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12492,12 +12700,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12594,11 +12804,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12703,12 +12914,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12798,6 +13011,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -12811,12 +13025,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -13115,11 +13331,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -13224,12 +13441,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -13319,6 +13538,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13332,12 +13552,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13434,11 +13656,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13543,12 +13766,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13638,6 +13863,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -13651,12 +13877,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -13730,11 +13958,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13839,12 +14068,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13934,6 +14165,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -13947,12 +14179,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -14049,11 +14283,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -14158,12 +14393,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -14253,6 +14490,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -14266,12 +14504,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -14580,11 +14820,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -14689,12 +14930,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -14784,6 +15027,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -14797,12 +15041,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -14918,11 +15164,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -15027,12 +15274,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -15122,6 +15371,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -15135,12 +15385,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionleft.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionleft.shot
@@ -73,11 +73,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -182,12 +183,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -277,6 +280,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -290,12 +294,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -411,11 +417,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -520,12 +527,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -615,6 +624,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -628,12 +638,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -922,11 +934,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -1031,12 +1044,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -1126,6 +1141,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1139,12 +1155,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1241,11 +1259,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1350,12 +1369,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1445,6 +1466,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1458,12 +1480,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -1535,11 +1559,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1644,12 +1669,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1739,6 +1766,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1752,12 +1780,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -1854,11 +1884,12 @@ LoadedCheerio {
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
-                                                "class": "selector selection-checkbox",
+                                                "class": "selector selector-medium selection-checkbox",
                                               },
                                               "children": Array [
                                                 Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1963,12 +1994,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -2058,6 +2091,7 @@ LoadedCheerio {
                                                   "parent": [Circular],
                                                   "prev": Node {
                                                     "attribs": Object {
+                                                      "aria-disabled": "false",
                                                       "id": "selectCheckBox",
                                                       "readonly": "",
                                                       "type": "checkbox",
@@ -2071,12 +2105,14 @@ LoadedCheerio {
                                                     "prev": null,
                                                     "type": "tag",
                                                     "x-attribsNamespace": Object {
+                                                      "aria-disabled": undefined,
                                                       "id": undefined,
                                                       "readonly": undefined,
                                                       "type": undefined,
                                                       "value": undefined,
                                                     },
                                                     "x-attribsPrefix": Object {
+                                                      "aria-disabled": undefined,
                                                       "id": undefined,
                                                       "readonly": undefined,
                                                       "type": undefined,
@@ -2187,11 +2223,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -2296,12 +2333,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -2391,6 +2430,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2404,12 +2444,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2506,11 +2548,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2615,12 +2658,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2710,6 +2755,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -2723,12 +2769,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -2800,11 +2848,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2909,12 +2958,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3004,6 +3055,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -3017,12 +3069,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3119,11 +3173,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -3228,12 +3283,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3323,6 +3380,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -3336,12 +3394,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -3640,11 +3700,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -3749,12 +3810,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -3844,6 +3907,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -3857,12 +3921,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3959,11 +4025,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4068,12 +4135,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4163,6 +4232,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4176,12 +4246,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4255,11 +4327,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4364,12 +4437,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4459,6 +4534,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4472,12 +4548,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4574,11 +4652,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4683,12 +4762,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4778,6 +4859,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -4791,12 +4873,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -5130,11 +5214,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -5239,12 +5324,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -5334,6 +5421,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5347,12 +5435,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5468,11 +5558,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5577,12 +5668,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5672,6 +5765,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -5685,12 +5779,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -5979,11 +6075,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -6088,12 +6185,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -6183,6 +6282,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6196,12 +6296,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6298,11 +6400,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6407,12 +6510,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6502,6 +6607,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -6515,12 +6621,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6592,11 +6700,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6701,12 +6810,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6796,6 +6907,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -6809,12 +6921,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6911,11 +7025,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -7020,12 +7135,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -7115,6 +7232,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -7128,12 +7246,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -7244,11 +7364,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -7353,12 +7474,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -7448,6 +7571,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7461,12 +7585,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7563,11 +7689,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7672,12 +7799,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7767,6 +7896,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -7780,12 +7910,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -7857,11 +7989,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7966,12 +8099,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -8061,6 +8196,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -8074,12 +8210,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -8176,11 +8314,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -8285,12 +8424,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -8380,6 +8521,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -8393,12 +8535,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -8697,11 +8841,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -8806,12 +8951,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -8901,6 +9048,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -8914,12 +9062,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9016,11 +9166,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -9125,12 +9276,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9220,6 +9373,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9233,12 +9387,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9312,11 +9468,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -9421,12 +9578,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9516,6 +9675,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9529,12 +9689,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9631,11 +9793,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9740,12 +9903,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9835,6 +10000,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -9848,12 +10014,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -10397,11 +10565,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -10506,12 +10675,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -10601,6 +10772,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -10614,12 +10786,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -10716,11 +10890,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -10825,12 +11000,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -10920,6 +11097,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -10933,12 +11111,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11010,11 +11190,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -11119,12 +11300,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -11214,6 +11397,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -11227,12 +11411,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11329,11 +11515,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -11438,12 +11625,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11533,6 +11722,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -11546,12 +11736,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -11662,11 +11854,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -11771,12 +11964,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -11866,6 +12061,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -11879,12 +12075,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -11981,11 +12179,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -12090,12 +12289,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -12185,6 +12386,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12198,12 +12400,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12275,11 +12479,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -12384,12 +12589,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -12479,6 +12686,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12492,12 +12700,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12594,11 +12804,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12703,12 +12914,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12798,6 +13011,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -12811,12 +13025,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -13115,11 +13331,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -13224,12 +13441,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -13319,6 +13538,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13332,12 +13552,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13434,11 +13656,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13543,12 +13766,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13638,6 +13863,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -13651,12 +13877,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -13730,11 +13958,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13839,12 +14068,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13934,6 +14165,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -13947,12 +14179,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -14049,11 +14283,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -14158,12 +14393,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -14253,6 +14490,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -14266,12 +14504,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -14580,11 +14820,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -14689,12 +14930,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -14784,6 +15027,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -14797,12 +15041,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -14918,11 +15164,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -15027,12 +15274,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -15122,6 +15371,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -15135,12 +15385,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionwithcols.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionwithcols.shot
@@ -73,11 +73,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -182,12 +183,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -277,6 +280,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -290,12 +294,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -415,11 +421,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -524,12 +531,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -619,6 +628,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -632,12 +642,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -928,11 +940,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -1037,12 +1050,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -1132,6 +1147,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1145,12 +1161,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1251,11 +1269,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1360,12 +1379,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1455,6 +1476,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1468,12 +1490,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -1547,11 +1571,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1656,12 +1681,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1751,6 +1778,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1764,12 +1792,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -1870,11 +1900,12 @@ LoadedCheerio {
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
-                                                "class": "selector selection-checkbox",
+                                                "class": "selector selector-medium selection-checkbox",
                                               },
                                               "children": Array [
                                                 Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1979,12 +2010,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -2074,6 +2107,7 @@ LoadedCheerio {
                                                   "parent": [Circular],
                                                   "prev": Node {
                                                     "attribs": Object {
+                                                      "aria-disabled": "false",
                                                       "id": "selectCheckBox",
                                                       "readonly": "",
                                                       "type": "checkbox",
@@ -2087,12 +2121,14 @@ LoadedCheerio {
                                                     "prev": null,
                                                     "type": "tag",
                                                     "x-attribsNamespace": Object {
+                                                      "aria-disabled": undefined,
                                                       "id": undefined,
                                                       "readonly": undefined,
                                                       "type": undefined,
                                                       "value": undefined,
                                                     },
                                                     "x-attribsPrefix": Object {
+                                                      "aria-disabled": undefined,
                                                       "id": undefined,
                                                       "readonly": undefined,
                                                       "type": undefined,
@@ -2205,11 +2241,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -2314,12 +2351,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -2409,6 +2448,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2422,12 +2462,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2528,11 +2570,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2637,12 +2680,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2732,6 +2777,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -2745,12 +2791,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -2824,11 +2872,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2933,12 +2982,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3028,6 +3079,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -3041,12 +3093,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3147,11 +3201,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -3256,12 +3311,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3351,6 +3408,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -3364,12 +3422,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -3670,11 +3730,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -3779,12 +3840,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -3874,6 +3937,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -3887,12 +3951,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3993,11 +4059,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4102,12 +4169,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4197,6 +4266,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4210,12 +4280,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4291,11 +4363,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4400,12 +4473,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4495,6 +4570,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4508,12 +4584,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4614,11 +4692,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -4723,12 +4802,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -4818,6 +4899,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -4831,12 +4913,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -5172,11 +5256,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -5281,12 +5366,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -5376,6 +5463,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5389,12 +5477,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5514,11 +5604,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5623,12 +5714,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5718,6 +5811,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -5731,12 +5825,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6027,11 +6123,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -6136,12 +6233,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -6231,6 +6330,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6244,12 +6344,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6350,11 +6452,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6459,12 +6562,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6554,6 +6659,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -6567,12 +6673,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6646,11 +6754,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6755,12 +6864,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6850,6 +6961,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -6863,12 +6975,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6969,11 +7083,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -7078,12 +7193,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -7173,6 +7290,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -7186,12 +7304,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -7304,11 +7424,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -7413,12 +7534,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -7508,6 +7631,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7521,12 +7645,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7627,11 +7753,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7736,12 +7863,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7831,6 +7960,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -7844,12 +7974,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -7923,11 +8055,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -8032,12 +8165,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -8127,6 +8262,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -8140,12 +8276,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -8246,11 +8384,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -8355,12 +8494,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -8450,6 +8591,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -8463,12 +8605,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -8769,11 +8913,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -8878,12 +9023,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -8973,6 +9120,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -8986,12 +9134,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9092,11 +9242,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -9201,12 +9352,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9296,6 +9449,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9309,12 +9463,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9390,11 +9546,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -9499,12 +9656,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -9594,6 +9753,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9607,12 +9767,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9713,11 +9875,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9822,12 +9985,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9917,6 +10082,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -9930,12 +10096,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -10481,11 +10649,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -10590,12 +10759,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -10685,6 +10856,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -10698,12 +10870,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -10804,11 +10978,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -10913,12 +11088,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -11008,6 +11185,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -11021,12 +11199,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11100,11 +11280,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -11209,12 +11390,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -11304,6 +11487,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -11317,12 +11501,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11423,11 +11609,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -11532,12 +11719,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -11627,6 +11816,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -11640,12 +11830,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -11758,11 +11950,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -11867,12 +12060,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -11962,6 +12157,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -11975,12 +12171,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -12081,11 +12279,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -12190,12 +12389,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -12285,6 +12486,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12298,12 +12500,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12377,11 +12581,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -12486,12 +12691,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -12581,6 +12788,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12594,12 +12802,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12700,11 +12910,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -12809,12 +13020,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -12904,6 +13117,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -12917,12 +13131,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -13223,11 +13439,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -13332,12 +13549,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -13427,6 +13646,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13440,12 +13660,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13546,11 +13768,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13655,12 +13878,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -13750,6 +13975,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -13763,12 +13989,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -13844,11 +14072,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -13953,12 +14182,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -14048,6 +14279,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -14061,12 +14293,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -14167,11 +14401,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -14276,12 +14511,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -14371,6 +14608,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -14384,12 +14622,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -14700,11 +14940,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -14809,12 +15050,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -14904,6 +15147,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -14917,12 +15161,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -15042,11 +15288,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -15151,12 +15398,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -15246,6 +15495,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -15259,12 +15509,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.accepttrue.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.accepttrue.shot
@@ -915,7 +915,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1072,7 +1072,7 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-disabled": "false",
+                      "aria-disabled": "true",
                       "aria-label": "Next",
                       "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                       "disabled": "",
@@ -1203,7 +1203,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1360,7 +1360,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -1571,7 +1571,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1671,7 +1671,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1789,7 +1789,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1950,7 +1950,7 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Previous",
                     "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2116,7 +2116,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2273,7 +2273,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2404,7 +2404,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Previous",
               "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -2561,7 +2561,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -2772,7 +2772,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2872,7 +2872,7 @@ LoadedCheerio {
             "parent": [Circular],
             "prev": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2990,7 +2990,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Next",
               "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -3151,7 +3151,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.nocrashonchange.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.nocrashonchange.shot
@@ -915,7 +915,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1072,7 +1072,7 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-disabled": "false",
+                      "aria-disabled": "true",
                       "aria-label": "Next",
                       "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                       "disabled": "",
@@ -1203,7 +1203,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1360,7 +1360,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -1571,7 +1571,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1671,7 +1671,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1789,7 +1789,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1950,7 +1950,7 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Previous",
                     "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2116,7 +2116,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2273,7 +2273,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2404,7 +2404,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Previous",
               "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -2561,7 +2561,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -2772,7 +2772,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2872,7 +2872,7 @@ LoadedCheerio {
             "parent": [Circular],
             "prev": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2990,7 +2990,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Next",
               "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -3151,7 +3151,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.position.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.position.shot
@@ -915,7 +915,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1072,7 +1072,7 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-disabled": "false",
+                      "aria-disabled": "true",
                       "aria-label": "Next",
                       "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                       "disabled": "",
@@ -1203,7 +1203,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1360,7 +1360,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -1571,7 +1571,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1671,7 +1671,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1789,7 +1789,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1950,7 +1950,7 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Previous",
                     "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2116,7 +2116,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2273,7 +2273,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2404,7 +2404,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Previous",
               "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -2561,7 +2561,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -2772,7 +2772,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2872,7 +2872,7 @@ LoadedCheerio {
             "parent": [Circular],
             "prev": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2990,7 +2990,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Next",
               "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -3151,7 +3151,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.renders.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.renders.shot
@@ -915,7 +915,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1072,7 +1072,7 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-disabled": "false",
+                      "aria-disabled": "true",
                       "aria-label": "Next",
                       "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                       "disabled": "",
@@ -1203,7 +1203,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1360,7 +1360,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -1571,7 +1571,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1671,7 +1671,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -1789,7 +1789,7 @@ LoadedCheerio {
             },
             Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -1950,7 +1950,7 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Previous",
                     "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2116,7 +2116,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2273,7 +2273,7 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-disabled": "false",
+                    "aria-disabled": "true",
                     "aria-label": "Next",
                     "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                     "disabled": "",
@@ -2404,7 +2404,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Previous",
               "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -2561,7 +2561,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Next",
                   "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                   "disabled": "",
@@ -2772,7 +2772,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Next",
                 "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2872,7 +2872,7 @@ LoadedCheerio {
             "parent": [Circular],
             "prev": Node {
               "attribs": Object {
-                "aria-disabled": "false",
+                "aria-disabled": "true",
                 "aria-label": "Previous",
                 "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                 "disabled": "",
@@ -2990,7 +2990,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
-              "aria-disabled": "false",
+              "aria-disabled": "true",
               "aria-label": "Next",
               "class": "pagination-button pagination-next button button-neutral button-medium icon-left disabled",
               "disabled": "",
@@ -3151,7 +3151,7 @@ LoadedCheerio {
               "parent": [Circular],
               "prev": Node {
                 "attribs": Object {
-                  "aria-disabled": "false",
+                  "aria-disabled": "true",
                   "aria-label": "Previous",
                   "class": "pagination-button pagination-previous button button-neutral button-medium icon-left disabled",
                   "disabled": "",

--- a/src/components/Table/Tests/__snapshots__/Table.usecolselectionwithkey.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.usecolselectionwithkey.shot
@@ -71,11 +71,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -180,12 +181,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -275,6 +278,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -288,12 +292,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -406,11 +412,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -515,12 +522,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -610,6 +619,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -623,12 +633,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -726,11 +738,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -835,12 +848,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -930,6 +945,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -943,12 +959,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -1042,11 +1060,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -1151,12 +1170,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -1246,6 +1267,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1259,12 +1281,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1333,11 +1357,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -1442,12 +1467,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -1537,6 +1564,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1550,12 +1578,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1649,11 +1679,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -1758,12 +1789,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -1853,6 +1886,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -1866,12 +1900,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -1965,11 +2001,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -2074,12 +2111,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -2169,6 +2208,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2182,12 +2222,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2281,11 +2323,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2390,12 +2433,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2485,6 +2530,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -2498,12 +2544,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -2574,11 +2622,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -2683,12 +2732,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -2778,6 +2829,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -2791,12 +2843,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -2890,11 +2944,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -2999,12 +3054,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3094,6 +3151,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -3107,12 +3165,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
@@ -3241,11 +3301,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -3350,12 +3411,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -3445,6 +3508,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -3458,12 +3522,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3576,11 +3642,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -3685,12 +3752,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -3780,6 +3849,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -3793,12 +3863,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -3896,11 +3968,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -4005,12 +4078,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -4100,6 +4175,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -4113,12 +4189,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -4212,11 +4290,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -4321,12 +4400,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -4416,6 +4497,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4429,12 +4511,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4503,11 +4587,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -4612,12 +4697,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -4707,6 +4794,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4720,12 +4808,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -4819,11 +4909,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -4928,12 +5019,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5023,6 +5116,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -5036,12 +5130,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -5135,11 +5231,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -5244,12 +5341,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -5339,6 +5438,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -5352,12 +5452,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -5451,11 +5553,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -5560,12 +5663,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -5655,6 +5760,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5668,12 +5774,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -5744,11 +5852,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -5853,12 +5962,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -5948,6 +6059,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -5961,12 +6073,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6060,11 +6174,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -6169,12 +6284,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -6264,6 +6381,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -6277,12 +6395,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -6433,11 +6553,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -6542,12 +6663,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -6637,6 +6760,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -6650,12 +6774,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -6749,11 +6875,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -6858,12 +6985,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -6953,6 +7082,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -6966,12 +7096,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7040,11 +7172,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -7149,12 +7282,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -7244,6 +7379,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7257,12 +7393,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7356,11 +7494,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -7465,12 +7604,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -7560,6 +7701,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -7573,12 +7715,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -7672,11 +7816,12 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "class": "selector selection-checkbox",
+                                      "class": "selector selector-medium selection-checkbox",
                                     },
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "id": "selectCheckBox",
                                           "readonly": "",
                                           "type": "checkbox",
@@ -7781,12 +7926,14 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
                                           "value": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "id": undefined,
                                           "readonly": undefined,
                                           "type": undefined,
@@ -7876,6 +8023,7 @@ LoadedCheerio {
                                         "parent": [Circular],
                                         "prev": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -7889,12 +8037,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -7988,11 +8138,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -8097,12 +8248,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -8192,6 +8345,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -8205,12 +8359,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -8281,11 +8437,12 @@ LoadedCheerio {
                                   "children": Array [
                                     Node {
                                       "attribs": Object {
-                                        "class": "selector selection-checkbox",
+                                        "class": "selector selector-medium selection-checkbox",
                                       },
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "id": "selectCheckBox",
                                             "readonly": "",
                                             "type": "checkbox",
@@ -8390,12 +8547,14 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
                                             "value": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "id": undefined,
                                             "readonly": undefined,
                                             "type": undefined,
@@ -8485,6 +8644,7 @@ LoadedCheerio {
                                           "parent": [Circular],
                                           "prev": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -8498,12 +8658,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -8597,11 +8759,12 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "selector selection-checkbox",
+                                          "class": "selector selector-medium selection-checkbox",
                                         },
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "id": "selectCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
@@ -8706,12 +8869,14 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
                                               "value": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "id": undefined,
                                               "readonly": undefined,
                                               "type": undefined,
@@ -8801,6 +8966,7 @@ LoadedCheerio {
                                             "parent": [Circular],
                                             "prev": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -8814,12 +8980,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -8923,11 +9091,12 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "selector selection-checkbox",
+                                            "class": "selector selector-medium selection-checkbox",
                                           },
                                           "children": Array [
                                             Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "id": "selectCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
@@ -9032,12 +9201,14 @@ LoadedCheerio {
                                               "prev": null,
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
                                                 "value": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "id": undefined,
                                                 "readonly": undefined,
                                                 "type": undefined,
@@ -9127,6 +9298,7 @@ LoadedCheerio {
                                               "parent": [Circular],
                                               "prev": Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -9140,12 +9312,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -9258,11 +9432,12 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "selector selection-checkbox",
+                                              "class": "selector selector-medium selection-checkbox",
                                             },
                                             "children": Array [
                                               Node {
                                                 "attribs": Object {
+                                                  "aria-disabled": "false",
                                                   "id": "selectCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
@@ -9367,12 +9542,14 @@ LoadedCheerio {
                                                 "prev": null,
                                                 "type": "tag",
                                                 "x-attribsNamespace": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
                                                   "value": undefined,
                                                 },
                                                 "x-attribsPrefix": Object {
+                                                  "aria-disabled": undefined,
                                                   "id": undefined,
                                                   "readonly": undefined,
                                                   "type": undefined,
@@ -9462,6 +9639,7 @@ LoadedCheerio {
                                                 "parent": [Circular],
                                                 "prev": Node {
                                                   "attribs": Object {
+                                                    "aria-disabled": "false",
                                                     "id": "selectCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
@@ -9475,12 +9653,14 @@ LoadedCheerio {
                                                   "prev": null,
                                                   "type": "tag",
                                                   "x-attribsNamespace": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,
                                                     "value": undefined,
                                                   },
                                                   "x-attribsPrefix": Object {
+                                                    "aria-disabled": undefined,
                                                     "id": undefined,
                                                     "readonly": undefined,
                                                     "type": undefined,

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -18,7 +18,12 @@ import {
     TwoStateButton,
 } from './components/Button';
 
-import { CheckBox, CheckBoxGroup, LabelPosition } from './components/CheckBox';
+import {
+    CheckBox,
+    CheckBoxGroup,
+    LabelPosition,
+    SelectorSize,
+} from './components/CheckBox';
 
 import { ConfigProvider } from './components/ConfigProvider';
 
@@ -178,6 +183,7 @@ export {
     RangePickerProps,
     ResizeObserver,
     Select,
+    SelectorSize,
     SearchBox,
     SecondaryButton,
     Slider,

--- a/src/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
+++ b/src/src/components/CheckBox/__snapshots__/CheckBox.stories.storyshot
@@ -2,9 +2,10 @@
 
 exports[`Storyshots Check Box Check Box 1`] = `
 <div
-  className="selector my-checkbox-class"
+  className="selector selector-medium my-checkbox-class"
 >
   <input
+    aria-disabled={false}
     aria-label="Label"
     checked={true}
     disabled={false}
@@ -34,7 +35,7 @@ exports[`Storyshots Check Box Check Box 1`] = `
 exports[`Storyshots Check Box Check Box Group 1`] = `
 <div
   checked={true}
-  className="checkbox-group vertical"
+  className="checkbox-group vertical checkbox-group-medium"
   defaultChecked={
     Array [
       "First",
@@ -43,9 +44,10 @@ exports[`Storyshots Check Box Check Box Group 1`] = `
   role="group"
 >
   <div
-    className="selector"
+    className="selector selector-medium"
   >
     <input
+      aria-disabled={false}
       checked={false}
       disabled={false}
       id="test-1"
@@ -70,9 +72,10 @@ exports[`Storyshots Check Box Check Box Group 1`] = `
     </label>
   </div>
   <div
-    className="selector"
+    className="selector selector-medium"
   >
     <input
+      aria-disabled={false}
       checked={false}
       disabled={false}
       id="test-2"
@@ -97,9 +100,10 @@ exports[`Storyshots Check Box Check Box Group 1`] = `
     </label>
   </div>
   <div
-    className="selector"
+    className="selector selector-medium"
   >
     <input
+      aria-disabled={false}
       checked={false}
       disabled={false}
       id="test-3"

--- a/src/src/components/CheckBox/__snapshots__/ToggleSwitch.stories.storyshot
+++ b/src/src/components/CheckBox/__snapshots__/ToggleSwitch.stories.storyshot
@@ -2,9 +2,10 @@
 
 exports[`Storyshots Toggle Switch Toggle Switch 1`] = `
 <div
-  className="selector my-toggle-class"
+  className="selector selector-medium my-toggle-class"
 >
   <input
+    aria-disabled={false}
     aria-label="Label"
     checked={true}
     disabled={false}

--- a/src/src/components/ConfigProvider/__snapshots__/ConfigProvider.stories.storyshot
+++ b/src/src/components/ConfigProvider/__snapshots__/ConfigProvider.stories.storyshot
@@ -4830,7 +4830,7 @@ exports[`Storyshots Config Provider Theming 1`] = `
     </svg>
   </span>
   <div
-    className="checkbox-group vertical"
+    className="checkbox-group vertical checkbox-group-medium"
     defaultChecked={
       Array [
         "First",
@@ -4839,9 +4839,10 @@ exports[`Storyshots Config Provider Theming 1`] = `
     role="group"
   >
     <div
-      className="selector"
+      className="selector selector-medium"
     >
       <input
+        aria-disabled={false}
         checked={true}
         disabled={false}
         id="test-1"
@@ -4866,9 +4867,10 @@ exports[`Storyshots Config Provider Theming 1`] = `
       </label>
     </div>
     <div
-      className="selector"
+      className="selector selector-medium"
     >
       <input
+        aria-disabled={false}
         checked={false}
         disabled={false}
         id="test-2"
@@ -4893,9 +4895,10 @@ exports[`Storyshots Config Provider Theming 1`] = `
       </label>
     </div>
     <div
-      className="selector"
+      className="selector selector-medium"
     >
       <input
+        aria-disabled={false}
         checked={false}
         disabled={false}
         id="test-3"
@@ -4921,9 +4924,10 @@ exports[`Storyshots Config Provider Theming 1`] = `
     </div>
   </div>
   <div
-    className="selector"
+    className="selector selector-medium"
   >
     <input
+      aria-disabled={false}
       checked={false}
       disabled={false}
       id="4fzzzxj"
@@ -4947,13 +4951,14 @@ exports[`Storyshots Config Provider Theming 1`] = `
   </div>
   <div
     aria-label="Radio Group"
-    className="radio-group vertical"
+    className="radio-group vertical radio-group-medium"
     role="group"
   >
     <div
-      className="selector"
+      className="selector selector-medium"
     >
       <input
+        aria-disabled={false}
         checked={true}
         disabled={false}
         id="oea2exk-1"
@@ -4979,9 +4984,10 @@ exports[`Storyshots Config Provider Theming 1`] = `
       </label>
     </div>
     <div
-      className="selector"
+      className="selector selector-medium"
     >
       <input
+        aria-disabled={false}
         checked={false}
         disabled={false}
         id="oea2exk-2"
@@ -5007,9 +5013,10 @@ exports[`Storyshots Config Provider Theming 1`] = `
       </label>
     </div>
     <div
-      className="selector"
+      className="selector selector-medium"
     >
       <input
+        aria-disabled={false}
         checked={false}
         disabled={false}
         id="oea2exk-3"

--- a/src/src/components/Inputs/SearchBox/__snapshots__/SearchBox.stories.storyshot
+++ b/src/src/components/Inputs/SearchBox/__snapshots__/SearchBox.stories.storyshot
@@ -65,6 +65,7 @@ exports[`Storyshots Input Search Box 1`] = `
       className="input-group left-icon"
     >
       <input
+        aria-disabled={false}
         aria-label="Search"
         autoFocus={false}
         className="my-searchbox-class pill-shape pill-shape-with-icon pill-shape-with-icon-button pill-shape-with-icon-and-icon-button left-icon clear-not-visible"

--- a/src/src/components/Inputs/TextInput/__snapshots__/TextInput.stories.storyshot
+++ b/src/src/components/Inputs/TextInput/__snapshots__/TextInput.stories.storyshot
@@ -62,6 +62,7 @@ exports[`Storyshots Input Text Input 1`] = `
     className="input-group left-icon"
   >
     <input
+      aria-disabled={false}
       aria-label="Sample text"
       autoFocus={false}
       className="my-textinput-class pill-shape pill-shape-with-icon pill-shape-with-icon-button pill-shape-with-icon-and-icon-button left-icon clear-not-visible"

--- a/src/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
+++ b/src/src/components/Pagination/__snapshots__/Pagination.stories.storyshot
@@ -154,7 +154,7 @@ exports[`Storyshots Pagination All Combined 1`] = `
     </li>
   </ul>
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Next"
     className="pagination-button pagination-next button button-neutral button-medium icon-left disabled"
     defaultChecked={false}
@@ -197,6 +197,7 @@ exports[`Storyshots Pagination All Combined 1`] = `
         className="input-group left-icon"
       >
         <input
+          aria-disabled={false}
           autoFocus={false}
           className="editor pill-shape left-icon clear-not-visible"
           defaultValue={4}
@@ -223,7 +224,7 @@ exports[`Storyshots Pagination Basic Few 1`] = `
 >
   <span />
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Previous"
     className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
     defaultChecked={false}
@@ -355,7 +356,7 @@ exports[`Storyshots Pagination Basic Many 1`] = `
 >
   <span />
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Previous"
     className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
     defaultChecked={false}
@@ -581,7 +582,7 @@ exports[`Storyshots Pagination Change Page Size 1`] = `
   </span>
   <span />
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Previous"
     className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
     defaultChecked={false}
@@ -653,7 +654,7 @@ exports[`Storyshots Pagination Change Page Size 1`] = `
     </li>
   </ul>
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Next"
     className="pagination-button pagination-next button button-neutral button-medium icon-left disabled"
     defaultChecked={false}
@@ -696,7 +697,7 @@ exports[`Storyshots Pagination Dots 1`] = `
 >
   <span />
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Previous"
     className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
     defaultChecked={false}
@@ -960,6 +961,7 @@ exports[`Storyshots Pagination Jump To 1`] = `
         className="input-group left-icon"
       >
         <input
+          aria-disabled={false}
           autoFocus={false}
           className="editor pill-shape left-icon clear-not-visible"
           defaultValue={5}
@@ -986,7 +988,7 @@ exports[`Storyshots Pagination Simplified 1`] = `
 >
   <span />
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Previous"
     className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
     defaultChecked={false}
@@ -1081,7 +1083,7 @@ exports[`Storyshots Pagination Total Item Count 1`] = `
     1000 Total
   </span>
   <button
-    aria-disabled={false}
+    aria-disabled={true}
     aria-label="Previous"
     className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
     defaultChecked={false}

--- a/src/src/components/PersistentBar/__snapshots__/PersistentBar.stories.storyshot
+++ b/src/src/components/PersistentBar/__snapshots__/PersistentBar.stories.storyshot
@@ -323,7 +323,7 @@ exports[`Storyshots Persistent Bar Top Bar Pagination 1`] = `
   >
     <span />
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -537,7 +537,7 @@ exports[`Storyshots Persistent Bar Top Bar With Text 1`] = `
   >
     <span />
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}

--- a/src/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
+++ b/src/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
@@ -12,9 +12,10 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
   }
 >
   <div
-    className="selector my-radiobutton-class"
+    className="selector selector-medium my-radiobutton-class"
   >
     <input
+      aria-disabled={false}
       aria-label="Label 1"
       checked={true}
       disabled={false}
@@ -41,9 +42,10 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
     </label>
   </div>
   <div
-    className="selector my-radiobutton-class"
+    className="selector selector-medium my-radiobutton-class"
   >
     <input
+      aria-disabled={false}
       aria-label="Label 2"
       checked={false}
       disabled={false}
@@ -70,9 +72,10 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
     </label>
   </div>
   <div
-    className="selector my-radiobutton-class"
+    className="selector selector-medium my-radiobutton-class"
   >
     <input
+      aria-disabled={false}
       aria-label="Label 3"
       checked={false}
       disabled={false}
@@ -103,9 +106,10 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
 
 exports[`Storyshots Radio Button Radio Button 1`] = `
 <div
-  className="selector my-radiobutton-class"
+  className="selector selector-medium my-radiobutton-class"
 >
   <input
+    aria-disabled={false}
     aria-label="Label"
     checked={false}
     disabled={false}
@@ -136,13 +140,14 @@ exports[`Storyshots Radio Button Radio Button 1`] = `
 exports[`Storyshots Radio Button Radio Group 1`] = `
 <div
   aria-label="Radio Group"
-  className="radio-group vertical"
+  className="radio-group vertical radio-group-medium"
   role="group"
 >
   <div
-    className="selector"
+    className="selector selector-medium"
   >
     <input
+      aria-disabled={false}
       checked={true}
       disabled={false}
       id="oea2exk-1"
@@ -168,9 +173,10 @@ exports[`Storyshots Radio Button Radio Group 1`] = `
     </label>
   </div>
   <div
-    className="selector"
+    className="selector selector-medium"
   >
     <input
+      aria-disabled={false}
       checked={false}
       disabled={false}
       id="oea2exk-2"
@@ -196,9 +202,10 @@ exports[`Storyshots Radio Button Radio Group 1`] = `
     </label>
   </div>
   <div
-    className="selector"
+    className="selector selector-medium"
   >
     <input
+      aria-disabled={false}
       checked={false}
       disabled={false}
       id="oea2exk-3"

--- a/src/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -24,6 +24,7 @@ exports[`Storyshots Select Basic 1`] = `
         >
           <input
             aria-controls="dropdown-22"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -99,6 +100,7 @@ exports[`Storyshots Select Disabled 1`] = `
         >
           <input
             aria-controls="dropdown-24"
+            aria-disabled={true}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -172,6 +174,7 @@ exports[`Storyshots Select Dynamic 1`] = `
         >
           <input
             aria-controls="dropdown-26"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -247,6 +250,7 @@ exports[`Storyshots Select Filterable 1`] = `
         >
           <input
             aria-controls="dropdown-28"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -322,6 +326,7 @@ exports[`Storyshots Select Multiple 1`] = `
         >
           <input
             aria-controls="dropdown-30"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -397,6 +402,7 @@ exports[`Storyshots Select Multiple With No Filter 1`] = `
         >
           <input
             aria-controls="dropdown-32"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -472,6 +478,7 @@ exports[`Storyshots Select Options Disabled 1`] = `
         >
           <input
             aria-controls="dropdown-34"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -547,6 +554,7 @@ exports[`Storyshots Select With Clear 1`] = `
         >
           <input
             aria-controls="dropdown-36"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
@@ -622,6 +630,7 @@ exports[`Storyshots Select With Default Value 1`] = `
         >
           <input
             aria-controls="dropdown-38"
+            aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}

--- a/src/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -1400,7 +1400,7 @@ exports[`Storyshots Table Basic 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -1532,6 +1532,7 @@ exports[`Storyshots Table Basic 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -2952,7 +2953,7 @@ exports[`Storyshots Table Bordered 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -3084,6 +3085,7 @@ exports[`Storyshots Table Bordered 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -4504,7 +4506,7 @@ exports[`Storyshots Table Cell Bordered 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -4636,6 +4638,7 @@ exports[`Storyshots Table Cell Bordered 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -7540,7 +7543,7 @@ exports[`Storyshots Table Ellipsis 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -7672,6 +7675,7 @@ exports[`Storyshots Table Ellipsis 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -9503,7 +9507,7 @@ exports[`Storyshots Table Ellipsis With Tooltip 1`] = `
       Total 16
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -9619,6 +9623,7 @@ exports[`Storyshots Table Ellipsis With Tooltip 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -11436,7 +11441,7 @@ exports[`Storyshots Table Expandable Row 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -11568,6 +11573,7 @@ exports[`Storyshots Table Expandable Row 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -13038,7 +13044,7 @@ exports[`Storyshots Table Filter 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -13170,6 +13176,7 @@ exports[`Storyshots Table Filter 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -16405,7 +16412,7 @@ exports[`Storyshots Table Fixed Columns 1`] = `
         16 Total
       </span>
       <button
-        aria-disabled={false}
+        aria-disabled={true}
         aria-label="Previous"
         className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
         defaultChecked={false}
@@ -16537,6 +16544,7 @@ exports[`Storyshots Table Fixed Columns 1`] = `
             className="input-group left-icon"
           >
             <input
+              aria-disabled={false}
               autoFocus={false}
               className="editor pill-shape left-icon clear-not-visible"
               defaultValue={1}
@@ -19794,7 +19802,7 @@ exports[`Storyshots Table Fixed Columns And Header 1`] = `
         16 Total
       </span>
       <button
-        aria-disabled={false}
+        aria-disabled={true}
         aria-label="Previous"
         className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
         defaultChecked={false}
@@ -19926,6 +19934,7 @@ exports[`Storyshots Table Fixed Columns And Header 1`] = `
             className="input-group left-icon"
           >
             <input
+              aria-disabled={false}
               autoFocus={false}
               className="editor pill-shape left-icon clear-not-visible"
               defaultValue={1}
@@ -21452,7 +21461,7 @@ exports[`Storyshots Table Fixed Header 1`] = `
         16 Total
       </span>
       <button
-        aria-disabled={false}
+        aria-disabled={true}
         aria-label="Previous"
         className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
         defaultChecked={false}
@@ -21584,6 +21593,7 @@ exports[`Storyshots Table Fixed Header 1`] = `
             className="input-group left-icon"
           >
             <input
+              aria-disabled={false}
               autoFocus={false}
               className="editor pill-shape left-icon clear-not-visible"
               defaultValue={1}
@@ -23015,7 +23025,7 @@ exports[`Storyshots Table Header And Footer 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -23147,6 +23157,7 @@ exports[`Storyshots Table Header And Footer 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -24567,7 +24578,7 @@ exports[`Storyshots Table Header Bordered 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -24699,6 +24710,7 @@ exports[`Storyshots Table Header Bordered 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -27831,7 +27843,7 @@ exports[`Storyshots Table Header Grouping 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -27963,6 +27975,7 @@ exports[`Storyshots Table Header Grouping 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -29383,7 +29396,7 @@ exports[`Storyshots Table Inner Bordered 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -29515,6 +29528,7 @@ exports[`Storyshots Table Inner Bordered 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -30935,7 +30949,7 @@ exports[`Storyshots Table Large 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -31067,6 +31081,7 @@ exports[`Storyshots Table Large 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -32487,7 +32502,7 @@ exports[`Storyshots Table Medium 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -32619,6 +32634,7 @@ exports[`Storyshots Table Medium 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -34298,7 +34314,7 @@ exports[`Storyshots Table Nested 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -34430,6 +34446,7 @@ exports[`Storyshots Table Nested 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -35067,7 +35084,7 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                   className="selector selector-medium selection-checkbox disabled"
                 >
                   <input
-                    aria-disabled={false}
+                    aria-disabled={true}
                     checked={false}
                     disabled={true}
                     id="selectCheckBox"
@@ -36696,7 +36713,7 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -36828,6 +36845,7 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -38248,7 +38266,7 @@ exports[`Storyshots Table Outer Bordered 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -38380,6 +38398,7 @@ exports[`Storyshots Table Outer Bordered 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -38789,7 +38808,7 @@ exports[`Storyshots Table Responsive 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -38921,6 +38940,7 @@ exports[`Storyshots Table Responsive 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -40341,7 +40361,7 @@ exports[`Storyshots Table Row Bordered 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -40473,6 +40493,7 @@ exports[`Storyshots Table Row Bordered 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -40956,7 +40977,7 @@ exports[`Storyshots Table Selection 1`] = `
                   className="selector selector-medium selection-checkbox disabled"
                 >
                   <input
-                    aria-disabled={false}
+                    aria-disabled={true}
                     checked={false}
                     disabled={true}
                     id="selectCheckBox"
@@ -42467,7 +42488,7 @@ exports[`Storyshots Table Selection 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -42599,6 +42620,7 @@ exports[`Storyshots Table Selection 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -44019,7 +44041,7 @@ exports[`Storyshots Table Small 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -44151,6 +44173,7 @@ exports[`Storyshots Table Small 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -45649,7 +45672,7 @@ exports[`Storyshots Table Sort 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -45781,6 +45804,7 @@ exports[`Storyshots Table Sort 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -47435,7 +47459,7 @@ exports[`Storyshots Table Sort Multiple 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -47567,6 +47591,7 @@ exports[`Storyshots Table Sort Multiple 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
@@ -49013,7 +49038,7 @@ exports[`Storyshots Table Summary 1`] = `
       16 Total
     </span>
     <button
-      aria-disabled={false}
+      aria-disabled={true}
       aria-label="Previous"
       className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
       defaultChecked={false}
@@ -49145,6 +49170,7 @@ exports[`Storyshots Table Summary 1`] = `
           className="input-group left-icon"
         >
           <input
+            aria-disabled={false}
             autoFocus={false}
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}

--- a/src/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -34551,9 +34551,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                   className="table-selection-column"
                 >
                   <div
-                    className="selector selection-checkbox"
+                    className="selector selector-medium selection-checkbox"
                   >
                     <input
+                      aria-disabled={false}
                       checked={false}
                       disabled={false}
                       id="selectCheckBox"
@@ -34682,9 +34683,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -34808,9 +34810,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -34934,9 +34937,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -35060,9 +35064,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox disabled"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={true}
                     id="selectCheckBox"
@@ -35186,9 +35191,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -35312,9 +35318,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -35438,9 +35445,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -35564,9 +35572,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -35690,9 +35699,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -35816,9 +35826,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -35941,9 +35952,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -36067,9 +36079,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -36193,9 +36206,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -36319,9 +36333,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -36445,9 +36460,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -36571,9 +36587,10 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -40525,9 +40542,10 @@ exports[`Storyshots Table Selection 1`] = `
                   className="table-selection-column"
                 >
                   <div
-                    className="selector selection-checkbox"
+                    className="selector selector-medium selection-checkbox"
                   >
                     <input
+                      aria-disabled={false}
                       checked={false}
                       disabled={false}
                       id="selectCheckBox"
@@ -40599,9 +40617,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -40710,9 +40729,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -40821,9 +40841,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -40932,9 +40953,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox disabled"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={true}
                     id="selectCheckBox"
@@ -41043,9 +41065,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41154,9 +41177,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41265,9 +41289,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41376,9 +41401,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41487,9 +41513,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41598,9 +41625,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41709,9 +41737,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41819,9 +41848,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -41930,9 +41960,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -42041,9 +42072,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -42152,9 +42184,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"
@@ -42263,9 +42296,10 @@ exports[`Storyshots Table Selection 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="selector selection-checkbox"
+                  className="selector selector-medium selection-checkbox"
                 >
                   <input
+                    aria-disabled={false}
                     checked={false}
                     disabled={false}
                     id="selectCheckBox"

--- a/src/styles/themes/_definitions-light.scss
+++ b/src/styles/themes/_definitions-light.scss
@@ -148,7 +148,7 @@ $space-xxs: 4px;
 $space-xs: 8px;
 $space-s: 12px;
 $space-m: 16px;
-$space-l-fitted: 20px;
+$space-ml: 20px;
 $space-l: 24px;
 $space-xl: 32px;
 $space-xxl: 40px;

--- a/src/styles/themes/_definitions-light.scss
+++ b/src/styles/themes/_definitions-light.scss
@@ -171,6 +171,7 @@ $label-no-value-margin-bottom: 15px;
 
 // Corner-radius Definitions
 
+$corner-radius-xs: 2px;
 $corner-radius-s: 4px;
 $corner-radius-m: 8px;
 $corner-radius-l: 16px;
@@ -249,30 +250,66 @@ $all-backdrops: rgba(0, 0, 0, 0.5);
 
 // Sizing
 
-$selector-input-width: 18px;
-$selector-input-height: 18px;
-$checkmark-after-width: 6px;
-$checkmark-after-height: 10px;
-$checkmark-height: 18px;
-$checkmark-width: 18px;
-$radio-height: 20px;
-$radio-width: 20px;
-$radio-after-width: 6px;
-$radio-after-height: 6px;
-$toggle-after-width: 12px;
-$toggle-after-height: 12px;
-$toggle-height: 20px;
-$toggle-width: 40px;
+$checkmark-large-after-width: 8px;
+$checkmark-large-after-height: 14px;
+$checkmark-large-height: 20px;
+$checkmark-large-width: 20px;
+$checkmark-medium-after-width: 6px;
+$checkmark-medium-after-height: 12px;
+$checkmark-medium-height: 16px;
+$checkmark-medium-width: 16px;
+$checkmark-small-after-width: 6px;
+$checkmark-small-after-height: 10px;
+$checkmark-small-height: 14px;
+$checkmark-small-width: 14px;
+$radio-large-height: 20px;
+$radio-large-width: 20px;
+$radio-large-after-width: 6px;
+$radio-large-after-height: 6px;
+$radio-medium-height: 16px;
+$radio-medium-width: 16px;
+$radio-medium-after-width: 4px;
+$radio-medium-after-height: 4px;
+$radio-small-height: 14px;
+$radio-small-width: 14px;
+$radio-small-after-width: 4px;
+$radio-small-after-height: 4px;
+$toggle-large-after-width: 12px;
+$toggle-large-after-height: 12px;
+$toggle-large-height: 20px;
+$toggle-large-width: 40px;
+$toggle-medium-after-width: 8px;
+$toggle-medium-after-height: 8px;
+$toggle-medium-height: 16px;
+$toggle-medium-width: 32px;
+$toggle-small-after-width: 6px;
+$toggle-small-after-height: 6px;
+$toggle-small-height: 12px;
+$toggle-small-width: 24px;
 
 // Positioning
 
-$checkmark-after-left: 4px;
-$checkmark-after-top: 0.5px;
-$radio-after-top: 5px;
-$radio-after-left: 5px;
-$toggle-after-left: 2px;
-$toggle-after-left-checked: 22px;
-$toggle-after-top: 2px;
+$checkmark-large-after-left: 4px;
+$checkmark-large-after-top: -1px;
+$checkmark-medium-after-left: 3px;
+$checkmark-medium-after-top: -1px;
+$checkmark-small-after-left: 2px;
+$checkmark-small-after-top: -1px;
+$radio-large-after-top: 5px;
+$radio-large-after-left: 5px;
+$radio-medium-after-top: 4px;
+$radio-medium-after-left: 4px;
+$radio-small-after-top: 3px;
+$radio-small-after-left: 3px;
+$toggle-large-after-left: 2px;
+$toggle-large-after-left-checked: 22px;
+$toggle-large-after-top: 2px;
+$toggle-medium-after-left: 2px;
+$toggle-medium-after-left-checked: 18px;
+$toggle-medium-after-top: 2px;
+$toggle-small-after-left: 2px;
+$toggle-small-after-left-checked: 12px;
+$toggle-small-after-top: 1px;
 
 // END: CONSTANTS
 


### PR DESCRIPTION
## SUMMARY:

- Updated the button CSS
- Updated the Dialog Button type
- Updated the Dialog CSS
- Added props to selectors and selector groups
- updated selector CSS

https://user-images.githubusercontent.com/99700808/181661384-0437c09b-8ef6-42b6-bcec-fff7ddb49658.mp4

https://user-images.githubusercontent.com/99700808/181661407-9629210c-f389-4d58-bd47-47ab841b4777.mp4

## JIRA TASK (Eightfold Employees Only):

ENG-23846: [Button] [Theme2] Default style has the wrong color in pressed state
ENG-23847: [Button] [Theme2] Split style's divider line is not passing accessibility
ENG-23852: [Dialog] [Theme2] cancel button should be neutral version and not default version
ENG-23853: [Modal] [Theme2] Close button should be in neutral style
ENG-23858; [Info Bar] [Theme2] surrounding padding should be 20px. 
ENG-25252: Add ability to disable radio and checkbox groups at parent level
ENG-25728: [Selectors] RadioButton and CheckBox need size prop
ENG-25730: [Selectors] AllowDisabledFocus prop is missing

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [X] I have added unittests for this change

## TEST PLAN:
Pull this pr and do `yarn` and `yarn storybook` verify the changes tot he following stories:

RadioButton
CheckBox
Default Button
Split Button
Dialog
Modal (inherits from Dialog)
InfoBar
