### PR TITLE
fix: button: use configprovider focus visible styles

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -172,6 +172,12 @@
             background-color: var(--button-counter-active-background-color);
         }
     }
+
+    /** Hides the browser default keyboard focus-visible styles
+        use the ConfigProvider instead */
+    &:focus-visible {
+        outline: none;
+    }
 }
 
 .button-text-large {

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -173,8 +173,8 @@
         }
     }
 
-    /** Hides the browser default keyboard focus-visible styles
-        use the ConfigProvider instead */
+    // Hides the browser default keyboard focus-visible styles.
+    // Use the ConfigProvider instead.
     &:focus-visible {
         outline: none;
     }

--- a/src/components/Link/link.module.scss
+++ b/src/components/Link/link.module.scss
@@ -10,4 +10,19 @@
     &.primary {
         color: var(--primary-color);
     }
+
+    /** Hides the browser default keyboard focus-visible styles
+        use the ConfigProvider instead */
+    &:focus-visible {
+        outline: none;
+    }
+}
+
+:global(.focus-visible) {
+    .link-style {
+        &.focus-visible,
+        &:focus-visible {
+            box-shadow: $focus-visible-box-shadow;
+        }
+    }
 }

--- a/src/components/Link/link.module.scss
+++ b/src/components/Link/link.module.scss
@@ -11,8 +11,8 @@
         color: var(--primary-color);
     }
 
-    /** Hides the browser default keyboard focus-visible styles
-        use the ConfigProvider instead */
+    // Hides the browser default keyboard focus-visible styles.
+    // Use the ConfigProvider instead.
     &:focus-visible {
         outline: none;
     }

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -85,6 +85,12 @@
         display: flex;
         align-content: flex-start;
     }
+
+    /** Hides the browser default keyboard focus-visible styles
+        use the ConfigProvider instead */
+    &:focus-visible {
+        outline: none;
+    }
 }
 
 :global(.focus-visible) {

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -86,8 +86,8 @@
         align-content: flex-start;
     }
 
-    /** Hides the browser default keyboard focus-visible styles
-        use the ConfigProvider instead */
+    // Hides the browser default keyboard focus-visible styles.
+    // Use the ConfigProvider instead.
     &:focus-visible {
         outline: none;
     }

--- a/src/components/Table/Styles/table.module.scss
+++ b/src/components/Table/Styles/table.module.scss
@@ -619,8 +619,8 @@
                 margin-right: $space-s;
             }
 
-            /** Hides the browser default keyboard focus-visible styles
-                use the ConfigProvider instead */
+            // Hides the browser default keyboard focus-visible styles.
+            // Use the ConfigProvider instead.
             &:focus-visible {
                 outline: none;
             }

--- a/src/components/Table/Styles/table.module.scss
+++ b/src/components/Table/Styles/table.module.scss
@@ -618,6 +618,12 @@
                     ceil(calc((14 * 1.4 - 2 * 3) / 2));
                 margin-right: $space-s;
             }
+
+            /** Hides the browser default keyboard focus-visible styles
+                use the ConfigProvider instead */
+            &:focus-visible {
+                outline: none;
+            }
         }
 
         tr {
@@ -792,6 +798,19 @@
                     &-active {
                         background-color: $table-sticky-scroll-bar-active-background-color;
                     }
+                }
+            }
+        }
+    }
+}
+
+:global(.focus-visible) {
+    .table-wrapper {
+        .table {
+            &-row-expand-icon {
+                &.focus-visible,
+                &:focus-visible {
+                    box-shadow: $focus-visible-box-shadow;
                 }
             }
         }

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -73,6 +73,12 @@
         .icon + .label:not(:empty) {
             margin-left: $space-xs;
         }
+
+        /** Hides the browser default keyboard focus-visible styles
+            use the ConfigProvider instead */
+        &:focus-visible {
+            outline: none;
+        }
     }
 
     &.small {
@@ -109,6 +115,17 @@
             }
             .tab-indicator {
                 display: none;
+            }
+        }
+    }
+}
+
+:global(.focus-visible) {
+    .tab-wrap {
+        .tab {
+            &.focus-visible,
+            &:focus-visible {
+                box-shadow: $focus-visible-box-shadow;
             }
         }
     }

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -74,8 +74,8 @@
             margin-left: $space-xs;
         }
 
-        /** Hides the browser default keyboard focus-visible styles
-            use the ConfigProvider instead */
+        // Hides the browser default keyboard focus-visible styles.
+        // Use the ConfigProvider instead.
         &:focus-visible {
             outline: none;
         }


### PR DESCRIPTION
## SUMMARY:
A recent update to remove some global resets to `<button>` elements regressed the `focus-visible` styles. This change fixes and applies the global style to all buttons in Octuple components

## JIRA TASK (Eightfold Employees Only):
ENG-26733

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
pull the pr branch and run `yarn`, then `yarn install` and verify via the `ConfigProvider` story the styles via tabbing around the components (excluding the color pickers). Or implement a `button` in a `ConfigProvider` using CodeSandbox CI.
