### PR TITLE
fix: table: clip long table header text

### DIFF
--- a/src/components/Table/Internal/octable.module.scss
+++ b/src/components/Table/Internal/octable.module.scss
@@ -125,6 +125,7 @@
         border-top: 0;
         border-left: 0;
         transition: box-shadow 0.3s;
+        @include text-overflow();
 
         &.table-rtl {
             border-right: 0;


### PR DESCRIPTION
## SUMMARY:
fix: table: clip long table header text

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
