### PR TITLE
fix: update page as currentPage prop value updates

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -69,6 +69,10 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
             setTotal(total);
         }, [total]);
 
+        useEffect((): void => {
+            setCurrentPage(currentPage);
+        }, [currentPage]);
+
         const previous = (): void => {
             const oldVal: number = _currentPage;
             const newVal: number = _currentPage - 1;


### PR DESCRIPTION
## SUMMARY:
Added outside control for `_currentPage` in Pagination
This fix will be needed for https://github.com/EightfoldAI/octuple/pull/322 so that we can set the page back to 1 when certain action is triggered

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/jira/software/c/projects/ENG/boards/29?modal=detail&selectedIssue=ENG-26836
https://eightfoldai.atlassian.net/jira/software/c/projects/ENG/boards/29?modal=detail&selectedIssue=ENG-27400

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [x] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
