### PR TITLE
fix: radio button size

### DIFF
--- a/src/components/RadioButton/radio.module.scss
+++ b/src/components/RadioButton/radio.module.scss
@@ -119,7 +119,7 @@
     }
 
     .selector-label {
-        font-size: $text-font-size-3;
+        font-size: $text-font-size-2;
 
         &-end {
             margin-left: $space-xs;
@@ -158,7 +158,7 @@
         }
 
         .selector-label {
-            font-size: $text-font-size-4;
+            font-size: $text-font-size-3;
 
             &-end {
                 margin-left: $space-m;
@@ -198,7 +198,7 @@
         }
 
         .selector-label {
-            font-size: $text-font-size-3;
+            font-size: $text-font-size-2;
 
             &-end {
                 margin-left: $space-xs;
@@ -238,7 +238,7 @@
         }
 
         .selector-label {
-            font-size: $text-font-size-2;
+            font-size: $text-font-size-1;
 
             &-end {
                 margin-left: $space-xxs;


### PR DESCRIPTION
## SUMMARY:
fix: radio button size.
The [PR](https://github.com/EightfoldAI/octuple/pull/332) changed the radio selector label size. This impacted Radio's across TA & starts to break the UI at multiple places. Reverting the changes in this PR.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
1. skip