### PR TITLE
fix: menuitem: add no wrap so long text doesnt wrap to next line

### DIFF
--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -10,6 +10,7 @@
     font-weight: $text-font-weight-regular;
     transition: all $motion-duration-extra-fast $motion-easing-easeinout 0s;
     margin: $space-xxs 0;
+    white-space: nowrap;
 
     &.large {
         height: 44px;
@@ -114,6 +115,7 @@
     border-bottom: solid 1px var(--border-color);
     margin: 0 $space-m $space-m;
     font-weight: $text-font-weight-semibold;
+    white-space: nowrap;
 
     &:first-child {
         padding-top: 0;


### PR DESCRIPTION
## SUMMARY:
fix: menuitem: add no wrap do long text doesnt wrap to next line

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
skip