### PR TITLE
fix: added transparency prop to system ui button

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -285,7 +285,7 @@ System_UI.args = {
     ...buttonArgs,
     ariaLabel: 'System UI Button',
     text: 'System UI Button',
-    transparentBg: true,
+    transparent: true,
 };
 
 Default.args = {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -285,7 +285,7 @@ System_UI.args = {
     ...buttonArgs,
     ariaLabel: 'System UI Button',
     text: 'System UI Button',
-    transparent: true,
+    transparent: false,
 };
 
 Default.args = {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -285,6 +285,7 @@ System_UI.args = {
     ...buttonArgs,
     ariaLabel: 'System UI Button',
     text: 'System UI Button',
+    transparentBg: true,
 };
 
 Default.args = {

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -209,6 +209,7 @@ export interface ButtonProps extends NativeButtonProps {
     toggle?: boolean;
     /**
      * The button will remain transparent
+     * @default false
      */
     transparent?: boolean;
 }

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -210,5 +210,5 @@ export interface ButtonProps extends NativeButtonProps {
     /**
      * The button will remain transparent
      */
-    transparentBg?: boolean;
+    transparent?: boolean;
 }

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -207,4 +207,8 @@ export interface ButtonProps extends NativeButtonProps {
      * The button is a toggle button with distinct on and off states.
      */
     toggle?: boolean;
+    /**
+     * The button will remain transparent
+     */
+    transparentBg?: boolean;
 }

--- a/src/components/Button/SystemUIButton/SystemUIButton.tsx
+++ b/src/components/Button/SystemUIButton/SystemUIButton.tsx
@@ -38,6 +38,7 @@ export const SystemUIButton: FC<ButtonProps> = React.forwardRef(
             style,
             toggle,
             buttonWidth,
+            transparentBg,
             ...rest
         },
         ref: Ref<HTMLButtonElement>
@@ -46,6 +47,7 @@ export const SystemUIButton: FC<ButtonProps> = React.forwardRef(
             classNames,
             styles.button,
             styles.buttonSystemUi,
+            { [styles.transparentBg]: !!transparentBg },
         ]);
 
         return (

--- a/src/components/Button/SystemUIButton/SystemUIButton.tsx
+++ b/src/components/Button/SystemUIButton/SystemUIButton.tsx
@@ -38,7 +38,7 @@ export const SystemUIButton: FC<ButtonProps> = React.forwardRef(
             style,
             toggle,
             buttonWidth,
-            transparentBg,
+            transparent = false,
             ...rest
         },
         ref: Ref<HTMLButtonElement>
@@ -47,7 +47,7 @@ export const SystemUIButton: FC<ButtonProps> = React.forwardRef(
             classNames,
             styles.button,
             styles.buttonSystemUi,
-            { [styles.transparentBg]: !!transparentBg },
+            { [styles.transparent]: transparent },
         ]);
 
         return (

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -349,15 +349,15 @@
     --color: var(--grey-color-60);
     color: var(--color);
 
-    &:not(.transparent-bg) {
+    &:not(.transparent) {
         background-color: var(--bg);
     }
 
-    &:not(.transparent-bg):hover {
+    &:not(.transparent):hover {
         --bg: var(--grey-color-10);
     }
 
-    &:not(.transparent-bg):active {
+    &:not(.transparent):active {
         --bg: var(--grey-color-20);
     }
 }

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -348,13 +348,16 @@
     --bg: var(--background-color);
     --color: var(--grey-color-60);
     color: var(--color);
-    background-color: var(--bg);
 
-    &:hover {
+    &:not(.transparent-bg) {
+        background-color: var(--bg);
+    }
+
+    &:not(.transparent-bg):hover {
         --bg: var(--grey-color-10);
     }
 
-    &:active {
+    &:not(.transparent-bg):active {
         --bg: var(--grey-color-20);
     }
 }

--- a/src/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -381,7 +381,7 @@ exports[`Storyshots Button System UI 1`] = `
 <button
   aria-disabled={false}
   aria-label="System UI Button"
-  className="my-btn-class button button-system-ui transparent-bg pill-shape icon-left"
+  className="my-btn-class button button-system-ui transparent pill-shape icon-left"
   data-test-id="my-btn-test-id"
   defaultChecked={false}
   disabled={false}

--- a/src/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -381,7 +381,7 @@ exports[`Storyshots Button System UI 1`] = `
 <button
   aria-disabled={false}
   aria-label="System UI Button"
-  className="my-btn-class button button-system-ui pill-shape icon-left"
+  className="my-btn-class button button-system-ui transparent-bg pill-shape icon-left"
   data-test-id="my-btn-test-id"
   defaultChecked={false}
   disabled={false}


### PR DESCRIPTION
## SUMMARY:
Exposed prop to enable transparent background in SystemUI button

https://user-images.githubusercontent.com/109717425/185600355-1ff534fe-790c-4133-acb5-20e490e8a15c.mov


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-27005

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
