### PR TITLE
fix: adjust peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "react": ">=16.14.0",
-        "react-dom": "=>16.14.0"
+        "react-dom": ">=16.14.0"
     },
     "devDependencies": {
         "@babel/core": "7.17.5",

--- a/package.json
+++ b/package.json
@@ -71,11 +71,8 @@
         "shallowequal": "1.1.0"
     },
     "peerDependencies": {
-        "@types/react": "17.0.39",
-        "@types/react-dom": "17.0.11",
-        "react": "17.0.2",
-        "react-app-polyfill": "3.0.0",
-        "react-dom": "17.0.2"
+        "react": ">=16.14.0",
+        "react-dom": "=>16.14.0"
     },
     "devDependencies": {
         "@babel/core": "7.17.5",


### PR DESCRIPTION
## SUMMARY:
When trying to install Octuple or other npm packages, it is necessary to use the --force flag if not on the very specific react version referenced in peerDepedencies provided by Octuple. Relaxing this rule and assuming we should at least support the react version currently in use for eightfold.ai applications.

## JIRA TASK (Eightfold Employees Only):
NA

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
