### PR TITLE
fix: input: fixes rectangle shape for theme 2 input and textarea

### DIFF
--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -7,7 +7,7 @@
 
         background-color: var(--background-color);
         border: 1px solid var(--border-color);
-        border-radius: $corner-radius-xl;
+        border-radius: $corner-radius-m;
         box-sizing: border-box;
         color: var(--grey-color-60);
         font-family: 'Source Sans Pro', sans-serif;
@@ -871,7 +871,7 @@
     .text-area {
         background-color: var(--background-color);
         border: 1px solid var(--border-color);
-        border-radius: $corner-radius-s;
+        border-radius: $corner-radius-m;
         box-sizing: border-box;
         color: var(--grey-color-60);
         font-family: 'Source Sans Pro', sans-serif;


### PR DESCRIPTION
## SUMMARY:
This changes to make pill the default shape regressed the default rectangle shape in css. This change reverts the regression and updates the radius to map to theme 2.

## JIRA TASK (Eightfold Employees Only):
ENG-26634

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and run `yarn`, then `yarn storybook`, then verify the change in Input stories - or use CodeSandbox CI and implement a `TextInput` and `TextArea` with `shape={TextInputShape.Rectangle}`