### PR TITLE
fix: added fix for split btn icon

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -347,6 +347,11 @@ Split.args = {
     split: true,
     splitButtonChecked: false,
     text: 'Split Button',
+    splitButtonProps: {
+        iconProps: {
+            path: IconName.mdiClockOutline,
+        },
+    },
 };
 
 Split_With_Counter.args = {

--- a/src/components/Button/SplitButton/SplitButton.tsx
+++ b/src/components/Button/SplitButton/SplitButton.tsx
@@ -134,15 +134,18 @@ export const SplitButton: FC<SplitButtonProps> = React.forwardRef(
             return iconSize;
         };
 
+        const getButtonIconPath = (): IconName =>
+            iconProps?.path
+                ? iconProps.path
+                : checked
+                ? IconName.mdiChevronUp
+                : IconName.mdiChevronDown;
+
         const getButtonIcon = (): JSX.Element => (
             <Icon
                 {...iconProps}
                 classNames={styles.icon}
-                path={
-                    iconProps?.path || checked
-                        ? IconName.mdiChevronUp
-                        : IconName.mdiChevronDown
-                }
+                path={getButtonIconPath()}
                 size={getButtonIconSize()}
             />
         );


### PR DESCRIPTION
## SUMMARY:
Fixing the slipt button icon path.

https://user-images.githubusercontent.com/109717425/185612690-d11c09e1-09d8-4352-8f17-9a50f7825895.mov


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-27267

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
