### PR TITLE
fix: radiobutton: fixes width of radio element in flex when layout is constrained

### DIFF
--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -201,6 +201,48 @@ const Bespoke_RadioGroup_Story: ComponentStory<typeof RadioButton> = (args) => {
 
 export const Bespoke_Radio_Group = Bespoke_RadioGroup_Story.bind({});
 
+const RadioButton_With_Custom_Label_Story: ComponentStory<
+    typeof RadioButton
+> = (args) => {
+    const [selected, setSelected] = useState<RadioButtonValue>('label1');
+
+    const radioChangeHandler = (
+        e?: React.ChangeEvent<HTMLInputElement>
+    ): void => {
+        setSelected(e.target.value);
+    };
+
+    return (
+        <RadioButton
+            {...args}
+            checked={selected === 'Label1'}
+            onChange={radioChangeHandler}
+        />
+    );
+};
+
+export const RadioButton_With_Custom_Label =
+    RadioButton_With_Custom_Label_Story.bind({});
+
+const RadioGroup_With_Custom_Label_Story: ComponentStory<typeof RadioGroup> = (
+    args
+) => {
+    const [selected, setSelected] = useState<RadioButtonValue>(args.value);
+    return (
+        <RadioGroup
+            {...args}
+            value={selected}
+            onChange={(e) => {
+                args.onChange(e);
+                setSelected(e.target.value);
+            }}
+        />
+    );
+};
+
+export const RadioGroup_With_Custom_Label =
+    RadioGroup_With_Custom_Label_Story.bind({});
+
 const radioButtonArgs: Object = {
     allowDisabledFocus: false,
     ariaLabel: 'Label',
@@ -237,4 +279,42 @@ Radio_Group.args = {
 Bespoke_Radio_Group.args = {
     ...radioButtonArgs,
     name: 'roleGroupName',
+};
+
+RadioButton_With_Custom_Label.args = {
+    ...radioButtonArgs,
+    label: (
+        <div>
+            <div style={{ fontWeight: 'bold' }}>Line one with some text</div>
+            <div>
+                Line two with some details about the above text. This could be a
+                description or summary of some sort.
+            </div>
+        </div>
+    ),
+};
+
+RadioGroup_With_Custom_Label.args = {
+    allowDisabledFocus: false,
+    ariaLabel: 'Radio Group',
+    disabled: false,
+    value: 'Radio1',
+    items: [1, 2, 3].map((i) => ({
+        value: `Radio${i}`,
+        label: (
+            <div>
+                <div style={{ fontWeight: 'bold' }}>
+                    Line one with some text
+                </div>
+                <div>
+                    Line two with some details about the above text. This could
+                    be a description or summary of some sort.
+                </div>
+            </div>
+        ),
+        name: 'group',
+        id: `oea2exk-${i}`,
+    })),
+    layout: 'vertical',
+    size: SelectorSize.Medium,
 };

--- a/src/components/RadioButton/radio.module.scss
+++ b/src/components/RadioButton/radio.module.scss
@@ -23,13 +23,14 @@
 
         & + label {
             .radio-button {
-                position: relative;
-                height: $radio-medium-height;
-                width: $radio-medium-width;
-                border-radius: 50%;
                 border: $space-xxxs solid var(--grey-color-70);
+                border-radius: 50%;
+                height: $radio-medium-height;
+                min-width: $radio-medium-width;
+                position: relative;
                 transition: all $motion-duration-extra-fast $motion-ease-in-back
                     $motion-delay-s;
+                width: $radio-medium-width;
 
                 &:after {
                     top: $radio-medium-after-top;
@@ -133,6 +134,7 @@
             & + label {
                 .radio-button {
                     height: $radio-large-height;
+                    min-width: $radio-large-width;
                     width: $radio-large-width;
 
                     &:after {
@@ -171,6 +173,7 @@
             & + label {
                 .radio-button {
                     height: $radio-medium-height;
+                    min-width: $radio-medium-width;
                     width: $radio-medium-width;
 
                     &:after {
@@ -209,6 +212,7 @@
             & + label {
                 .radio-button {
                     height: $radio-small-height;
+                    min-width: $radio-small-width;
                     width: $radio-small-width;
 
                     &:after {

--- a/src/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
+++ b/src/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
@@ -137,6 +137,52 @@ exports[`Storyshots Radio Button Radio Button 1`] = `
 </div>
 `;
 
+exports[`Storyshots Radio Button Radio Button With Custom Label 1`] = `
+<div
+  className="selector selector-medium my-radiobutton-class"
+>
+  <input
+    aria-disabled={false}
+    aria-label="Label"
+    checked={false}
+    disabled={false}
+    id="myRadioButtonId"
+    name="myRadioButtonName"
+    onChange={[Function]}
+    readOnly={true}
+    type="radio"
+    value="Label1"
+  />
+  <label
+    className=""
+    htmlFor="myRadioButtonId"
+  >
+    <span
+      className="radio-button"
+      id="myRadioButtonId-custom-radio"
+    />
+    <span
+      className="selector-label selector-label-end"
+    >
+      <div>
+        <div
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Line one with some text
+        </div>
+        <div>
+          Line two with some details about the above text. This could be a description or summary of some sort.
+        </div>
+      </div>
+    </span>
+  </label>
+</div>
+`;
+
 exports[`Storyshots Radio Button Radio Group 1`] = `
 <div
   aria-label="Radio Group"
@@ -227,6 +273,141 @@ exports[`Storyshots Radio Button Radio Group 1`] = `
         className="selector-label selector-label-end"
       >
         Radio3
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
+<div
+  aria-label="Radio Group"
+  className="radio-group vertical radio-group-medium"
+  role="group"
+>
+  <div
+    className="selector selector-medium"
+  >
+    <input
+      aria-disabled={false}
+      checked={true}
+      disabled={false}
+      id="oea2exk-1"
+      name="group"
+      onChange={[Function]}
+      readOnly={true}
+      type="radio"
+      value="Radio1"
+    />
+    <label
+      className=""
+      htmlFor="oea2exk-1"
+    >
+      <span
+        className="radio-button"
+        id="oea2exk-1-custom-radio"
+      />
+      <span
+        className="selector-label selector-label-end"
+      >
+        <div>
+          <div
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Line one with some text
+          </div>
+          <div>
+            Line two with some details about the above text. This could be a description or summary of some sort.
+          </div>
+        </div>
+      </span>
+    </label>
+  </div>
+  <div
+    className="selector selector-medium"
+  >
+    <input
+      aria-disabled={false}
+      checked={false}
+      disabled={false}
+      id="oea2exk-2"
+      name="group"
+      onChange={[Function]}
+      readOnly={true}
+      type="radio"
+      value="Radio2"
+    />
+    <label
+      className=""
+      htmlFor="oea2exk-2"
+    >
+      <span
+        className="radio-button"
+        id="oea2exk-2-custom-radio"
+      />
+      <span
+        className="selector-label selector-label-end"
+      >
+        <div>
+          <div
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Line one with some text
+          </div>
+          <div>
+            Line two with some details about the above text. This could be a description or summary of some sort.
+          </div>
+        </div>
+      </span>
+    </label>
+  </div>
+  <div
+    className="selector selector-medium"
+  >
+    <input
+      aria-disabled={false}
+      checked={false}
+      disabled={false}
+      id="oea2exk-3"
+      name="group"
+      onChange={[Function]}
+      readOnly={true}
+      type="radio"
+      value="Radio3"
+    />
+    <label
+      className=""
+      htmlFor="oea2exk-3"
+    >
+      <span
+        className="radio-button"
+        id="oea2exk-3-custom-radio"
+      />
+      <span
+        className="selector-label selector-label-end"
+      >
+        <div>
+          <div
+            style={
+              Object {
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Line one with some text
+          </div>
+          <div>
+            Line two with some details about the above text. This could be a description or summary of some sort.
+          </div>
+        </div>
       </span>
     </label>
   </div>


### PR DESCRIPTION
## SUMMARY:
When the RadioButton is used in a thinner layout, the first element gets distorted. This change ensures the width is consistent.

## JIRA TASK (Eightfold Employees Only):
ENG-25650

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Verify the additional stories by either pulling the pr and doing `yarn`, and `yarn storybook` or implement a radio group using the pr CodeSandbox React build, resize the browser to test the layout of the group.