### PR TITLE
fix: radio group: updates story implementation to scope selection states

### DIFF
--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Label } from '../Label';
 import { RadioButton, RadioButtonValue, RadioGroup } from './';
 import { LabelPosition, SelectorSize } from '../CheckBox';
 import { Stack } from '../Stack';
@@ -142,15 +143,19 @@ const RadioButton_Story: ComponentStory<typeof RadioButton> = (args) => {
 export const Radio_Button = RadioButton_Story.bind({});
 
 const RadioGroup_Story: ComponentStory<typeof RadioGroup> = (args) => {
-    const [selected, setSelected] = useState<RadioButtonValue>(args.value);
+    const [selected1, setSelected1] = useState<RadioButtonValue>(args.value);
+
+    const radioChangeGroupHandler = (
+        e?: React.ChangeEvent<HTMLInputElement>
+    ): void => {
+        setSelected1(e.target.value);
+    };
+
     return (
         <RadioGroup
             {...args}
-            value={selected}
-            onChange={(e) => {
-                args.onChange(e);
-                setSelected(e.target.value);
-            }}
+            value={selected1}
+            onChange={radioChangeGroupHandler}
         />
     );
 };
@@ -158,41 +163,83 @@ const RadioGroup_Story: ComponentStory<typeof RadioGroup> = (args) => {
 export const Radio_Group = RadioGroup_Story.bind({});
 
 const Bespoke_RadioGroup_Story: ComponentStory<typeof RadioButton> = (args) => {
-    const [selected, setSelected] = useState<RadioButtonValue>('label1');
+    const [selected2a, setSelected2a] = useState<RadioButtonValue>('label1');
+    const [selected2b, setSelected2b] = useState<RadioButtonValue>('label1');
 
-    const radioChangeHandler = (
+    const radioChangeGroupAHandler = (
         e?: React.ChangeEvent<HTMLInputElement>
     ): void => {
-        setSelected(e.target.value);
+        setSelected2a(e.target.value);
+    };
+
+    const radioChangeGroupBHandler = (
+        e?: React.ChangeEvent<HTMLInputElement>
+    ): void => {
+        setSelected2b(e.target.value);
     };
 
     return (
         <Stack direction="vertical" gap="m">
+            <Label text="Group 1" />
             <RadioButton
                 {...args}
                 ariaLabel={'Label 1'}
-                checked={selected === 'label1'}
-                id={'myRadioButtonId1'}
+                checked={selected2a === 'label1'}
+                id={'myBespokeRadioGroup1-Id1'}
                 label={'Label 1'}
-                onChange={radioChangeHandler}
+                name={'bespokeGroup1'}
+                onChange={radioChangeGroupAHandler}
                 value={'label1'}
             />
             <RadioButton
                 {...args}
                 ariaLabel={'Label 2'}
-                checked={selected === 'label2'}
-                id={'myRadioButtonId2'}
+                checked={selected2a === 'label2'}
+                id={'myBespokeRadioGroup1-Id2'}
                 label={'Label 2'}
-                onChange={radioChangeHandler}
+                name={'bespokeGroup1'}
+                onChange={radioChangeGroupAHandler}
                 value={'label2'}
             />
             <RadioButton
                 {...args}
                 ariaLabel={'Label 3'}
-                checked={selected === 'label3'}
-                id={'myRadioButtonId3'}
+                checked={selected2a === 'label3'}
+                id={'myBespokeRadioGroup1-Id3'}
                 label={'Label 3'}
-                onChange={radioChangeHandler}
+                name={'bespokeGroup1'}
+                onChange={radioChangeGroupAHandler}
+                value={'label3'}
+            />
+            <Label text="Group 2" />
+            <RadioButton
+                {...args}
+                ariaLabel={'Label 1'}
+                checked={selected2b === 'label1'}
+                id={'myBespokeRadioGroup2-Id1'}
+                label={'Label 1'}
+                name={'bespokeGroup2'}
+                onChange={radioChangeGroupBHandler}
+                value={'label1'}
+            />
+            <RadioButton
+                {...args}
+                ariaLabel={'Label 2'}
+                checked={selected2b === 'label2'}
+                id={'myBespokeRadioGroup2-Id2'}
+                label={'Label 2'}
+                name={'bespokeGroup2'}
+                onChange={radioChangeGroupBHandler}
+                value={'label2'}
+            />
+            <RadioButton
+                {...args}
+                ariaLabel={'Label 3'}
+                checked={selected2b === 'label3'}
+                id={'myBespokeRadioGroup2-Id3'}
+                label={'Label 3'}
+                name={'bespokeGroup2'}
+                onChange={radioChangeGroupBHandler}
                 value={'label3'}
             />
         </Stack>
@@ -227,14 +274,14 @@ export const RadioButton_With_Custom_Label =
 const RadioGroup_With_Custom_Label_Story: ComponentStory<typeof RadioGroup> = (
     args
 ) => {
-    const [selected, setSelected] = useState<RadioButtonValue>(args.value);
+    const [selected3, setSelected3] = useState<RadioButtonValue>(args.value);
     return (
         <RadioGroup
             {...args}
-            value={selected}
+            value={selected3}
             onChange={(e) => {
                 args.onChange(e);
-                setSelected(e.target.value);
+                setSelected3(e.target.value);
             }}
         />
     );
@@ -246,15 +293,15 @@ export const RadioGroup_With_Custom_Label =
 const radioButtonArgs: Object = {
     allowDisabledFocus: false,
     ariaLabel: 'Label',
-    label: 'Label',
-    labelPosition: LabelPosition.End,
     checked: false,
     classNames: 'my-radiobutton-class',
     disabled: false,
-    name: 'myRadioButtonName',
-    value: 'Label1',
     id: 'myRadioButtonId',
+    label: 'Label',
+    labelPosition: LabelPosition.End,
+    name: 'myRadioButtonName',
     size: SelectorSize.Medium,
+    value: 'Label1',
 };
 
 Radio_Button.args = {
@@ -265,20 +312,20 @@ Radio_Group.args = {
     allowDisabledFocus: false,
     ariaLabel: 'Radio Group',
     disabled: false,
-    value: 'Radio1',
-    items: [1, 2, 3].map((i) => ({
-        value: `Radio${i}`,
-        label: `Radio${i}`,
-        name: 'group',
+    items: [1, 2, 3].map((i: number) => ({
+        ariaLabel: `Radio${i}`,
         id: `oea2exk-${i}`,
+        label: `Radio${i}`,
+        name: 'group1',
+        value: `Radio${i}`,
     })),
     layout: 'vertical',
     size: SelectorSize.Medium,
+    value: 'Radio1',
 };
 
 Bespoke_Radio_Group.args = {
     ...radioButtonArgs,
-    name: 'roleGroupName',
 };
 
 RadioButton_With_Custom_Label.args = {
@@ -296,11 +343,12 @@ RadioButton_With_Custom_Label.args = {
 
 RadioGroup_With_Custom_Label.args = {
     allowDisabledFocus: false,
-    ariaLabel: 'Radio Group',
+    ariaLabel: 'Radio Group Custom',
     disabled: false,
-    value: 'Radio1',
-    items: [1, 2, 3].map((i) => ({
-        value: `Radio${i}`,
+    items: [1, 2, 3].map((i: number) => ({
+        ariaLabel: `Radio${i}`,
+        checked: i === 1,
+        id: `qgc4gzm-${i}`,
         label: (
             <div>
                 <div style={{ fontWeight: 'bold' }}>
@@ -312,9 +360,10 @@ RadioGroup_With_Custom_Label.args = {
                 </div>
             </div>
         ),
-        name: 'group',
-        id: `oea2exk-${i}`,
+        name: 'group3',
+        value: `Radio${i}`,
     })),
     layout: 'vertical',
     size: SelectorSize.Medium,
+    value: 'Radio1',
 };

--- a/src/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
+++ b/src/src/components/RadioButton/__snapshots__/RadioButton.stories.storyshot
@@ -12,6 +12,15 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
   }
 >
   <div
+    className="field-label medium"
+  >
+    <label
+      className="text-style medium"
+    >
+      Group 1
+    </label>
+  </div>
+  <div
     className="selector selector-medium my-radiobutton-class"
   >
     <input
@@ -19,8 +28,8 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
       aria-label="Label 1"
       checked={true}
       disabled={false}
-      id="myRadioButtonId1"
-      name="roleGroupName"
+      id="myBespokeRadioGroup1-Id1"
+      name="bespokeGroup1"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -28,11 +37,11 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
     />
     <label
       className=""
-      htmlFor="myRadioButtonId1"
+      htmlFor="myBespokeRadioGroup1-Id1"
     >
       <span
         className="radio-button"
-        id="myRadioButtonId1-custom-radio"
+        id="myBespokeRadioGroup1-Id1-custom-radio"
       />
       <span
         className="selector-label selector-label-end"
@@ -49,8 +58,8 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
       aria-label="Label 2"
       checked={false}
       disabled={false}
-      id="myRadioButtonId2"
-      name="roleGroupName"
+      id="myBespokeRadioGroup1-Id2"
+      name="bespokeGroup1"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -58,11 +67,11 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
     />
     <label
       className=""
-      htmlFor="myRadioButtonId2"
+      htmlFor="myBespokeRadioGroup1-Id2"
     >
       <span
         className="radio-button"
-        id="myRadioButtonId2-custom-radio"
+        id="myBespokeRadioGroup1-Id2-custom-radio"
       />
       <span
         className="selector-label selector-label-end"
@@ -79,8 +88,8 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
       aria-label="Label 3"
       checked={false}
       disabled={false}
-      id="myRadioButtonId3"
-      name="roleGroupName"
+      id="myBespokeRadioGroup1-Id3"
+      name="bespokeGroup1"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -88,11 +97,110 @@ exports[`Storyshots Radio Button Bespoke Radio Group 1`] = `
     />
     <label
       className=""
-      htmlFor="myRadioButtonId3"
+      htmlFor="myBespokeRadioGroup1-Id3"
     >
       <span
         className="radio-button"
-        id="myRadioButtonId3-custom-radio"
+        id="myBespokeRadioGroup1-Id3-custom-radio"
+      />
+      <span
+        className="selector-label selector-label-end"
+      >
+        Label 3
+      </span>
+    </label>
+  </div>
+  <div
+    className="field-label medium"
+  >
+    <label
+      className="text-style medium"
+    >
+      Group 2
+    </label>
+  </div>
+  <div
+    className="selector selector-medium my-radiobutton-class"
+  >
+    <input
+      aria-disabled={false}
+      aria-label="Label 1"
+      checked={true}
+      disabled={false}
+      id="myBespokeRadioGroup2-Id1"
+      name="bespokeGroup2"
+      onChange={[Function]}
+      readOnly={true}
+      type="radio"
+      value="label1"
+    />
+    <label
+      className=""
+      htmlFor="myBespokeRadioGroup2-Id1"
+    >
+      <span
+        className="radio-button"
+        id="myBespokeRadioGroup2-Id1-custom-radio"
+      />
+      <span
+        className="selector-label selector-label-end"
+      >
+        Label 1
+      </span>
+    </label>
+  </div>
+  <div
+    className="selector selector-medium my-radiobutton-class"
+  >
+    <input
+      aria-disabled={false}
+      aria-label="Label 2"
+      checked={false}
+      disabled={false}
+      id="myBespokeRadioGroup2-Id2"
+      name="bespokeGroup2"
+      onChange={[Function]}
+      readOnly={true}
+      type="radio"
+      value="label2"
+    />
+    <label
+      className=""
+      htmlFor="myBespokeRadioGroup2-Id2"
+    >
+      <span
+        className="radio-button"
+        id="myBespokeRadioGroup2-Id2-custom-radio"
+      />
+      <span
+        className="selector-label selector-label-end"
+      >
+        Label 2
+      </span>
+    </label>
+  </div>
+  <div
+    className="selector selector-medium my-radiobutton-class"
+  >
+    <input
+      aria-disabled={false}
+      aria-label="Label 3"
+      checked={false}
+      disabled={false}
+      id="myBespokeRadioGroup2-Id3"
+      name="bespokeGroup2"
+      onChange={[Function]}
+      readOnly={true}
+      type="radio"
+      value="label3"
+    />
+    <label
+      className=""
+      htmlFor="myBespokeRadioGroup2-Id3"
+    >
+      <span
+        className="radio-button"
+        id="myBespokeRadioGroup2-Id3-custom-radio"
       />
       <span
         className="selector-label selector-label-end"
@@ -194,10 +302,11 @@ exports[`Storyshots Radio Button Radio Group 1`] = `
   >
     <input
       aria-disabled={false}
+      aria-label="Radio1"
       checked={true}
       disabled={false}
       id="oea2exk-1"
-      name="group"
+      name="group1"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -223,10 +332,11 @@ exports[`Storyshots Radio Button Radio Group 1`] = `
   >
     <input
       aria-disabled={false}
+      aria-label="Radio2"
       checked={false}
       disabled={false}
       id="oea2exk-2"
-      name="group"
+      name="group1"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -252,10 +362,11 @@ exports[`Storyshots Radio Button Radio Group 1`] = `
   >
     <input
       aria-disabled={false}
+      aria-label="Radio3"
       checked={false}
       disabled={false}
       id="oea2exk-3"
-      name="group"
+      name="group1"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -281,7 +392,7 @@ exports[`Storyshots Radio Button Radio Group 1`] = `
 
 exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
 <div
-  aria-label="Radio Group"
+  aria-label="Radio Group Custom"
   className="radio-group vertical radio-group-medium"
   role="group"
 >
@@ -290,10 +401,11 @@ exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
   >
     <input
       aria-disabled={false}
+      aria-label="Radio1"
       checked={true}
       disabled={false}
-      id="oea2exk-1"
-      name="group"
+      id="qgc4gzm-1"
+      name="group3"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -301,11 +413,11 @@ exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
     />
     <label
       className=""
-      htmlFor="oea2exk-1"
+      htmlFor="qgc4gzm-1"
     >
       <span
         className="radio-button"
-        id="oea2exk-1-custom-radio"
+        id="qgc4gzm-1-custom-radio"
       />
       <span
         className="selector-label selector-label-end"
@@ -332,10 +444,11 @@ exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
   >
     <input
       aria-disabled={false}
+      aria-label="Radio2"
       checked={false}
       disabled={false}
-      id="oea2exk-2"
-      name="group"
+      id="qgc4gzm-2"
+      name="group3"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -343,11 +456,11 @@ exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
     />
     <label
       className=""
-      htmlFor="oea2exk-2"
+      htmlFor="qgc4gzm-2"
     >
       <span
         className="radio-button"
-        id="oea2exk-2-custom-radio"
+        id="qgc4gzm-2-custom-radio"
       />
       <span
         className="selector-label selector-label-end"
@@ -374,10 +487,11 @@ exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
   >
     <input
       aria-disabled={false}
+      aria-label="Radio3"
       checked={false}
       disabled={false}
-      id="oea2exk-3"
-      name="group"
+      id="qgc4gzm-3"
+      name="group3"
       onChange={[Function]}
       readOnly={true}
       type="radio"
@@ -385,11 +499,11 @@ exports[`Storyshots Radio Button Radio Group With Custom Label 1`] = `
     />
     <label
       className=""
-      htmlFor="oea2exk-3"
+      htmlFor="qgc4gzm-3"
     >
       <span
         className="radio-button"
-        id="oea2exk-3-custom-radio"
+        id="qgc4gzm-3-custom-radio"
       />
       <span
         className="selector-label selector-label-end"


### PR DESCRIPTION
## SUMMARY:
The Storybook implementation was not scoping the Radio groups properly, this fixes the stories and the args to properly scope the groups and fix selections in both Canvas and Docs views, improving documentation.

## JIRA TASK (Eightfold Employees Only):
ENG-25650

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr and do `yarn`, then `yarn storybook`, verify the changes in Radio stories. or use CodeSandbox CI and implement the groups to verify - using the story implementation as guidance.

