### PR TITLE
feat: select: add resizeobserver usemaxvisiblesections hook and dynamic pills

### DIFF
--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -1,7 +1,7 @@
 import { OcBaseProps } from '../OcBase';
 import { IconProps } from '../Icon';
 
-interface AccordionBaseProps extends OcBaseProps<HTMLSpanElement> {
+interface AccordionBaseProps extends OcBaseProps<HTMLDivElement> {
     /**
      * Accordion is in an expanded state or not
      * @default false

--- a/src/components/CheckBox/CheckBoxGroup.tsx
+++ b/src/components/CheckBox/CheckBoxGroup.tsx
@@ -21,7 +21,7 @@ export const CheckBoxGroup: FC<CheckboxGroupProps> = React.forwardRef(
             value,
             ...rest
         },
-        ref: Ref<HTMLDivElement>
+        ref: Ref<HTMLInputElement>
     ) => {
         const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
         const mediumScreenActive: boolean = useMatchMedia(Breakpoints.Medium);

--- a/src/components/DateTimePicker/DatePicker/Styles/mixins.scss
+++ b/src/components/DateTimePicker/DatePicker/Styles/mixins.scss
@@ -8,10 +8,12 @@ $picker-input-padding-vertical: max(
             round(
                     (
                             (
-                                    strip-units($picker-input-height-s) -
-                                        strip-units($picker-font-size-m) *
-                                        strip-units($picker-line-height-m)
-                                ) / 2
+                                (
+                                        strip-units($picker-input-height-s) -
+                                            strip-units($picker-font-size-m) *
+                                            strip-units($picker-line-height-m)
+                                    ) / 2
+                            )
                         ) * 10
                 ) / 10
         ) - strip-units($picker-border-width),
@@ -25,7 +27,7 @@ $picker-input-padding-vertical: max(
             strip-units($font-size) * strip-units($padding-horizontal)
         ) + 2;
     $padding-top: max(
-        ((strip-units($input-height) - strip-units($font-height)) / 2),
+        calc((strip-units($input-height) - strip-units($font-height)) / 2),
         0
     );
     $padding-bottom: max(

--- a/src/components/DateTimePicker/DatePicker/datepicker.module.scss
+++ b/src/components/DateTimePicker/DatePicker/datepicker.module.scss
@@ -119,7 +119,7 @@
     }
 
     &-dropdown-range {
-        padding: ($picker-arrow-size * 2 / 3) 0;
+        padding: calc($picker-arrow-size * 2 / 3) 0;
 
         &-hidden {
             display: none;
@@ -127,7 +127,7 @@
     }
 
     &-partial > &-time-partial {
-        padding-top: ($space-xs / 2);
+        padding-top: calc($space-xs / 2);
     }
 
     &-ranges {
@@ -135,7 +135,7 @@
         padding: ($space-xs / 2) $space-s;
         overflow: hidden;
         line-height: $picker-line-height-m - 2 * $picker-border-width -
-            ($space-xs / 2);
+            calc($space-xs / 2);
         text-align: left;
         list-style: none;
 
@@ -159,17 +159,17 @@
 
     &-large &-ranges {
         line-height: $picker-line-height-l - 2 * $picker-border-width -
-            ($space-xs / 2);
+            calc($space-xs / 2);
     }
 
     &-medium &-ranges {
         line-height: $picker-line-height-m - 2 * $picker-border-width -
-            ($space-xs / 2);
+            calc($space-xs / 2);
     }
 
     &-small &-ranges {
         line-height: $picker-line-height-s - 2 * $picker-border-width -
-            ($space-xs / 2);
+            calc($space-xs / 2);
     }
 
     &-large {

--- a/src/components/DateTimePicker/Internal/ocpicker.module.scss
+++ b/src/components/DateTimePicker/Internal/ocpicker.module.scss
@@ -952,7 +952,7 @@
         display: flex;
         flex: none;
         align-self: center;
-        margin-left: ($space-xs / 2);
+        margin-left: calc($space-xs / 2);
         line-height: 1;
         pointer-events: none;
 
@@ -1009,14 +1009,14 @@
         &-placement-topLeft,
         &-placement-topRight {
             .picker-range-arrow {
-                bottom: $picker-arrow-size / 2 + 1px;
+                bottom: calc($picker-arrow-size / 2) + 1px;
                 transform: rotate(135deg);
             }
         }
         &-placement-bottomLeft,
         &-placement-bottomright {
             .picker-range-arrow {
-                top: $picker-arrow-size / 2 + 1px;
+                top: calc($picker-arrow-size / 2) + 1px;
                 transform: rotate(-45deg);
             }
         }
@@ -1056,7 +1056,8 @@
             &:before {
                 width: $picker-arrow-size;
                 height: $picker-arrow-size;
-                border: $picker-arrow-size / 2 solid $picker-border-color-active;
+                border: calc($picker-arrow-size / 2) solid
+                    $picker-border-color-active;
                 border-color: $picker-border-color-active
                     $picker-border-color-active transparent transparent;
             }
@@ -1064,7 +1065,7 @@
             &:after {
                 width: $picker-arrow-size - 2px;
                 height: $picker-arrow-size - 2px;
-                border: ($picker-arrow-size - 2px) / 2 solid
+                border: calc(calc($picker-arrow-size - 2px) / 2) solid
                     $picker-border-color-active;
                 border-color: $picker-background-color $picker-background-color
                     transparent transparent;
@@ -1158,7 +1159,8 @@
 
     &-placement-bottomLeft {
         .picker-range-arrow {
-            top: ($picker-arrow-size / 2) - ($picker-arrow-size / 3) + 0.7px;
+            top: calc($picker-arrow-size / 2) - calc($picker-arrow-size / 3) +
+                0.7px;
             display: block;
             transform: rotate(-135deg) translateY(1px);
         }
@@ -1166,7 +1168,8 @@
 
     &-placement-topLeft {
         .picker-range-arrow {
-            bottom: ($picker-arrow-size / 2) - ($picker-arrow-size / 3) + 0.7px;
+            bottom: calc($picker-arrow-size / 2) - calc($picker-arrow-size / 3) +
+                0.7px;
             display: block;
             transform: rotate(45deg);
         }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -56,6 +56,8 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         closeOnOutsideClick = true,
         visible,
         onClickOutside,
+        width,
+        height,
     }) => {
         const [mergedVisible, setVisible] = useMergedState<boolean>(false, {
             value: visible,
@@ -135,6 +137,8 @@ export const Dropdown: FC<DropdownProps> = React.memo(
             position: strategy,
             top: y ?? '',
             left: x ?? '',
+            width: width ?? '',
+            height: height ?? '',
         };
 
         const getReference = (): JSX.Element => {

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -81,4 +81,12 @@ export interface DropdownProps {
      * @param event
      */
     onClickOutside?: (event: MouseEvent) => void;
+    /**
+     * Manually control the width of the dropdown
+     */
+    width?: number;
+    /**
+     * Manually control the height of the dropdown
+     */
+    height?: number;
 }

--- a/src/components/Grid/Styles/mixins.scss
+++ b/src/components/Grid/Styles/mixins.scss
@@ -2,22 +2,22 @@
     @if $index > 0 {
         .col#{$class}-#{$index} {
             display: block;
-            flex: 0 0 percentage(($index / $grid-columns));
-            max-width: percentage(($index / $grid-columns));
+            flex: 0 0 percentage(calc($index / $grid-columns));
+            max-width: percentage(calc($index / $grid-columns));
         }
         .col#{$class}-push-#{$index} {
-            left: percentage(($index / $grid-columns));
+            left: percentage(calc($index / $grid-columns));
         }
         .col#{$class}-pull-#{$index} {
-            right: percentage(($index / $grid-columns));
+            right: percentage(calc($index / $grid-columns));
         }
         .col#{$class}-offset-#{$index} {
-            margin-left: percentage(($index / $grid-columns));
+            margin-left: percentage(calc($index / $grid-columns));
         }
         .col#{$class}-order-#{$index} {
             order: $index;
         }
-        @include loop-grid-columns(($index - 1), $class);
+        @include loop-grid-columns(calc($index - 1), $class);
     }
 
     @if $index == 0 {

--- a/src/components/Grid/Styles/rtl.scss
+++ b/src/components/Grid/Styles/rtl.scss
@@ -17,7 +17,7 @@
         .col#{$class}-push-#{$index} {
             // reset property in RTL direction
             &.col-rtl {
-                right: percentage(($index / $grid-columns));
+                right: percentage(calc($index / $grid-columns));
                 left: auto;
             }
         }
