### PR TITLE
fix: pagination: fix onCurrentChange event getting fired on change of total

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -45,6 +45,9 @@ export default {
             ],
             control: { type: 'check' },
         },
+        onCurrentChange: {
+            action: 'onCurrentChange',
+        },
     },
 } as ComponentMeta<typeof Pagination>;
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -65,6 +65,10 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
                 pageSizes.indexOf(pageSize) > -1 ? pageSize : pageSizes[0]
             );
             jumpToPage?.(currentPage);
+        }, []);
+
+        useEffect((): void => {
+            setTotal(total);
         }, [total]);
 
         const previous = (): void => {


### PR DESCRIPTION
## SUMMARY:
fix: pagination: fix onCurrentChange event getting fired on change of total

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-25039

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
