### PR TITLE
fix: navbar: apply scoped css resets to navbar component

### DIFF
--- a/src/components/Navbar/navbar.module.scss
+++ b/src/components/Navbar/navbar.module.scss
@@ -1,4 +1,10 @@
 .navbar-container {
+    @include button-wrapped-reset();
+    @include input-reset();
+    @include select-reset();
+    @include selector-reset();
+    @include textarea-reset();
+
     align-items: center;
     background-color: var(--navbar-background);
     color: var(--navbar-text-color);

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -1,6 +1,5 @@
-@mixin backdrop {
+@mixin surface-layout {
     position: fixed;
-    background-color: $all-backdrops;
     top: 0;
     right: 0;
     z-index: $z-index-500;
@@ -12,7 +11,20 @@
     opacity: 0;
 }
 
-/** Scoped reset taken from normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+@mixin backdrop {
+    @include surface-layout();
+
+    background-color: $all-backdrops;
+}
+
+@mixin no-backdrop {
+    @include surface-layout();
+
+    background: none;
+}
+
+/** Scoped reset taken from normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css
+    To be applied directly to un-wrapped buttons (The octuple button component is not wrapped) */
 @mixin button-reset() {
     /**
     * 1. Change the font styles in all browsers.
@@ -66,6 +78,73 @@
     font: inherit;
     cursor: pointer;
     outline: inherit;
+}
+
+/** Scoped reset taken from normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css
+    To be applied to components that contain buttons */
+@mixin button-wrapped-reset() {
+    /**
+    * 1. Change the font styles in all browsers.
+    * 2. Remove the margin in Firefox and Safari.
+    */
+
+    button {
+        font-family: inherit; /* 1 */
+        font-size: 100%; /* 1 */
+        line-height: 1.15; /* 1 */
+        margin: 0; /* 2 */
+    }
+
+    /**
+    * Show the overflow in IE.
+    * 1. Show the overflow in Edge.
+    */
+
+    button {
+        overflow: visible;
+    }
+
+    /**
+    * Remove the inheritance of text transform in Edge, Firefox, and IE.
+    * 1. Remove the inheritance of text transform in Firefox.
+    */
+
+    button {
+        text-transform: none;
+    }
+
+    /**
+    * Correct the inability to style clickable types in iOS and Safari.
+    */
+
+    button {
+        -webkit-appearance: button;
+    }
+
+    [type='button'],
+    [type='reset'],
+    [type='submit'] {
+        -webkit-appearance: button;
+    }
+
+    /**
+    * Remove the inner border and padding in Firefox.
+    */
+
+    button::-moz-focus-inner {
+        border-style: none;
+        padding: 0;
+    }
+
+    button {
+        background: none;
+        color: inherit;
+        border: none;
+        padding: 0;
+        font: inherit;
+        cursor: pointer;
+        outline: inherit;
+    }
 }
 
 /** Scoped reset taken from normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */


### PR DESCRIPTION
## SUMMARY:
The NavBar component may contain  non-octuple components. Need to scope resets here too.

## JIRA TASK (Eightfold Employees Only):
ENG-26289

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request
