### PR TITLE
fix: check box sizes

### DIFF
--- a/src/components/CheckBox/checkbox.module.scss
+++ b/src/components/CheckBox/checkbox.module.scss
@@ -212,7 +212,7 @@
     }
 
     .selector-label {
-        font-size: $text-font-size-3;
+        font-size: $text-font-size-2;
 
         &-end {
             margin-left: $space-xs;
@@ -274,7 +274,7 @@
         }
 
         .selector-label {
-            font-size: $text-font-size-4;
+            font-size: $text-font-size-3;
 
             &-end {
                 margin-left: $space-m;
@@ -337,7 +337,7 @@
         }
 
         .selector-label {
-            font-size: $text-font-size-3;
+            font-size: $text-font-size-2;
 
             &-end {
                 margin-left: $space-xs;
@@ -396,7 +396,7 @@
         }
 
         .selector-label {
-            font-size: $text-font-size-2;
+            font-size: $text-font-size-1;
 
             &-end {
                 margin-left: $space-xxs;


### PR DESCRIPTION
## SUMMARY:
fix: check box sizes
The https://github.com/EightfoldAI/octuple/pull/332 changed the checkbox selector label size. This impacted Checkboxes across TA & starts to break the UI at multiple places. Reverting the changes in this PR.
## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
1. Skip