@@ -26,14 +26,14 @@
             // reset property in RTL direction
             &.col-rtl {
                 right: auto;
-                left: percentage(($index / $grid-columns));
+                left: percentage(calc($index / $grid-columns));
             }
         }
 
         .col#{$class}-offset-#{$index} {
             // reset property in RTL direction
             &.col-rtl {
-                margin-right: percentage(($index / $grid-columns));
+                margin-right: percentage(calc($index / $grid-columns));
                 margin-left: 0;
             }
         }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -20,6 +20,7 @@ export const Icon: FC<IconProps> = ({
     rotate,
     size = IconSize.Medium,
     spin,
+    style,
     title,
     vertical,
     'data-test-id': dataTestId,
@@ -65,6 +66,7 @@ export const Icon: FC<IconProps> = ({
             className={iconClassNames}
             id={id}
             role={role}
+            style={style}
         >
             {iconComponent}
         </span>

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -10,8 +10,12 @@ export enum IconSize {
 }
 
 export interface IconProps
-    extends OcBaseProps<HTMLSpanElement>,
+    extends React.HTMLAttributes<HTMLSpanElement>,
         Omit<MdiIconProps, 'path'> {
+    /**
+     * Custom classnames of the component
+     */
+    classNames?: string;
     /**
      * The icon svg path name.
      */
@@ -75,4 +79,8 @@ export interface IconProps
      * Name of the icon as defined in icomoon app
      */
     icomoonIconName?: string;
+    /**
+     * Unique id used to target element for testing
+     */
+    'data-test-id'?: string;
 }

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -35,6 +35,10 @@ export interface IconProps
      */
     horizontal?: boolean;
     /**
+     * Style of the icon wrapper
+     */
+    style?: React.CSSProperties;
+    /**
      * The icon id.
      */
     id?: string;

--- a/src/components/Label/Label.types.ts
+++ b/src/components/Label/Label.types.ts
@@ -1,7 +1,8 @@
-import { ButtonProps } from '../Button';
+import { ButtonIconAlign, ButtonTextAlign } from '../Button';
 import { Placement, Strategy } from '@floating-ui/react-dom';
 import { TooltipTheme } from '../Tooltip';
 import { OcBaseProps } from '../OcBase';
+import { IconProps } from '../Icon';
 
 export enum LabelSize {
     Large = 'large',
@@ -9,20 +10,7 @@ export enum LabelSize {
     Small = 'small',
 }
 
-export interface LabelIconButtonProps
-    extends Omit<
-        ButtonProps,
-        | 'buttonWidth'
-        | 'checked'
-        | 'htmlType'
-        | 'onContextMenu'
-        | 'shape'
-        | 'size'
-        | 'split'
-        | 'splitButtonChecked'
-        | 'splitButtonProps'
-        | 'toggle'
-    > {
+export interface LabelIconButtonProps {
     /**
      * The label icon button is shown.
      * @default false
@@ -47,6 +35,80 @@ export interface LabelIconButtonProps
      * @default absolute
      */
     toolTipPositionStrategy?: Strategy;
+    /**
+     * Allows focus on the button when it's disabled.
+     */
+    allowDisabledFocus?: boolean;
+    /**
+     * The button icon alignment.
+     * @default ButtonIconAlign.Left
+     */
+    alignIcon?: ButtonIconAlign;
+    /**
+     * The button text alignment.
+     * @default ButtonTextAlign.Center
+     */
+    alignText?: ButtonTextAlign;
+    /**
+     * The button aria-label text.
+     */
+    ariaLabel?: string;
+    /**
+     * The button class names.
+     */
+    classNames?: string;
+    /**
+     * The button counter string.
+     */
+    counter?: string;
+    /**
+     * The button disabled state.
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * The button disruptive state.
+     * @default false
+     */
+    disruptive?: boolean;
+    /**
+     * The button drop shadow state.
+     * @default false
+     */
+    dropShadow?: boolean;
+    /**
+     * The button icon props.
+     */
+    iconProps?: IconProps;
+    /**
+     * The button id.
+     */
+    id?: string;
+    /**
+     * The button onClick event handler.
+     */
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    /**
+     * The button style.
+     */
+    style?: React.CSSProperties;
+    /**
+     * The button text.
+     */
+    text?: string;
+    /**
+     * The button will remain transparent
+     * @default false
+     */
+    transparent?: boolean;
+    /**
+     * If the button is in loading state
+     */
+    loading?: boolean;
+    /**
+     * Unique id used to target element for testing
+     */
+    'data-test-id'?: string;
 }
 
 export interface LabelProps extends OcBaseProps<HTMLDivElement> {

--- a/src/components/Layout/Layout.types.ts
+++ b/src/components/Layout/Layout.types.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import { OcBaseProps } from '../OcBase';
 
 export interface GeneratorProps {
     cssModifier: string;
@@ -13,7 +12,11 @@ export interface GeneratorProps {
         | 'section';
 }
 
-export interface BasicProps extends OcBaseProps<HTMLDivElement> {
+export interface BasicProps extends React.HTMLAttributes<HTMLDivElement> {
+    /**
+     * Custom classnames of the component
+     */
+    classNames?: string;
     /**
      * The layout has an aside.
      */
@@ -26,6 +29,10 @@ export interface BasicProps extends OcBaseProps<HTMLDivElement> {
      * The layout uses octuple styles.
      */
     octupleStyles?: boolean;
+    /**
+     * Unique id used to target element for testing
+     */
+    'data-test-id'?: string;
 }
 
 export interface LayoutContextProps {
@@ -68,7 +75,7 @@ export const AsideContext: React.Context<AsideContextProps> =
 
 export type CollapseType = 'clickTrigger' | 'responsive';
 
-export interface AsideProps extends OcBaseProps<HTMLDivElement> {
+export interface AsideProps extends React.HTMLAttributes<HTMLDivElement> {
     /**
      * The aside class names.
      */
@@ -81,6 +88,10 @@ export interface AsideProps extends OcBaseProps<HTMLDivElement> {
      * The aside breakpoints, to enable a responsive layout.
      */
     breakpoint?: 'xs' | 'sm' | 'md' | 'lg';
+    /**
+     * Custom classnames of the component
+     */
+    classNames?: string;
     /**
      * Sets whether the aside is collapsed.
      */
@@ -126,4 +137,8 @@ export interface AsideProps extends OcBaseProps<HTMLDivElement> {
      * The aside width trigger style.
      */
     zeroWidthTriggerStyle?: React.CSSProperties;
+    /**
+     * Unique id used to target element for testing
+     */
+    'data-test-id'?: string;
 }

--- a/src/components/Layout/layout.module.scss
+++ b/src/components/Layout/layout.module.scss
@@ -128,7 +128,7 @@
                 width: $layout-zero-trigger-width;
                 height: $layout-zero-trigger-height;
                 color: $layout-trigger-color;
-                font-size: ($layout-zero-trigger-width / 2);
+                font-size: calc($layout-zero-trigger-width / 2);
                 line-height: $layout-zero-trigger-height;
                 text-align: center;
                 background: var(--primary-color);

--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -33,9 +33,11 @@ export interface MenuItemProps {
     size?: MenuSize;
 }
 
+type NativeMenuButtonProps = Omit<OcBaseProps<HTMLButtonElement>, 'children'>;
+
 export interface MenuItemButtonProps
     extends MenuItemProps,
-        OcBaseProps<Omit<HTMLButtonElement, 'children'>> {
+        NativeMenuButtonProps {
     /**
      * Menu item icon props
      */

--- a/src/components/OcBase/Base.types.ts
+++ b/src/components/OcBase/Base.types.ts
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, Ref } from 'react';
 
 export interface OcBaseProps<T> extends HTMLAttributes<T> {
     /**
@@ -9,4 +9,8 @@ export interface OcBaseProps<T> extends HTMLAttributes<T> {
      * Unique id used to target element for testing
      */
     'data-test-id'?: string;
+    /**
+     * The component ref
+     */
+    ref?: Ref<T>;
 }

--- a/src/components/Panel/panel.module.scss
+++ b/src/components/Panel/panel.module.scss
@@ -178,7 +178,7 @@
         }
 
         .header-action-buttons {
-            margin-right: -$space-xl / 2;
+            margin-right: calc(-#{$space-xl} / 2);
         }
     }
 }

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -9,6 +9,7 @@ import { ButtonSize, DefaultButton } from '../Button';
 export const Pill: FC<PillProps> = React.forwardRef(
     (
         {
+            classNames,
             color,
             label,
             iconProps,
@@ -19,6 +20,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
             pillButtonProps,
             type = PillType.default,
             size = PillSize.Large,
+            style,
             ...rest
         },
         ref: Ref<HTMLDivElement>
@@ -43,7 +45,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
         ]);
         const tagClassName: string = mergeClasses([
             styles.tagPills,
-            rest.classNames,
+            classNames,
             { [styles.red]: theme === 'red' },
             { [styles.redOrange]: theme === 'redOrange' },
             { [styles.orange]: theme === 'orange' },
@@ -59,7 +61,12 @@ export const Pill: FC<PillProps> = React.forwardRef(
             { [styles.xsmall]: size === PillSize.XSmall },
         ]);
         return (
-            <div {...rest} className={tagClassName} style={{ color }} ref={ref}>
+            <div
+                {...rest}
+                className={tagClassName}
+                style={{ ...style, color }}
+                ref={ref}
+            >
                 {iconProps && (
                     <Icon
                         {...iconProps}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -9,7 +9,6 @@ import {
     SelectSize,
 } from './Select.types';
 import { Stories } from '@storybook/addon-docs';
-import { TextInputWidth } from '../Inputs';
 
 const defaultOptions: SelectOption[] = [
     {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -9,6 +9,7 @@ import {
     SelectSize,
 } from './Select.types';
 import { Stories } from '@storybook/addon-docs';
+import { TextInputWidth } from '../Inputs';
 
 const defaultOptions: SelectOption[] = [
     {
@@ -108,18 +109,10 @@ export default {
 } as ComponentMeta<typeof Select>;
 
 const Wrapper: FC<SelectProps> = ({ children }) => {
-    return (
-        <div
-            style={{
-                width: '200px',
-            }}
-        >
-            {children}
-        </div>
-    );
+    return <div>{children}</div>;
 };
 
-const DynamicSelect: FC<SelectProps> = () => {
+const DynamicSelect: FC<SelectProps> = (args) => {
     const timer = useRef<ReturnType<typeof setTimeout>>(null);
     const [options, setOptions] = useState([]);
     const [isLoading, setIsLoading] = useState(false);
@@ -139,6 +132,7 @@ const DynamicSelect: FC<SelectProps> = () => {
     };
     return (
         <Select
+            {...args}
             filterable={true}
             isLoading={isLoading}
             loadOptions={loadOptions}
@@ -150,19 +144,20 @@ const DynamicSelect: FC<SelectProps> = () => {
 const Basic_Story: ComponentStory<typeof Select> = (args) => (
     <>
         <Wrapper>
-            <Select {...args}></Select>
+            <Select {...args} />
         </Wrapper>
     </>
 );
 
 const Dynamic_Story: ComponentStory<typeof Select> = (args) => (
     <Wrapper>
-        <DynamicSelect {...args}></DynamicSelect>
+        <DynamicSelect {...args} />
     </Wrapper>
 );
 
 export type SelectStory = ComponentStory<React.FC<SelectProps>>;
 export const Basic: SelectStory = Basic_Story.bind({});
+export const Dynamic_Width: SelectStory = Basic_Story.bind({});
 export const With_DefaultValue: SelectStory = Basic_Story.bind({});
 export const Disabled: SelectStory = Basic_Story.bind({});
 export const Options_Disabled: SelectStory = Basic_Story.bind({});
@@ -175,12 +170,21 @@ export const Dynamic: SelectStory = Dynamic_Story.bind({});
 const SelectArgs: SelectProps = {
     classNames: 'octuple-select-class',
     'data-test-id': 'octuple-select-test-id',
-    style: {},
+    style: {
+        width: 256,
+    },
     options: defaultOptions,
 };
 
 Basic.args = {
     ...SelectArgs,
+};
+
+Dynamic_Width.args = {
+    ...SelectArgs,
+    style: {
+        width: '100%',
+    },
 };
 
 With_DefaultValue.args = {
@@ -234,6 +238,9 @@ Multiple.args = {
         ...Basic.args.textInputProps,
         clearable: true,
     },
+    style: {
+        width: '100%',
+    },
 };
 
 Multiple_With_NoFilter.args = {
@@ -243,6 +250,9 @@ Multiple_With_NoFilter.args = {
     textInputProps: {
         ...Basic.args.textInputProps,
         clearable: true,
+    },
+    style: {
+        width: '100%',
     },
 };
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -10,6 +10,20 @@ Enzyme.configure({ adapter: new Adapter() });
 
 let matchMedia: any;
 
+class ResizeObserver {
+    observe() {
+        // do nothing
+    }
+    unobserve() {
+        // do nothing
+    }
+    disconnect() {
+        // do nothing
+    }
+}
+
+window.ResizeObserver = ResizeObserver;
+
 describe('Select', () => {
     beforeAll(() => {
         matchMedia = new MatchMediaMock();

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -24,7 +24,7 @@ export interface SelectOption extends MenuItemButtonProps {
     id?: string;
 }
 
-export interface SelectProps extends OcBaseProps<HTMLSelectElement> {
+export interface SelectProps extends OcBaseProps<HTMLDivElement> {
     /**
      * Default Value
      * @default ''
@@ -60,6 +60,11 @@ export interface SelectProps extends OcBaseProps<HTMLSelectElement> {
      * @default false
      */
     multiple?: boolean;
+
+    /**
+     * Callback called when the clear button is clicked
+     */
+    onClear?: () => void;
 
     /**
      * Callback called when options are selected/unselected

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -2,7 +2,9 @@
     font-family: $octuple-font-family;
     position: relative;
     width: 100%;
-    min-width: 256px; // The minimum width required to ensure multi-select pills have enough room for 1 pill + the count
+
+    // The minimum width required to ensure multi-select pills have enough room for 1 pill + the count
+    min-width: 256px;
 
     .select-dropdown-overlay {
         padding: 0;

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -2,9 +2,9 @@
     font-family: $octuple-font-family;
     position: relative;
     width: 100%;
+    min-width: 256px; // The minimum width required to ensure multi-select pills have enough room for 1 pill + the count
 
     .select-dropdown-overlay {
-        width: 400px;
         padding: 0;
 
         .select-spinner {
@@ -34,7 +34,8 @@
     }
 
     .multi-select-pill {
-        max-width: 96px;
+        margin-right: $space-xs;
+        max-width: 144px;
         text-align: center;
         display: flex;
         justify-content: center;
@@ -42,12 +43,12 @@
 
         span {
             @include text-overflow;
-            max-width: 80px;
+            max-width: 128px;
         }
     }
 
     .multi-select-count {
-        margin-left: $space-xs;
+        margin-right: $space-xs;
     }
 
     .selected-option {

--- a/src/components/Slider/slider.module.scss
+++ b/src/components/Slider/slider.module.scss
@@ -1,5 +1,5 @@
 @function strip-units($number) {
-    @return $number / ($number * 0 + 1);
+    @return calc($number / ($number * 0 + 1px));
 }
 
 // Represents the diameter of the thumb slider

--- a/src/components/Spinner/Spinner.types.ts
+++ b/src/components/Spinner/Spinner.types.ts
@@ -1,12 +1,18 @@
-import { OcBaseProps } from '../OcBase';
-
 export enum SpinnerSize {
     Large = '64px',
     Default = '48px',
     Small = '30px',
 }
 
-export interface SpinnerProps extends OcBaseProps<HTMLElement> {
+export interface SpinnerProps extends React.HTMLAttributes<HTMLElement> {
+    /**
+     * Custom classnames of the component
+     */
+    classNames?: string;
+    /**
+     * Unique id used to target element for testing
+     */
+    'data-test-id'?: string;
     /**
      * Size of the spinner
      * @default SpinnerSize.Default

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -22,7 +22,7 @@
         &:first-child {
             padding-left: 0;
             .tab-indicator {
-                width: calc(100% - #{$space-xl / 2});
+                width: calc(100% - calc(#{$space-xl / 2}));
             }
         }
 

--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -23,9 +23,10 @@ $tooltip-arrow-shadow: 1px 1px 2px rgba(15, 20, 31, 0.12);
     font-family: $octuple-font-family;
     font-size: $text-font-size-1;
     text-align: center;
-    z-index: $z-index-100;
+    z-index: $z-index-400;
     padding: $space-xs;
     border-radius: $corner-radius-s;
+    overflow-wrap: break-word;
 
     &.dark {
         --bg: var(--grey-color-80);

--- a/src/hooks/useMaxVisibleSections.ts
+++ b/src/hooks/useMaxVisibleSections.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+
+export const useMaxVisibleSections = (
+    containerRef: React.MutableRefObject<HTMLElement>,
+    itemsRef: React.MutableRefObject<HTMLElement[]>,
+    extraItemWidth = 0,
+    itemPadding = 0,
+    linesToShow = 1,
+    itemsLength = 0
+) => {
+    const [maxSections, setMaxSections] = useState({
+        width: 0,
+        count: 0,
+        filled: false,
+    });
+
+    const computeVisibleSections = () => {
+        const availableWidth: number =
+            (containerRef.current?.getBoundingClientRect().width -
+                extraItemWidth) *
+            linesToShow;
+        const sections = itemsRef.current?.reduce(
+            (
+                acc: {
+                    width: number;
+                    count: number;
+                    filled: boolean;
+                },
+                ref: HTMLElement
+            ) => {
+                if (!ref) {
+                    return acc;
+                }
+                const sectionWidth =
+                    ref.getBoundingClientRect().width + itemPadding;
+                if (acc.width + sectionWidth < availableWidth) {
+                    acc.width += sectionWidth;
+                    acc.count += 1;
+                } else {
+                    return { ...acc, filled: true };
+                }
+                return acc;
+            },
+            {
+                width: 0,
+                count: 0,
+                filled: false,
+            }
+        );
+        setMaxSections(sections);
+    };
+
+    useEffect(() => {
+        if (!itemsRef.current) {
+            return () => {};
+        }
+        computeVisibleSections();
+        return () => {};
+    }, [itemsRef, itemsLength]);
+
+    useEffect(() => {
+        if (!containerRef.current) {
+            return () => {};
+        }
+        const ro = new ResizeObserver(() => {
+            computeVisibleSections();
+        });
+        ro.observe(containerRef.current);
+        return () => {
+            ro.disconnect();
+        };
+    }, [containerRef]);
+
+    return maxSections;
+};

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -131,6 +131,8 @@ import { useOnClickOutside } from './hooks/useOnClickOutside';
 
 import { useScrollLock } from './hooks/useScrollLock';
 
+import { useMaxVisibleSections } from './hooks/useMaxVisibleSections';
+
 export {
     Accordion,
     Avatar,
@@ -236,6 +238,7 @@ export {
     TwoStateButton,
     useBoolean,
     useMatchMedia,
+    useMaxVisibleSections,
     useOnClickOutside,
     useScrollLock,
 };

--- a/src/src/components/Loader/__snapshots__/Loader.stories.storyshot
+++ b/src/src/components/Loader/__snapshots__/Loader.stories.storyshot
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Loader Default 1`] = `
+<div
+  className="loader-container my-loader-class"
+>
+  <div
+    className="dot small"
+  />
+  <div
+    className="dot small"
+  />
+  <div
+    className="dot small"
+  />
+</div>
+`;

--- a/src/src/components/Select/__snapshots__/Select.stories.storyshot
+++ b/src/src/components/Select/__snapshots__/Select.stories.storyshot
@@ -1,17 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Select Basic 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": 256,
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -28,7 +26,7 @@ exports[`Storyshots Select Basic 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="select-input with-icon input-stretch right-icon clear-disabled clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
             disabled={false}
             id="input-33"
             onChange={[Function]}
@@ -41,12 +39,16 @@ exports[`Storyshots Select Basic 1`] = `
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -69,7 +71,7 @@ exports[`Storyshots Select Basic 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -78,17 +80,15 @@ exports[`Storyshots Select Basic 1`] = `
 `;
 
 exports[`Storyshots Select Disabled 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": 256,
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -105,7 +105,7 @@ exports[`Storyshots Select Disabled 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="select-input with-icon input-stretch right-icon clear-disabled clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
             disabled={true}
             id="input-35"
             onChange={[Function]}
@@ -118,12 +118,16 @@ exports[`Storyshots Select Disabled 1`] = `
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -146,7 +150,7 @@ exports[`Storyshots Select Disabled 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -155,15 +159,15 @@ exports[`Storyshots Select Disabled 1`] = `
 `;
 
 exports[`Storyshots Select Dynamic 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+<div>
   <div
-    className="select-wrapper"
+    className="select-wrapper octuple-select-class"
+    data-test-id="octuple-select-test-id"
+    style={
+      Object {
+        "width": 256,
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -180,7 +184,7 @@ exports[`Storyshots Select Dynamic 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="with-icon input-stretch right-icon clear-disabled clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-not-visible"
             disabled={false}
             id="input-37"
             onChange={[Function]}
@@ -193,12 +197,16 @@ exports[`Storyshots Select Dynamic 1`] = `
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -221,7 +229,7 @@ exports[`Storyshots Select Dynamic 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -229,18 +237,16 @@ exports[`Storyshots Select Dynamic 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Filterable 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+exports[`Storyshots Select Dynamic Width 1`] = `
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -257,25 +263,29 @@ exports[`Storyshots Select Filterable 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="with-icon input-stretch right-icon clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
             disabled={false}
             id="input-39"
             onChange={[Function]}
             onClick={[Function]}
             placeholder="Select"
-            readOnly={false}
+            readOnly={true}
             required={false}
             role="textbox"
             tabIndex={0}
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -298,7 +308,7 @@ exports[`Storyshots Select Filterable 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -306,18 +316,16 @@ exports[`Storyshots Select Filterable 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Multiple 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+exports[`Storyshots Select Filterable 1`] = `
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": 256,
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -334,7 +342,7 @@ exports[`Storyshots Select Multiple 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="with-icon input-stretch right-icon clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-not-visible"
             disabled={false}
             id="input-41"
             onChange={[Function]}
@@ -347,12 +355,16 @@ exports[`Storyshots Select Multiple 1`] = `
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -375,7 +387,7 @@ exports[`Storyshots Select Multiple 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -383,18 +395,16 @@ exports[`Storyshots Select Multiple 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Multiple With No Filter 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+exports[`Storyshots Select Multiple 1`] = `
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -411,25 +421,29 @@ exports[`Storyshots Select Multiple With No Filter 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="select-input with-icon input-stretch right-icon clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-not-visible"
             disabled={false}
             id="input-43"
             onChange={[Function]}
             onClick={[Function]}
             placeholder="Select"
-            readOnly={true}
+            readOnly={false}
             required={false}
             role="textbox"
             tabIndex={0}
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -452,7 +466,7 @@ exports[`Storyshots Select Multiple With No Filter 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -460,18 +474,16 @@ exports[`Storyshots Select Multiple With No Filter 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select Options Disabled 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+exports[`Storyshots Select Multiple With No Filter 1`] = `
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": "100%",
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -488,7 +500,7 @@ exports[`Storyshots Select Options Disabled 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="select-input with-icon input-stretch right-icon clear-disabled clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-not-visible"
             disabled={false}
             id="input-45"
             onChange={[Function]}
@@ -501,12 +513,16 @@ exports[`Storyshots Select Options Disabled 1`] = `
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -529,7 +545,7 @@ exports[`Storyshots Select Options Disabled 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -537,18 +553,16 @@ exports[`Storyshots Select Options Disabled 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select With Clear 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+exports[`Storyshots Select Options Disabled 1`] = `
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": 256,
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -565,7 +579,7 @@ exports[`Storyshots Select With Clear 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="select-input with-icon input-stretch right-icon clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
             disabled={false}
             id="input-47"
             onChange={[Function]}
@@ -578,12 +592,16 @@ exports[`Storyshots Select With Clear 1`] = `
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -606,7 +624,7 @@ exports[`Storyshots Select With Clear 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -614,18 +632,16 @@ exports[`Storyshots Select With Clear 1`] = `
 </div>
 `;
 
-exports[`Storyshots Select With Default Value 1`] = `
-<div
-  style={
-    Object {
-      "width": "200px",
-    }
-  }
->
+exports[`Storyshots Select With Clear 1`] = `
+<div>
   <div
     className="select-wrapper octuple-select-class"
     data-test-id="octuple-select-test-id"
-    style={Object {}}
+    style={
+      Object {
+        "width": 256,
+      }
+    }
   >
     <div
       className="select-dropdown-main-wrapper main-wrapper"
@@ -642,7 +658,7 @@ exports[`Storyshots Select With Default Value 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             autoFocus={false}
-            className="select-input with-icon input-stretch right-icon clear-disabled clear-not-visible"
+            className="select-input with-icon-button input-stretch right-icon clear-not-visible"
             disabled={false}
             id="input-49"
             onChange={[Function]}
@@ -655,12 +671,16 @@ exports[`Storyshots Select With Default Value 1`] = `
             type="text"
             value=""
           />
-          <div
-            className="icon-wrapper right-icon"
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
           >
             <span
               aria-hidden={false}
-              className="icon-wrapper"
+              className="icon icon-wrapper"
               role="presentation"
             >
               <svg
@@ -683,7 +703,86 @@ exports[`Storyshots Select With Default Value 1`] = `
                 />
               </svg>
             </span>
-          </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Select With Default Value 1`] = `
+<div>
+  <div
+    className="select-wrapper octuple-select-class"
+    data-test-id="octuple-select-test-id"
+    style={
+      Object {
+        "width": 256,
+      }
+    }
+  >
+    <div
+      className="select-dropdown-main-wrapper main-wrapper"
+    >
+      <div
+        className="input-wrapper input-stretch right-icon"
+      >
+        <div
+          className="input-group right-icon"
+        >
+          <input
+            aria-controls="dropdown-50"
+            aria-disabled={false}
+            aria-expanded={false}
+            aria-haspopup={true}
+            autoFocus={false}
+            className="select-input with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
+            disabled={false}
+            id="input-51"
+            onChange={[Function]}
+            onClick={[Function]}
+            placeholder="Select"
+            readOnly={true}
+            required={false}
+            role="textbox"
+            tabIndex={0}
+            type="text"
+            value=""
+          />
+          <button
+            aria-disabled={false}
+            className="icon-button right-icon button button-default pill-shape icon-left"
+            defaultChecked={false}
+            disabled={false}
+            onClick={[Function]}
+          >
+            <span
+              aria-hidden={false}
+              className="icon icon-wrapper"
+              role="presentation"
+            >
+              <svg
+                role="presentation"
+                style={
+                  Object {
+                    "height": "20px",
+                    "width": "20px",
+                  }
+                }
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </svg>
+            </span>
+          </button>
         </div>
       </div>
     </div>

--- a/src/src/components/Table/__snapshots__/Table.stories.storyshot
+++ b/src/src/components/Table/__snapshots__/Table.stories.storyshot
@@ -1347,1559 +1347,6 @@ exports[`Storyshots Table Basic 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-50"
-          aria-disabled={false}
-          aria-expanded={false}
-          aria-haspopup={true}
-          aria-label="Selected page size"
-          className="button button-neutral button-medium icon-left"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-          role="button"
-          tabIndex="0"
-        >
-          <span>
-            <span
-              aria-hidden={false}
-              className="icon icon-wrapper"
-              role="presentation"
-            >
-              <svg
-                role="presentation"
-                style={
-                  Object {
-                    "height": "20px",
-                    "width": "20px",
-                  }
-                }
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
-                  style={
-                    Object {
-                      "fill": "currentColor",
-                    }
-                  }
-                />
-              </svg>
-            </span>
-            <span
-              className="button-text-medium"
-            >
-              page / 10
-            </span>
-          </span>
-        </button>
-      </div>
-    </span>
-    <span
-      className="total"
-    >
-      16 Total
-    </span>
-    <button
-      aria-disabled={true}
-      aria-label="Previous"
-      className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
-      defaultChecked={false}
-      disabled={true}
-      onClick={[Function]}
-    >
-      <span
-        aria-hidden={false}
-        className="icon icon-wrapper"
-        role="presentation"
-      >
-        <svg
-          role="presentation"
-          style={
-            Object {
-              "height": "20px",
-              "width": "20px",
-            }
-          }
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
-            style={
-              Object {
-                "fill": "currentColor",
-              }
-            }
-          />
-        </svg>
-      </span>
-    </button>
-    <ul
-      className="pager"
-    >
-      <li>
-        <button
-          aria-checked={true}
-          aria-disabled={false}
-          aria-pressed={true}
-          className="pagination-button active button button-neutral button-medium"
-          defaultChecked={true}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            1
-          </span>
-        </button>
-      </li>
-      <li>
-        <button
-          aria-checked={false}
-          aria-disabled={false}
-          aria-pressed={false}
-          className="pagination-button button button-neutral button-medium"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            0
-          </span>
-        </button>
-      </li>
-      <li>
-        <button
-          aria-checked={false}
-          aria-disabled={false}
-          aria-pressed={false}
-          className="pagination-button button button-neutral button-medium"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            2
-          </span>
-        </button>
-      </li>
-    </ul>
-    <button
-      aria-disabled={false}
-      aria-label="Next"
-      className="pagination-button pagination-next button button-neutral button-medium icon-left"
-      defaultChecked={false}
-      disabled={false}
-      onClick={[Function]}
-    >
-      <span
-        aria-hidden={false}
-        className="icon icon-wrapper"
-        role="presentation"
-      >
-        <svg
-          role="presentation"
-          style={
-            Object {
-              "height": "20px",
-              "width": "20px",
-            }
-          }
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-            style={
-              Object {
-                "fill": "currentColor",
-              }
-            }
-          />
-        </svg>
-      </span>
-    </button>
-    <span
-      className="jump"
-    >
-      <div
-        className="input-wrapper left-icon"
-      >
-        <div
-          className="input-group left-icon"
-        >
-          <input
-            aria-disabled={false}
-            autoFocus={false}
-            className="editor pill-shape left-icon clear-not-visible"
-            defaultValue={1}
-            disabled={false}
-            id="input-51"
-            minLength={1}
-            onChange={[Function]}
-            readOnly={false}
-            required={false}
-            role="textbox"
-            tabIndex={0}
-            type="number"
-          />
-        </div>
-      </div>
-    </span>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Table Bordered 1`] = `
-<div
-  className="table-wrapper my-table-class"
->
-  <div
-    className="table table table-alternate table-bordered"
-    id="myTableId"
-  >
-    <div
-      className="table-container"
-    >
-      <div
-        className="table-content"
-        onScroll={[Function]}
-        style={Object {}}
-      >
-        <table
-          style={
-            Object {
-              "tableLayout": "auto",
-            }
-          }
-        >
-          <colgroup />
-          <thead
-            className="table-thead"
-          >
-            <tr>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Role
-              </th>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Profile
-              </th>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Level
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className="table-tbody"
-          >
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="1"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    AM
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Anamika Musafir
-                    </a>
-                    Beacon, NY
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                78
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="2"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Chandra Garg
-                    </a>
-                    Delhi, Delhi
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                86
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="3"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Regional Sales VP
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CF
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Clarey Fike
-                    </a>
-                    New York, NA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                95
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="4"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Director
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CD
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Cobbey Deevey
-                    </a>
-                    Atlanta, GA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                66
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="5"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    DS
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Dave Shaw
-                    </a>
-                    San Diego, USA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                72
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="6"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    FA
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Farida Ashfaq
-                    </a>
-                    Mumbai, Maharashtra
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="7"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    FB
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Frank Baptist
-                    </a>
-                    Houston, Texas Area
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                87
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="8"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    JF
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Jerome Feng
-                    </a>
-                    Irvine, CA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                88
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="9"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    JT
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Julie Tharoor
-                    </a>
-                    Bangalore, Karnataka
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                52
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="10"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    NG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Nikita Gagan
-                    </a>
-                    Delhi, Delhi
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="11"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Representative
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    PR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Peter Rege
-                    </a>
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="12"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    RR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Revathi Roy
-                    </a>
-                    San Francisco Bay Area
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                74
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="13"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Account Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    UL
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Urbanus Laurens
-                    </a>
-                    Salt Lake City, UT
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                76
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="14"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Account Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    VR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Vance Renner
-                    </a>
-                    St Louis, MO
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                90
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="15"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    ZG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Zarla Greener
-                    </a>
-                    Chicago, IL
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                79
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="16"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    DS
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Dave Doe
-                    </a>
-                    San Diego, USA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                72
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-  <div
-    className="table-pagination table-pagination-right pagination"
-    position={
-      Array [
-        "none",
-        "bottomRight",
-      ]
-    }
-  >
-    <span
-      className="sizes"
-    >
-      <div
-        className="main-wrapper"
-      >
-        <button
           aria-controls="dropdown-52"
           aria-disabled={false}
           aria-expanded={false}
@@ -3106,12 +1553,12 @@ exports[`Storyshots Table Bordered 1`] = `
 </div>
 `;
 
-exports[`Storyshots Table Cell Bordered 1`] = `
+exports[`Storyshots Table Bordered 1`] = `
 <div
   className="table-wrapper my-table-class"
 >
   <div
-    className="table table table-alternate table-cell-bordered"
+    className="table table table-alternate table-bordered"
     id="myTableId"
   >
     <div
@@ -4644,6 +3091,1559 @@ exports[`Storyshots Table Cell Bordered 1`] = `
             defaultValue={1}
             disabled={false}
             id="input-55"
+            minLength={1}
+            onChange={[Function]}
+            readOnly={false}
+            required={false}
+            role="textbox"
+            tabIndex={0}
+            type="number"
+          />
+        </div>
+      </div>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Table Cell Bordered 1`] = `
+<div
+  className="table-wrapper my-table-class"
+>
+  <div
+    className="table table table-alternate table-cell-bordered"
+    id="myTableId"
+  >
+    <div
+      className="table-container"
+    >
+      <div
+        className="table-content"
+        onScroll={[Function]}
+        style={Object {}}
+      >
+        <table
+          style={
+            Object {
+              "tableLayout": "auto",
+            }
+          }
+        >
+          <colgroup />
+          <thead
+            className="table-thead"
+          >
+            <tr>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Role
+              </th>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Profile
+              </th>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Level
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className="table-tbody"
+          >
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="1"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    AM
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Anamika Musafir
+                    </a>
+                    Beacon, NY
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                78
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="2"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Chandra Garg
+                    </a>
+                    Delhi, Delhi
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                86
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="3"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Regional Sales VP
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CF
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Clarey Fike
+                    </a>
+                    New York, NA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                95
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="4"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Director
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CD
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Cobbey Deevey
+                    </a>
+                    Atlanta, GA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                66
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="5"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    DS
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Dave Shaw
+                    </a>
+                    San Diego, USA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                72
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="6"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    FA
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Farida Ashfaq
+                    </a>
+                    Mumbai, Maharashtra
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="7"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    FB
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Frank Baptist
+                    </a>
+                    Houston, Texas Area
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                87
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="8"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    JF
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Jerome Feng
+                    </a>
+                    Irvine, CA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                88
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="9"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    JT
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Julie Tharoor
+                    </a>
+                    Bangalore, Karnataka
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                52
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="10"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    NG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Nikita Gagan
+                    </a>
+                    Delhi, Delhi
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="11"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Representative
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    PR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Peter Rege
+                    </a>
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="12"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    RR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Revathi Roy
+                    </a>
+                    San Francisco Bay Area
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                74
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="13"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Account Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    UL
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Urbanus Laurens
+                    </a>
+                    Salt Lake City, UT
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                76
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="14"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Account Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    VR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Vance Renner
+                    </a>
+                    St Louis, MO
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                90
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="15"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    ZG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Zarla Greener
+                    </a>
+                    Chicago, IL
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                79
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="16"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    DS
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Dave Doe
+                    </a>
+                    San Diego, USA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                72
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div
+    className="table-pagination table-pagination-right pagination"
+    position={
+      Array [
+        "none",
+        "bottomRight",
+      ]
+    }
+  >
+    <span
+      className="sizes"
+    >
+      <div
+        className="main-wrapper"
+      >
+        <button
+          aria-controls="dropdown-56"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-label="Selected page size"
+          className="button button-neutral button-medium icon-left"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <span>
+            <span
+              aria-hidden={false}
+              className="icon icon-wrapper"
+              role="presentation"
+            >
+              <svg
+                role="presentation"
+                style={
+                  Object {
+                    "height": "20px",
+                    "width": "20px",
+                  }
+                }
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </svg>
+            </span>
+            <span
+              className="button-text-medium"
+            >
+              page / 10
+            </span>
+          </span>
+        </button>
+      </div>
+    </span>
+    <span
+      className="total"
+    >
+      16 Total
+    </span>
+    <button
+      aria-disabled={true}
+      aria-label="Previous"
+      className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
+      defaultChecked={false}
+      disabled={true}
+      onClick={[Function]}
+    >
+      <span
+        aria-hidden={false}
+        className="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style={
+            Object {
+              "height": "20px",
+              "width": "20px",
+            }
+          }
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      className="pager"
+    >
+      <li>
+        <button
+          aria-checked={true}
+          aria-disabled={false}
+          aria-pressed={true}
+          className="pagination-button active button button-neutral button-medium"
+          defaultChecked={true}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            1
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-checked={false}
+          aria-disabled={false}
+          aria-pressed={false}
+          className="pagination-button button button-neutral button-medium"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            0
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-checked={false}
+          aria-disabled={false}
+          aria-pressed={false}
+          className="pagination-button button button-neutral button-medium"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            2
+          </span>
+        </button>
+      </li>
+    </ul>
+    <button
+      aria-disabled={false}
+      aria-label="Next"
+      className="pagination-button pagination-next button button-neutral button-medium icon-left"
+      defaultChecked={false}
+      disabled={false}
+      onClick={[Function]}
+    >
+      <span
+        aria-hidden={false}
+        className="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style={
+            Object {
+              "height": "20px",
+              "width": "20px",
+            }
+          }
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </span>
+    </button>
+    <span
+      className="jump"
+    >
+      <div
+        className="input-wrapper left-icon"
+      >
+        <div
+          className="input-group left-icon"
+        >
+          <input
+            aria-disabled={false}
+            autoFocus={false}
+            className="editor pill-shape left-icon clear-not-visible"
+            defaultValue={1}
+            disabled={false}
+            id="input-57"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -7490,7 +7490,7 @@ exports[`Storyshots Table Ellipsis 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-56"
+          aria-controls="dropdown-58"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -7680,7 +7680,7 @@ exports[`Storyshots Table Ellipsis 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-57"
+            id="input-59"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -9454,7 +9454,7 @@ exports[`Storyshots Table Ellipsis With Tooltip 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-58"
+          aria-controls="dropdown-60"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -9628,7 +9628,7 @@ exports[`Storyshots Table Ellipsis With Tooltip 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-59"
+            id="input-61"
             maxLength={2}
             minLength={1}
             onChange={[Function]}
@@ -11388,7 +11388,7 @@ exports[`Storyshots Table Expandable Row 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-62"
+          aria-controls="dropdown-64"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -11578,7 +11578,7 @@ exports[`Storyshots Table Expandable Row 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-63"
+            id="input-65"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -11652,7 +11652,7 @@ exports[`Storyshots Table Filter 1`] = `
                     className="main-wrapper"
                   >
                     <button
-                      aria-controls="dropdown-64"
+                      aria-controls="dropdown-66"
                       aria-disabled={false}
                       aria-expanded={false}
                       aria-haspopup={true}
@@ -12991,7 +12991,7 @@ exports[`Storyshots Table Filter 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-65"
+          aria-controls="dropdown-67"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -13181,7 +13181,7 @@ exports[`Storyshots Table Filter 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-66"
+            id="input-68"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -16359,7 +16359,7 @@ exports[`Storyshots Table Fixed Columns 1`] = `
           className="main-wrapper"
         >
           <button
-            aria-controls="dropdown-67"
+            aria-controls="dropdown-69"
             aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
@@ -16549,7 +16549,7 @@ exports[`Storyshots Table Fixed Columns 1`] = `
               className="editor pill-shape left-icon clear-not-visible"
               defaultValue={1}
               disabled={false}
-              id="input-68"
+              id="input-70"
               minLength={1}
               onChange={[Function]}
               readOnly={false}
@@ -19749,7 +19749,7 @@ exports[`Storyshots Table Fixed Columns And Header 1`] = `
           className="main-wrapper"
         >
           <button
-            aria-controls="dropdown-69"
+            aria-controls="dropdown-71"
             aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
@@ -19939,7 +19939,7 @@ exports[`Storyshots Table Fixed Columns And Header 1`] = `
               className="editor pill-shape left-icon clear-not-visible"
               defaultValue={1}
               disabled={false}
-              id="input-70"
+              id="input-72"
               minLength={1}
               onChange={[Function]}
               readOnly={false}
@@ -21408,7 +21408,7 @@ exports[`Storyshots Table Fixed Header 1`] = `
           className="main-wrapper"
         >
           <button
-            aria-controls="dropdown-71"
+            aria-controls="dropdown-73"
             aria-disabled={false}
             aria-expanded={false}
             aria-haspopup={true}
@@ -21598,7 +21598,7 @@ exports[`Storyshots Table Fixed Header 1`] = `
               className="editor pill-shape left-icon clear-not-visible"
               defaultValue={1}
               disabled={false}
-              id="input-72"
+              id="input-74"
               minLength={1}
               onChange={[Function]}
               readOnly={false}
@@ -22972,7 +22972,7 @@ exports[`Storyshots Table Header And Footer 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-73"
+          aria-controls="dropdown-75"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -23162,7 +23162,7 @@ exports[`Storyshots Table Header And Footer 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-74"
+            id="input-76"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -24525,7 +24525,7 @@ exports[`Storyshots Table Header Bordered 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-75"
+          aria-controls="dropdown-77"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -24715,7 +24715,7 @@ exports[`Storyshots Table Header Bordered 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-76"
+            id="input-78"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -27790,1559 +27790,6 @@ exports[`Storyshots Table Header Grouping 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-77"
-          aria-disabled={false}
-          aria-expanded={false}
-          aria-haspopup={true}
-          aria-label="Selected page size"
-          className="button button-neutral button-medium icon-left"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-          role="button"
-          tabIndex="0"
-        >
-          <span>
-            <span
-              aria-hidden={false}
-              className="icon icon-wrapper"
-              role="presentation"
-            >
-              <svg
-                role="presentation"
-                style={
-                  Object {
-                    "height": "20px",
-                    "width": "20px",
-                  }
-                }
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
-                  style={
-                    Object {
-                      "fill": "currentColor",
-                    }
-                  }
-                />
-              </svg>
-            </span>
-            <span
-              className="button-text-medium"
-            >
-              page / 10
-            </span>
-          </span>
-        </button>
-      </div>
-    </span>
-    <span
-      className="total"
-    >
-      16 Total
-    </span>
-    <button
-      aria-disabled={true}
-      aria-label="Previous"
-      className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
-      defaultChecked={false}
-      disabled={true}
-      onClick={[Function]}
-    >
-      <span
-        aria-hidden={false}
-        className="icon icon-wrapper"
-        role="presentation"
-      >
-        <svg
-          role="presentation"
-          style={
-            Object {
-              "height": "20px",
-              "width": "20px",
-            }
-          }
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
-            style={
-              Object {
-                "fill": "currentColor",
-              }
-            }
-          />
-        </svg>
-      </span>
-    </button>
-    <ul
-      className="pager"
-    >
-      <li>
-        <button
-          aria-checked={true}
-          aria-disabled={false}
-          aria-pressed={true}
-          className="pagination-button active button button-neutral button-medium"
-          defaultChecked={true}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            1
-          </span>
-        </button>
-      </li>
-      <li>
-        <button
-          aria-checked={false}
-          aria-disabled={false}
-          aria-pressed={false}
-          className="pagination-button button button-neutral button-medium"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            0
-          </span>
-        </button>
-      </li>
-      <li>
-        <button
-          aria-checked={false}
-          aria-disabled={false}
-          aria-pressed={false}
-          className="pagination-button button button-neutral button-medium"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            2
-          </span>
-        </button>
-      </li>
-    </ul>
-    <button
-      aria-disabled={false}
-      aria-label="Next"
-      className="pagination-button pagination-next button button-neutral button-medium icon-left"
-      defaultChecked={false}
-      disabled={false}
-      onClick={[Function]}
-    >
-      <span
-        aria-hidden={false}
-        className="icon icon-wrapper"
-        role="presentation"
-      >
-        <svg
-          role="presentation"
-          style={
-            Object {
-              "height": "20px",
-              "width": "20px",
-            }
-          }
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-            style={
-              Object {
-                "fill": "currentColor",
-              }
-            }
-          />
-        </svg>
-      </span>
-    </button>
-    <span
-      className="jump"
-    >
-      <div
-        className="input-wrapper left-icon"
-      >
-        <div
-          className="input-group left-icon"
-        >
-          <input
-            aria-disabled={false}
-            autoFocus={false}
-            className="editor pill-shape left-icon clear-not-visible"
-            defaultValue={1}
-            disabled={false}
-            id="input-78"
-            minLength={1}
-            onChange={[Function]}
-            readOnly={false}
-            required={false}
-            role="textbox"
-            tabIndex={0}
-            type="number"
-          />
-        </div>
-      </div>
-    </span>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Table Inner Bordered 1`] = `
-<div
-  className="table-wrapper my-table-class"
->
-  <div
-    className="table table table-alternate table-inner-bordered"
-    id="myTableId"
-  >
-    <div
-      className="table-container"
-    >
-      <div
-        className="table-content"
-        onScroll={[Function]}
-        style={Object {}}
-      >
-        <table
-          style={
-            Object {
-              "tableLayout": "auto",
-            }
-          }
-        >
-          <colgroup />
-          <thead
-            className="table-thead"
-          >
-            <tr>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Role
-              </th>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Profile
-              </th>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Level
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className="table-tbody"
-          >
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="1"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    AM
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Anamika Musafir
-                    </a>
-                    Beacon, NY
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                78
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="2"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Chandra Garg
-                    </a>
-                    Delhi, Delhi
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                86
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="3"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Regional Sales VP
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CF
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Clarey Fike
-                    </a>
-                    New York, NA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                95
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="4"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Director
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CD
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Cobbey Deevey
-                    </a>
-                    Atlanta, GA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                66
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="5"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    DS
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Dave Shaw
-                    </a>
-                    San Diego, USA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                72
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="6"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    FA
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Farida Ashfaq
-                    </a>
-                    Mumbai, Maharashtra
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="7"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    FB
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Frank Baptist
-                    </a>
-                    Houston, Texas Area
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                87
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="8"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    JF
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Jerome Feng
-                    </a>
-                    Irvine, CA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                88
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="9"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    JT
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Julie Tharoor
-                    </a>
-                    Bangalore, Karnataka
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                52
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="10"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    NG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Nikita Gagan
-                    </a>
-                    Delhi, Delhi
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="11"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Representative
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    PR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Peter Rege
-                    </a>
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="12"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    RR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Revathi Roy
-                    </a>
-                    San Francisco Bay Area
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                74
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="13"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Account Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    UL
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Urbanus Laurens
-                    </a>
-                    Salt Lake City, UT
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                76
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="14"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Account Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    VR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Vance Renner
-                    </a>
-                    St Louis, MO
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                90
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="15"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    ZG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Zarla Greener
-                    </a>
-                    Chicago, IL
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                79
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="16"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    DS
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Dave Doe
-                    </a>
-                    San Diego, USA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                72
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-  <div
-    className="table-pagination table-pagination-right pagination"
-    position={
-      Array [
-        "none",
-        "bottomRight",
-      ]
-    }
-  >
-    <span
-      className="sizes"
-    >
-      <div
-        className="main-wrapper"
-      >
-        <button
           aria-controls="dropdown-79"
           aria-disabled={false}
           aria-expanded={false}
@@ -29549,12 +27996,12 @@ exports[`Storyshots Table Inner Bordered 1`] = `
 </div>
 `;
 
-exports[`Storyshots Table Large 1`] = `
+exports[`Storyshots Table Inner Bordered 1`] = `
 <div
   className="table-wrapper my-table-class"
 >
   <div
-    className="table table table-alternate table-bordered"
+    className="table table table-alternate table-inner-bordered"
     id="myTableId"
   >
     <div
@@ -31102,12 +29549,12 @@ exports[`Storyshots Table Large 1`] = `
 </div>
 `;
 
-exports[`Storyshots Table Medium 1`] = `
+exports[`Storyshots Table Large 1`] = `
 <div
   className="table-wrapper my-table-class"
 >
   <div
-    className="table table table-medium table-alternate table-bordered"
+    className="table table table-alternate table-bordered"
     id="myTableId"
   >
     <div
@@ -32640,6 +31087,1559 @@ exports[`Storyshots Table Medium 1`] = `
             defaultValue={1}
             disabled={false}
             id="input-84"
+            minLength={1}
+            onChange={[Function]}
+            readOnly={false}
+            required={false}
+            role="textbox"
+            tabIndex={0}
+            type="number"
+          />
+        </div>
+      </div>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Table Medium 1`] = `
+<div
+  className="table-wrapper my-table-class"
+>
+  <div
+    className="table table table-medium table-alternate table-bordered"
+    id="myTableId"
+  >
+    <div
+      className="table-container"
+    >
+      <div
+        className="table-content"
+        onScroll={[Function]}
+        style={Object {}}
+      >
+        <table
+          style={
+            Object {
+              "tableLayout": "auto",
+            }
+          }
+        >
+          <colgroup />
+          <thead
+            className="table-thead"
+          >
+            <tr>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Role
+              </th>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Profile
+              </th>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Level
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className="table-tbody"
+          >
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="1"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    AM
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Anamika Musafir
+                    </a>
+                    Beacon, NY
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                78
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="2"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Chandra Garg
+                    </a>
+                    Delhi, Delhi
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                86
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="3"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Regional Sales VP
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CF
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Clarey Fike
+                    </a>
+                    New York, NA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                95
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="4"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Director
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CD
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Cobbey Deevey
+                    </a>
+                    Atlanta, GA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                66
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="5"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    DS
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Dave Shaw
+                    </a>
+                    San Diego, USA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                72
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="6"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    FA
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Farida Ashfaq
+                    </a>
+                    Mumbai, Maharashtra
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="7"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    FB
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Frank Baptist
+                    </a>
+                    Houston, Texas Area
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                87
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="8"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    JF
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Jerome Feng
+                    </a>
+                    Irvine, CA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                88
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="9"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    JT
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Julie Tharoor
+                    </a>
+                    Bangalore, Karnataka
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                52
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="10"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    NG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Nikita Gagan
+                    </a>
+                    Delhi, Delhi
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="11"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Representative
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    PR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Peter Rege
+                    </a>
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="12"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    RR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Revathi Roy
+                    </a>
+                    San Francisco Bay Area
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                74
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="13"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Account Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    UL
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Urbanus Laurens
+                    </a>
+                    Salt Lake City, UT
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                76
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="14"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Account Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    VR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Vance Renner
+                    </a>
+                    St Louis, MO
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                90
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="15"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    ZG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Zarla Greener
+                    </a>
+                    Chicago, IL
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                79
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="16"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    DS
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Dave Doe
+                    </a>
+                    San Diego, USA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                72
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div
+    className="table-pagination table-pagination-right pagination"
+    position={
+      Array [
+        "none",
+        "bottomRight",
+      ]
+    }
+  >
+    <span
+      className="sizes"
+    >
+      <div
+        className="main-wrapper"
+      >
+        <button
+          aria-controls="dropdown-85"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-label="Selected page size"
+          className="button button-neutral button-medium icon-left"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <span>
+            <span
+              aria-hidden={false}
+              className="icon icon-wrapper"
+              role="presentation"
+            >
+              <svg
+                role="presentation"
+                style={
+                  Object {
+                    "height": "20px",
+                    "width": "20px",
+                  }
+                }
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </svg>
+            </span>
+            <span
+              className="button-text-medium"
+            >
+              page / 10
+            </span>
+          </span>
+        </button>
+      </div>
+    </span>
+    <span
+      className="total"
+    >
+      16 Total
+    </span>
+    <button
+      aria-disabled={true}
+      aria-label="Previous"
+      className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
+      defaultChecked={false}
+      disabled={true}
+      onClick={[Function]}
+    >
+      <span
+        aria-hidden={false}
+        className="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style={
+            Object {
+              "height": "20px",
+              "width": "20px",
+            }
+          }
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      className="pager"
+    >
+      <li>
+        <button
+          aria-checked={true}
+          aria-disabled={false}
+          aria-pressed={true}
+          className="pagination-button active button button-neutral button-medium"
+          defaultChecked={true}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            1
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-checked={false}
+          aria-disabled={false}
+          aria-pressed={false}
+          className="pagination-button button button-neutral button-medium"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            0
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-checked={false}
+          aria-disabled={false}
+          aria-pressed={false}
+          className="pagination-button button button-neutral button-medium"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            2
+          </span>
+        </button>
+      </li>
+    </ul>
+    <button
+      aria-disabled={false}
+      aria-label="Next"
+      className="pagination-button pagination-next button button-neutral button-medium icon-left"
+      defaultChecked={false}
+      disabled={false}
+      onClick={[Function]}
+    >
+      <span
+        aria-hidden={false}
+        className="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style={
+            Object {
+              "height": "20px",
+              "width": "20px",
+            }
+          }
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </span>
+    </button>
+    <span
+      className="jump"
+    >
+      <div
+        className="input-wrapper left-icon"
+      >
+        <div
+          className="input-group left-icon"
+        >
+          <input
+            aria-disabled={false}
+            autoFocus={false}
+            className="editor pill-shape left-icon clear-not-visible"
+            defaultValue={1}
+            disabled={false}
+            id="input-86"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -34261,7 +34261,7 @@ exports[`Storyshots Table Nested 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-85"
+          aria-controls="dropdown-87"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -34451,7 +34451,7 @@ exports[`Storyshots Table Nested 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-86"
+            id="input-88"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -36660,7 +36660,7 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-87"
+          aria-controls="dropdown-89"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -36850,7 +36850,7 @@ exports[`Storyshots Table Order Select And Expand Column 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-88"
+            id="input-90"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -38213,7 +38213,7 @@ exports[`Storyshots Table Outer Bordered 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-89"
+          aria-controls="dropdown-91"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -38403,7 +38403,7 @@ exports[`Storyshots Table Outer Bordered 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-90"
+            id="input-92"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -38755,7 +38755,7 @@ exports[`Storyshots Table Responsive 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-91"
+          aria-controls="dropdown-93"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -38945,7 +38945,7 @@ exports[`Storyshots Table Responsive 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-92"
+            id="input-94"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -40308,7 +40308,7 @@ exports[`Storyshots Table Row Bordered 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-93"
+          aria-controls="dropdown-95"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -40498,7 +40498,7 @@ exports[`Storyshots Table Row Bordered 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-94"
+            id="input-96"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -42435,1559 +42435,6 @@ exports[`Storyshots Table Selection 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-95"
-          aria-disabled={false}
-          aria-expanded={false}
-          aria-haspopup={true}
-          aria-label="Selected page size"
-          className="button button-neutral button-medium icon-left"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-          role="button"
-          tabIndex="0"
-        >
-          <span>
-            <span
-              aria-hidden={false}
-              className="icon icon-wrapper"
-              role="presentation"
-            >
-              <svg
-                role="presentation"
-                style={
-                  Object {
-                    "height": "20px",
-                    "width": "20px",
-                  }
-                }
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
-                  style={
-                    Object {
-                      "fill": "currentColor",
-                    }
-                  }
-                />
-              </svg>
-            </span>
-            <span
-              className="button-text-medium"
-            >
-              page / 10
-            </span>
-          </span>
-        </button>
-      </div>
-    </span>
-    <span
-      className="total"
-    >
-      16 Total
-    </span>
-    <button
-      aria-disabled={true}
-      aria-label="Previous"
-      className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
-      defaultChecked={false}
-      disabled={true}
-      onClick={[Function]}
-    >
-      <span
-        aria-hidden={false}
-        className="icon icon-wrapper"
-        role="presentation"
-      >
-        <svg
-          role="presentation"
-          style={
-            Object {
-              "height": "20px",
-              "width": "20px",
-            }
-          }
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
-            style={
-              Object {
-                "fill": "currentColor",
-              }
-            }
-          />
-        </svg>
-      </span>
-    </button>
-    <ul
-      className="pager"
-    >
-      <li>
-        <button
-          aria-checked={true}
-          aria-disabled={false}
-          aria-pressed={true}
-          className="pagination-button active button button-neutral button-medium"
-          defaultChecked={true}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            1
-          </span>
-        </button>
-      </li>
-      <li>
-        <button
-          aria-checked={false}
-          aria-disabled={false}
-          aria-pressed={false}
-          className="pagination-button button button-neutral button-medium"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            0
-          </span>
-        </button>
-      </li>
-      <li>
-        <button
-          aria-checked={false}
-          aria-disabled={false}
-          aria-pressed={false}
-          className="pagination-button button button-neutral button-medium"
-          defaultChecked={false}
-          disabled={false}
-          onClick={[Function]}
-        >
-          <span
-            className="button-text-medium"
-          >
-            2
-          </span>
-        </button>
-      </li>
-    </ul>
-    <button
-      aria-disabled={false}
-      aria-label="Next"
-      className="pagination-button pagination-next button button-neutral button-medium icon-left"
-      defaultChecked={false}
-      disabled={false}
-      onClick={[Function]}
-    >
-      <span
-        aria-hidden={false}
-        className="icon icon-wrapper"
-        role="presentation"
-      >
-        <svg
-          role="presentation"
-          style={
-            Object {
-              "height": "20px",
-              "width": "20px",
-            }
-          }
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
-            style={
-              Object {
-                "fill": "currentColor",
-              }
-            }
-          />
-        </svg>
-      </span>
-    </button>
-    <span
-      className="jump"
-    >
-      <div
-        className="input-wrapper left-icon"
-      >
-        <div
-          className="input-group left-icon"
-        >
-          <input
-            aria-disabled={false}
-            autoFocus={false}
-            className="editor pill-shape left-icon clear-not-visible"
-            defaultValue={1}
-            disabled={false}
-            id="input-96"
-            minLength={1}
-            onChange={[Function]}
-            readOnly={false}
-            required={false}
-            role="textbox"
-            tabIndex={0}
-            type="number"
-          />
-        </div>
-      </div>
-    </span>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Table Small 1`] = `
-<div
-  className="table-wrapper my-table-class"
->
-  <div
-    className="table table table-small table-alternate table-bordered"
-    id="myTableId"
-  >
-    <div
-      className="table-container"
-    >
-      <div
-        className="table-content"
-        onScroll={[Function]}
-        style={Object {}}
-      >
-        <table
-          style={
-            Object {
-              "tableLayout": "auto",
-            }
-          }
-        >
-          <colgroup />
-          <thead
-            className="table-thead"
-          >
-            <tr>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Role
-              </th>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Profile
-              </th>
-              <th
-                className="table-cell my-header"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Level
-              </th>
-            </tr>
-          </thead>
-          <tbody
-            className="table-tbody"
-          >
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="1"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    AM
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Anamika Musafir
-                    </a>
-                    Beacon, NY
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                78
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="2"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Chandra Garg
-                    </a>
-                    Delhi, Delhi
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                86
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="3"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Regional Sales VP
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CF
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Clarey Fike
-                    </a>
-                    New York, NA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                95
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="4"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Director
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    CD
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Cobbey Deevey
-                    </a>
-                    Atlanta, GA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                66
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="5"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    DS
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Dave Shaw
-                    </a>
-                    San Diego, USA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                72
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="6"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    FA
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Farida Ashfaq
-                    </a>
-                    Mumbai, Maharashtra
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="7"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    FB
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Frank Baptist
-                    </a>
-                    Houston, Texas Area
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                87
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="8"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    JF
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Jerome Feng
-                    </a>
-                    Irvine, CA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                88
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="9"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    JT
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Julie Tharoor
-                    </a>
-                    Bangalore, Karnataka
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                52
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="10"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    NG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Nikita Gagan
-                    </a>
-                    Delhi, Delhi
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="11"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Representative
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    PR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Peter Rege
-                    </a>
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                97
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="12"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Sales Engineer
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    RR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Revathi Roy
-                    </a>
-                    San Francisco Bay Area
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                74
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="13"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Account Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    UL
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Urbanus Laurens
-                    </a>
-                    Salt Lake City, UT
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                76
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="14"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Senior Account Executive
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    VR
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Vance Renner
-                    </a>
-                    St Louis, MO
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                90
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="15"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    ZG
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Zarla Greener
-                    </a>
-                    Chicago, IL
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                79
-              </td>
-            </tr>
-            <tr
-              className="table-row table-row-level-0"
-              data-row-key="16"
-              onClick={[Function]}
-              style={Object {}}
-            >
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                Sales Engineer Manager
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                <div
-                  className="stack horizontal s"
-                  style={
-                    Object {
-                      "alignItems": undefined,
-                      "flexWrap": undefined,
-                      "justifyContent": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="wrapper-style image-style round-image green"
-                    style={
-                      Object {
-                        "fontSize": "18px",
-                        "height": "32px",
-                        "minHeight": "32px",
-                        "minWidth": "32px",
-                        "width": "32px",
-                      }
-                    }
-                  >
-                    DS
-                  </div>
-                  <div
-                    className="stack vertical xxs"
-                    style={
-                      Object {
-                        "alignItems": undefined,
-                        "flexWrap": undefined,
-                        "justifyContent": undefined,
-                      }
-                    }
-                  >
-                    <a
-                      className="link-style primary"
-                      target="_self"
-                    >
-                      Dave Doe
-                    </a>
-                    San Diego, USA
-                  </div>
-                </div>
-              </td>
-              <td
-                className="table-cell"
-                colSpan={null}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                rowSpan={null}
-                style={Object {}}
-              >
-                72
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-  <div
-    className="table-pagination table-pagination-right pagination"
-    position={
-      Array [
-        "none",
-        "bottomRight",
-      ]
-    }
-  >
-    <span
-      className="sizes"
-    >
-      <div
-        className="main-wrapper"
-      >
-        <button
           aria-controls="dropdown-97"
           aria-disabled={false}
           aria-expanded={false}
@@ -44194,12 +42641,12 @@ exports[`Storyshots Table Small 1`] = `
 </div>
 `;
 
-exports[`Storyshots Table Sort 1`] = `
+exports[`Storyshots Table Small 1`] = `
 <div
   className="table-wrapper my-table-class"
 >
   <div
-    className="table table table-alternate table-bordered"
+    className="table table table-small table-alternate table-bordered"
     id="myTableId"
   >
     <div
@@ -44243,92 +42690,14 @@ exports[`Storyshots Table Sort 1`] = `
                 Profile
               </th>
               <th
-                className="table-cell my-header table-column-has-sorters"
+                className="table-cell my-header"
                 colSpan={null}
-                onClick={[Function]}
-                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
                 rowSpan={null}
                 style={Object {}}
-                tabIndex={0}
               >
-                <div
-                  className="reference-wrapper"
-                  id="sortTip"
-                  onBlur={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <div
-                    className="table-column-sorters"
-                  >
-                    <span
-                      className="table-column-title"
-                    >
-                      Level
-                    </span>
-                    <span
-                      className="table-column-sorter table-column-sorter-full"
-                    >
-                      <span
-                        className="table-column-sorter-inner"
-                      >
-                        <span
-                          aria-hidden={false}
-                          className="table-column-sorter-up icon-wrapper"
-                          role="presentation"
-                        >
-                          <svg
-                            role="presentation"
-                            style={
-                              Object {
-                                "height": "16px",
-                                "width": "16px",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
-                              style={
-                                Object {
-                                  "fill": "currentColor",
-                                }
-                              }
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          aria-hidden={false}
-                          className="table-column-sorter-down icon-wrapper"
-                          role="presentation"
-                        >
-                          <svg
-                            role="presentation"
-                            style={
-                              Object {
-                                "height": "16px",
-                                "width": "16px",
-                              }
-                            }
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-                              style={
-                                Object {
-                                  "fill": "currentColor",
-                                }
-                              }
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </span>
-                  </div>
-                </div>
+                Level
               </th>
             </tr>
           </thead>
@@ -45810,6 +44179,1637 @@ exports[`Storyshots Table Sort 1`] = `
             defaultValue={1}
             disabled={false}
             id="input-100"
+            minLength={1}
+            onChange={[Function]}
+            readOnly={false}
+            required={false}
+            role="textbox"
+            tabIndex={0}
+            type="number"
+          />
+        </div>
+      </div>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Table Sort 1`] = `
+<div
+  className="table-wrapper my-table-class"
+>
+  <div
+    className="table table table-alternate table-bordered"
+    id="myTableId"
+  >
+    <div
+      className="table-container"
+    >
+      <div
+        className="table-content"
+        onScroll={[Function]}
+        style={Object {}}
+      >
+        <table
+          style={
+            Object {
+              "tableLayout": "auto",
+            }
+          }
+        >
+          <colgroup />
+          <thead
+            className="table-thead"
+          >
+            <tr>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Role
+              </th>
+              <th
+                className="table-cell my-header"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Profile
+              </th>
+              <th
+                className="table-cell my-header table-column-has-sorters"
+                colSpan={null}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+                tabIndex={0}
+              >
+                <div
+                  className="reference-wrapper"
+                  id="sortTip"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <div
+                    className="table-column-sorters"
+                  >
+                    <span
+                      className="table-column-title"
+                    >
+                      Level
+                    </span>
+                    <span
+                      className="table-column-sorter table-column-sorter-full"
+                    >
+                      <span
+                        className="table-column-sorter-inner"
+                      >
+                        <span
+                          aria-hidden={false}
+                          className="table-column-sorter-up icon-wrapper"
+                          role="presentation"
+                        >
+                          <svg
+                            role="presentation"
+                            style={
+                              Object {
+                                "height": "16px",
+                                "width": "16px",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
+                              style={
+                                Object {
+                                  "fill": "currentColor",
+                                }
+                              }
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          aria-hidden={false}
+                          className="table-column-sorter-down icon-wrapper"
+                          role="presentation"
+                        >
+                          <svg
+                            role="presentation"
+                            style={
+                              Object {
+                                "height": "16px",
+                                "width": "16px",
+                              }
+                            }
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                              style={
+                                Object {
+                                  "fill": "currentColor",
+                                }
+                              }
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            className="table-tbody"
+          >
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="1"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    AM
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Anamika Musafir
+                    </a>
+                    Beacon, NY
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                78
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="2"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Chandra Garg
+                    </a>
+                    Delhi, Delhi
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                86
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="3"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Regional Sales VP
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CF
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Clarey Fike
+                    </a>
+                    New York, NA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                95
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="4"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Director
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    CD
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Cobbey Deevey
+                    </a>
+                    Atlanta, GA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                66
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="5"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    DS
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Dave Shaw
+                    </a>
+                    San Diego, USA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                72
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="6"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    FA
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Farida Ashfaq
+                    </a>
+                    Mumbai, Maharashtra
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="7"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    FB
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Frank Baptist
+                    </a>
+                    Houston, Texas Area
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                87
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="8"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    JF
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Jerome Feng
+                    </a>
+                    Irvine, CA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                88
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="9"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    JT
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Julie Tharoor
+                    </a>
+                    Bangalore, Karnataka
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                52
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="10"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    NG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Nikita Gagan
+                    </a>
+                    Delhi, Delhi
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="11"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Representative
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    PR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Peter Rege
+                    </a>
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                97
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="12"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Sales Engineer
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    RR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Revathi Roy
+                    </a>
+                    San Francisco Bay Area
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                74
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="13"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Account Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    UL
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Urbanus Laurens
+                    </a>
+                    Salt Lake City, UT
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                76
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="14"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Senior Account Executive
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    VR
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Vance Renner
+                    </a>
+                    St Louis, MO
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                90
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="15"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    ZG
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Zarla Greener
+                    </a>
+                    Chicago, IL
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                79
+              </td>
+            </tr>
+            <tr
+              className="table-row table-row-level-0"
+              data-row-key="16"
+              onClick={[Function]}
+              style={Object {}}
+            >
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                Sales Engineer Manager
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                <div
+                  className="stack horizontal s"
+                  style={
+                    Object {
+                      "alignItems": undefined,
+                      "flexWrap": undefined,
+                      "justifyContent": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="wrapper-style image-style round-image green"
+                    style={
+                      Object {
+                        "fontSize": "18px",
+                        "height": "32px",
+                        "minHeight": "32px",
+                        "minWidth": "32px",
+                        "width": "32px",
+                      }
+                    }
+                  >
+                    DS
+                  </div>
+                  <div
+                    className="stack vertical xxs"
+                    style={
+                      Object {
+                        "alignItems": undefined,
+                        "flexWrap": undefined,
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <a
+                      className="link-style primary"
+                      target="_self"
+                    >
+                      Dave Doe
+                    </a>
+                    San Diego, USA
+                  </div>
+                </div>
+              </td>
+              <td
+                className="table-cell"
+                colSpan={null}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                rowSpan={null}
+                style={Object {}}
+              >
+                72
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div
+    className="table-pagination table-pagination-right pagination"
+    position={
+      Array [
+        "none",
+        "bottomRight",
+      ]
+    }
+  >
+    <span
+      className="sizes"
+    >
+      <div
+        className="main-wrapper"
+      >
+        <button
+          aria-controls="dropdown-101"
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-label="Selected page size"
+          className="button button-neutral button-medium icon-left"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+          role="button"
+          tabIndex="0"
+        >
+          <span>
+            <span
+              aria-hidden={false}
+              className="icon icon-wrapper"
+              role="presentation"
+            >
+              <svg
+                role="presentation"
+                style={
+                  Object {
+                    "height": "20px",
+                    "width": "20px",
+                  }
+                }
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z"
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </svg>
+            </span>
+            <span
+              className="button-text-medium"
+            >
+              page / 10
+            </span>
+          </span>
+        </button>
+      </div>
+    </span>
+    <span
+      className="total"
+    >
+      16 Total
+    </span>
+    <button
+      aria-disabled={true}
+      aria-label="Previous"
+      className="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
+      defaultChecked={false}
+      disabled={true}
+      onClick={[Function]}
+    >
+      <span
+        aria-hidden={false}
+        className="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style={
+            Object {
+              "height": "20px",
+              "width": "20px",
+            }
+          }
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      className="pager"
+    >
+      <li>
+        <button
+          aria-checked={true}
+          aria-disabled={false}
+          aria-pressed={true}
+          className="pagination-button active button button-neutral button-medium"
+          defaultChecked={true}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            1
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-checked={false}
+          aria-disabled={false}
+          aria-pressed={false}
+          className="pagination-button button button-neutral button-medium"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            0
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-checked={false}
+          aria-disabled={false}
+          aria-pressed={false}
+          className="pagination-button button button-neutral button-medium"
+          defaultChecked={false}
+          disabled={false}
+          onClick={[Function]}
+        >
+          <span
+            className="button-text-medium"
+          >
+            2
+          </span>
+        </button>
+      </li>
+    </ul>
+    <button
+      aria-disabled={false}
+      aria-label="Next"
+      className="pagination-button pagination-next button button-neutral button-medium icon-left"
+      defaultChecked={false}
+      disabled={false}
+      onClick={[Function]}
+    >
+      <span
+        aria-hidden={false}
+        className="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style={
+            Object {
+              "height": "20px",
+              "width": "20px",
+            }
+          }
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </svg>
+      </span>
+    </button>
+    <span
+      className="jump"
+    >
+      <div
+        className="input-wrapper left-icon"
+      >
+        <div
+          className="input-group left-icon"
+        >
+          <input
+            aria-disabled={false}
+            autoFocus={false}
+            className="editor pill-shape left-icon clear-not-visible"
+            defaultValue={1}
+            disabled={false}
+            id="input-102"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -47406,7 +47406,7 @@ exports[`Storyshots Table Sort Multiple 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-101"
+          aria-controls="dropdown-103"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -47596,7 +47596,7 @@ exports[`Storyshots Table Sort Multiple 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-102"
+            id="input-104"
             minLength={1}
             onChange={[Function]}
             readOnly={false}
@@ -48985,7 +48985,7 @@ exports[`Storyshots Table Summary 1`] = `
         className="main-wrapper"
       >
         <button
-          aria-controls="dropdown-103"
+          aria-controls="dropdown-105"
           aria-disabled={false}
           aria-expanded={false}
           aria-haspopup={true}
@@ -49175,7 +49175,7 @@ exports[`Storyshots Table Summary 1`] = `
             className="editor pill-shape left-icon clear-not-visible"
             defaultValue={1}
             disabled={false}
-            id="input-104"
+            id="input-106"
             minLength={1}
             onChange={[Function]}
             readOnly={false}


### PR DESCRIPTION
## SUMMARY:

- Fixes bug where dropdown width was not matching the select width but providing props and using state to match
- Fixes caching bug where partial searches were no being cleared
- Adds onClear callback
- Makes number of pills in multiple scenarios dynamic in number, increases their width to show more text
- Adds and exports useMaxVisibleSections hook
- Adds ability to style Icon wrapper
- Fixes component refs
- Adds ability to pass classNames and style to Pills
- Updates UTs
- Allows Tooltip content to wrap and brings tooltips above dropdown in z-order


https://user-images.githubusercontent.com/99700808/187560732-8e460cca-ce79-4203-8801-a52a63ce1c35.mp4



## JIRA TASK (Eightfold Employees Only):
ENG-27812
ENG-27857 (octuple package upgrade will be required)

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [X] Feature Pull Request

## TEST COVERAGE:
TODO: Update UTs to include new scenarios

## TEST PLAN:
pull the pr branch, run `yarn`, then `yarn storybook`, verify the changes to Select stories