### PR TITLE
fix: table: adds type annotations and omits private transformColumns property

### DIFF
--- a/src/components/Table/Internal/OcTable.types.ts
+++ b/src/components/Table/Internal/OcTable.types.ts
@@ -41,13 +41,38 @@ export type DataIndex = string | number | readonly (string | number)[];
 export type CellEllipsisType = { showTitle?: boolean } | boolean;
 
 interface ColumnSharedType<RecordType> {
-    title?: React.ReactNode;
-    key?: Key;
-    classNames?: string;
-    fixed?: FixedType;
-    onHeaderCell?: GetComponentProps<ColumnsType<RecordType>[number]>;
-    ellipsis?: CellEllipsisType;
+    /**
+     * Set the Table Column alignment.
+     * @default 'left'
+     */
     align?: AlignType;
+    /**
+     * The custom class names of the Table Column.
+     */
+    classNames?: string;
+    /**
+     * The ellipsis configuration of the Table cell content.
+     * `tableLayout` is `fixed` when ellipsis is true or { showTitle?: boolean }
+     */
+    ellipsis?: CellEllipsisType;
+    /**
+     * Set Column to fixed.
+     */
+    fixed?: FixedType;
+    /**
+     * Unique key of the Table Column.
+     * May be ignored if you've set a unique `dataIndex`.
+     */
+    key?: Key;
+    /**
+     * Set props on header cell.
+     */
+    onHeaderCell?: GetComponentProps<ColumnsType<RecordType>[number]>;
+    /**
+     * @private
+     * The Column title.
+     */
+    title?: React.ReactNode;
 }
 
 export interface ColumnGroupType<RecordType>
@@ -58,17 +83,40 @@ export interface ColumnGroupType<RecordType>
 export type AlignType = 'left' | 'center' | 'right';
 
 export interface ColumnType<RecordType> extends ColumnSharedType<RecordType> {
+    /**
+     * Span of the Table Column's title
+     */
     colSpan?: number;
+    /**
+     * Display field of the data record.
+     * Supports nest path by string array.
+     */
     dataIndex?: DataIndex;
+    /**
+     * Set props on cell.
+     */
+    onCell?: GetComponentProps<RecordType>;
+    /**
+     * Renderer of the Table cell.
+     * The return value should be a ReactNode.
+     */
     render?: (
         value: any,
         record: RecordType,
         index: number
     ) => React.ReactNode | RenderedCell<RecordType>;
-    shouldCellUpdate?: (record: RecordType, prevRecord: RecordType) => boolean;
+    /**
+     * Span of the Table Column row.
+     */
     rowSpan?: number;
+    /**
+     * Control the Table cell render logic.
+     */
+    shouldCellUpdate?: (record: RecordType, prevRecord: RecordType) => boolean;
+    /**
+     * The Table Column width.
+     */
     width?: number | string;
-    onCell?: GetComponentProps<RecordType>;
 }
 
 export type ColumnsType<RecordType = unknown> = readonly (
@@ -160,21 +208,73 @@ export type RenderExpandIcon<RecordType> = (
 ) => React.ReactNode;
 
 export interface ExpandableConfig<RecordType> {
-    expandedRowKeys?: readonly Key[];
-    defaultExpandedRowKeys?: readonly Key[];
-    expandedRowRender?: ExpandedRowRender<RecordType>;
-    expandRowByClick?: boolean;
-    expandIcon?: RenderExpandIcon<RecordType>;
-    onExpand?: (expanded: boolean, record: RecordType) => void;
-    onExpandedRowsChange?: (expandedKeys: readonly Key[]) => void;
-    defaultExpandAllRows?: boolean;
-    indentSize?: number;
-    showExpandColumn?: boolean;
-    expandedRowClassName?: RowClassName<RecordType>;
+    /**
+     * The Column contains children to display.
+     * @default 'children'
+     */
     childrenColumnName?: string;
-    rowExpandable?: (record: RecordType) => boolean;
+    /**
+     * The width of the expand Column
+     */
     columnWidth?: number | string;
+    /**
+     * Expand all rows by default.
+     * @default false
+     */
+    defaultExpandAllRows?: boolean;
+    /**
+     * Expanded row keys by default.
+     */
+    defaultExpandedRowKeys?: readonly Key[];
+    /**
+     * The expanded row's custom class name.
+     */
+    expandedRowClassName?: RowClassName<RecordType>;
+    /**
+     * Current expanded row keys.
+     */
+    expandedRowKeys?: readonly Key[];
+    /**
+     * Custom expand row Icon.
+     */
+    expandIcon?: RenderExpandIcon<RecordType>;
+    /**
+     * Whether to expand row by clicking anywhere in the row.
+     * @default false
+     */
+    expandRowByClick?: boolean;
+    /**
+     * Expanded container render for each row.
+     */
+    expandedRowRender?: ExpandedRowRender<RecordType>;
+    /**
+     * Whether the expansion icon is fixed.
+     * true | left | right
+     * @default false
+     */
     fixed?: FixedType;
+    /**
+     * Indent size in pixels of Table tree data.
+     * @default 15
+     */
+    indentSize?: number;
+    /**
+     * Callback executed when the expand row icon is clicked.
+     */
+    onExpand?: (expanded: boolean, record: RecordType) => void;
+    /**
+     * Callback executed when the expanded rows change.
+     */
+    onExpandedRowsChange?: (expandedKeys: readonly Key[]) => void;
+    /**
+     * Enable row expandable.
+     */
+    rowExpandable?: (record: RecordType) => boolean;
+    /**
+     * Show expand column.
+     * @default true
+     */
+    showExpandColumn?: boolean;
 }
 
 // =================== Render ===================
@@ -212,42 +312,116 @@ export interface MemoTableContentProps {
 }
 
 export interface OcTableProps<RecordType = unknown> {
+    /**
+     * The Table custom class names.
+     */
     classNames?: string;
-    style?: React.CSSProperties;
+    /**
+     * The Table children.
+     */
     children?: React.ReactNode;
-    data?: readonly RecordType[];
-    columns?: ColumnsType<RecordType>;
-    rowKey?: string | GetRowKey<RecordType>;
-    tableLayout?: TableLayout;
-
-    // Fixed Columns
-    scroll?: { x?: number | true | string; y?: number | string };
-
-    // expandableConfig
-    /** Config expand rows */
-    expandableConfig?: ExpandableConfig<RecordType>;
-    indentSize?: number;
-    rowClassName?: string | RowClassName<RecordType>;
-
-    // Additional Part
-    title?: FrameWrapperRender<RecordType>;
-    footer?: FrameWrapperRender<RecordType>;
-    summary?: (data: readonly RecordType[]) => React.ReactNode;
-
-    // Customize
-    id?: string;
-    showHeader?: boolean;
+    /**
+     * Override default Table elements.
+     */
     components?: TableComponents<RecordType>;
-    onRow?: GetComponentProps<RecordType>;
-    onHeaderRow?: GetComponentProps<readonly ColumnType<RecordType>[]>;
-    emptyText?: React.ReactNode | (() => React.ReactNode);
-    headerClassName?: string;
-
+    /**
+     * The Table canvas direction.
+     * options: 'ltr', 'rtl'
+     */
     direction?: string;
-
+    /**
+     * Configure expandable content.
+     */
+    expandableConfig?: ExpandableConfig<RecordType>;
+    /**
+     * The Table footer renderer.
+     */
+    footer?: FrameWrapperRender<RecordType>;
+    /**
+     * The custom class name of Table header.
+     */
+    headerClassName?: string;
+    /**
+     * The Table id.
+     */
+    id?: string;
+    /**
+     * Indent size in pixels of Table tree data.
+     */
+    indentSize?: number;
+    /**
+     * Set props on header row.
+     */
+    onHeaderRow?: GetComponentProps<readonly ColumnType<RecordType>[]>;
+    /**
+     * Set props on row.
+     */
+    onRow?: GetComponentProps<RecordType>;
+    /**
+     * The custom class name of Table row.
+     */
+    rowClassName?: string | RowClassName<RecordType>;
+    /**
+     * Table Row's unique key.
+     * May be a string or function that returns a string.
+     */
+    rowKey?: string | GetRowKey<RecordType>;
+    /**
+     * Show the Table header.
+     * @default true
+     */
+    showHeader?: boolean;
+    /**
+     * Set Table sticky header and scroll bar.
+     */
+    sticky?: boolean | TableSticky;
+    /**
+     * The Table custom style.
+     */
+    style?: React.CSSProperties;
+    /**
+     * The Table summary content.
+     */
+    summary?: (data: readonly RecordType[]) => React.ReactNode;
+    /**
+     * The table-layout attribute of <table> element.
+     * options: `fixed`, `auto`.
+     */
+    tableLayout?: TableLayout;
+    /**
+     * The Table title renderer.
+     */
+    title?: FrameWrapperRender<RecordType>;
+    /**
+     * @private
+     * The internal Table transform column with an additional debug column.
+     * TODO: investigate removing this internal prop if not needed.
+     */
     transformColumns?: (
         columns: ColumnsType<RecordType>
     ) => ColumnsType<RecordType>;
-
-    sticky?: boolean | TableSticky;
+    /**
+     * @private
+     * The internal Table columns.
+     */
+    columns?: ColumnsType<RecordType>;
+    /**
+     * @private
+     * The Table Data record array to be displayed.
+     */
+    data?: readonly RecordType[];
+    /**
+     * @private
+     * The Table empty text renderer.
+     */
+    emptyText?: React.ReactNode | (() => React.ReactNode);
+    /**
+     * @private
+     * Set if the Table is scrollable. May be used for fixed content.
+     * `x` sets horizontal scrolling, can also be used to specify the width of
+     * the scroll area, could be number, percent value, true and 'max-content'.
+     * `y` sets vertical scrolling, can also be used to specify the height of
+     * the scroll area, could be string or number.
+     */
+    scroll?: { x?: number | true | string; y?: number | string };
 }

--- a/src/components/Table/Table.types.tsx
+++ b/src/components/Table/Table.types.tsx
@@ -176,6 +176,9 @@ export interface ColumnType<RecordType>
 
 export interface ColumnGroupType<RecordType>
     extends Omit<ColumnType<RecordType>, 'dataIndex'> {
+    /**
+     * The ColumnGroup children.
+     */
     children: ColumnsType<RecordType>;
 }
 
@@ -186,15 +189,15 @@ export type ColumnsType<RecordType = unknown> = (
 
 export interface SelectionItem {
     /**
-     * Unique key of this selection.
+     * Unique key of the selection item.
      */
     key: string;
     /**
-     * Callback executed when this selection is clicked.
+     * Callback executed when the selection item is clicked.
      */
     onSelect?: SelectionItemSelectFn;
     /**
-     * Display text of this selection.
+     * Display text of the selection item.
      */
     text: React.ReactNode;
 }
@@ -324,18 +327,34 @@ export interface TablePaginationConfig extends Omit<PaginationProps, 'total'> {
 export const EMPTY_LIST: any[] = [];
 
 export interface ChangeEventInfo<RecordType> {
+    /**
+     * The chnage event params of filters.
+     */
+    filters: Record<string, FilterValue | null>;
+    /**
+     * The filter state.
+     */
+    filterStates: FilterState<RecordType>[];
+    /**
+     * The change event params of pagination.
+     */
     pagination: {
         currentPage?: number;
         pageSize?: number;
         total: number;
     };
-    filters: Record<string, FilterValue | null>;
-    sorter: SorterResult<RecordType> | SorterResult<RecordType>[];
-
-    filterStates: FilterState<RecordType>[];
-    sorterStates: SortState<RecordType>[];
-
+    /**
+     * The reset pagination function.
+     */
     resetPagination: Function;
+    /**
+     * The change event params of sorter.
+     */
+    sorter: SorterResult<RecordType> | SorterResult<RecordType>[];
+    /**
+     * The sorter state.
+     */
+    sorterStates: SortState<RecordType>[];
 }
 
 export interface TableProps<RecordType>

--- a/src/components/Table/Table.types.tsx
+++ b/src/components/Table/Table.types.tsx
@@ -76,30 +76,86 @@ export interface FilterDropdownProps {
 
 export interface ColumnType<RecordType>
     extends Omit<OcColumnType<RecordType>, 'title'> {
+    /**
+     * The default filtered values.
+     */
     defaultFilteredValue?: FilterValue | null;
+    /**
+     * The default order of sorted values.
+     */
     defaultSortOrder?: SortOrder;
-    filtered?: boolean;
-    filteredValue?: FilterValue | null;
+    /**
+     * Customized filter overlay.
+     */
     filterDropdown?:
         | React.ReactNode
         | ((props: FilterDropdownProps) => React.ReactNode);
+    /**
+     * Whether `filterDropdown` is visible.
+     */
+    filterDropdownVisible?: boolean;
+    /**
+     * Whether the `dataSource` is filtered.
+     */
+    filtered?: boolean;
+    /**
+     * Controlled filtered value.
+     */
+    filteredValue?: FilterValue | null;
+    /**
+     * Specify the filter UI.
+     */
     filterMode?: 'menu' | 'tree';
+    /**
+     * Whether multiple filters can be selected.
+     */
     filterMultiple?: boolean;
+    /**
+     * After filter reset, whether to restore the default filter.
+     */
+    filterResetToDefaultFilteredValue?: boolean;
+    /**
+     * Filter menu configuration.
+     */
     filters?: ColumnFilterItem[];
+    /**
+     * Whether to be searchable for filter menu.
+     */
     filterSearch?: FilterSearchType;
+    /**
+     * Function that determines if the row is displayed when filtered.
+     */
     onFilter?: (
         value: string | number | boolean,
         record: RecordType
     ) => boolean;
-    filterDropdownVisible?: boolean;
-    filterResetToDefaultFilteredValue?: boolean;
+    /**
+     * Callback executed when `filterDropdownVisible` is changed.
+     */
     onFilterDropdownVisibleChange?: (visible: boolean) => void;
     /**
-     * Determines the breakpoint when the colomn will hide/show
+     * Determines the breakpoint where the column will hide/show.
+     * Column is always visible if not set.
      */
     responsive?: Breakpoint[];
+    /**
+     * The Table header column show next sorter direction tooltip.
+     * Set as the property of Tooltip if its type is object.
+     * overrides `showSorterTooltip` in Table.
+     * @default true
+     */
     showSorterTooltip?: boolean | TooltipProps;
+    /**
+     * The Table Column sort directions.
+     * options: `ascend`, `descend`.
+     * overrides `sortDirections` in Table.
+     */
     sortDirections?: SortOrder[];
+    /**
+     * Sort function for local sort, see `Array.sort` compareFunction.
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+     * If you need sort buttons only, set to true.
+     */
     sorter?:
         | boolean
         | CompareFn<RecordType>
@@ -108,7 +164,13 @@ export interface ColumnType<RecordType>
               /** Config multiple sorter order priority */
               multiple?: number;
           };
+    /**
+     * Order of sorted values.
+     */
     sortOrder?: SortOrder;
+    /**
+     * The Column title.
+     */
     title?: ColumnTitle<RecordType>;
 }
 
@@ -123,8 +185,17 @@ export type ColumnsType<RecordType = unknown> = (
 )[];
 
 export interface SelectionItem {
+    /**
+     * Unique key of this selection.
+     */
     key: string;
+    /**
+     * Callback executed when this selection is clicked.
+     */
     onSelect?: SelectionItemSelectFn;
+    /**
+     * Display text of this selection.
+     */
     text: React.ReactNode;
 }
 
@@ -136,30 +207,77 @@ export type SelectionSelectFn<T> = (
 ) => void;
 
 export interface TableRowSelection<T> {
+    /**
+     * Check the Table row precisely;
+     * parent row and children rows are not associated.
+     * @default true
+     */
     checkStrictly?: boolean;
+    /**
+     * The selection Column width.
+     */
     columnWidth?: string | number;
+    /**
+     * The selection Column title.
+     */
     columnTitle?: string | React.ReactNode;
+    /**
+     * The default selected row keys.
+     */
     defaultSelectedRowKeys?: Key[];
+    /**
+     * Fixed selection column.
+     * @default 'left'
+     */
     fixed?: FixedType;
+    /**
+     * Get CheckBox or Radio Button props.
+     */
     getCheckboxProps?: (
         record: T
     ) => Partial<Omit<CheckboxProps, 'checked' | 'defaultChecked'>>;
+    /**
+     * Hide the selectAll CheckBox and custom selection.
+     * @default false
+     */
     hideSelectAll?: boolean;
-    /** Keep the selection keys in list
-     * even the key not exist in `dataSource` anymore
+    /**
+     * Callback executed when selected rows change.
+     */
+    onChange?: (selectedRowKeys: Key[], selectedRows: T[]) => void;
+    /**
+     * Callback executed when select/deselect one row.
+     */
+    onSelect?: SelectionSelectFn<T>;
+    /**
+     * Keep the selection keys in list
+     * even if the key no longer exists in `dataSource`.
      **/
     preserveSelectedRowKeys?: boolean;
-    selectedRowKeys?: Key[];
-    selections?: INTERNAL_SELECTION_ITEM[] | boolean;
-    type?: RowSelectionType;
-    onChange?: (selectedRowKeys: Key[], selectedRows: T[]) => void;
-    onSelect?: SelectionSelectFn<T>;
+    /**
+     * Renderer of the Table cell. Same as render in Column.
+     */
     renderCell?: (
         value: boolean,
         record: T,
         index: number,
         originNode: React.ReactNode
     ) => React.ReactNode | OcRenderedCell<T>;
+    /**
+     * Controlled selected row keys.
+     * @default []
+     */
+    selectedRowKeys?: Key[];
+    /**
+     * Custom selection configuration.
+     * Only displays default selections when set to true.
+     */
+    selections?: INTERNAL_SELECTION_ITEM[] | boolean;
+    /**
+     * The row selection type.
+     * options: checkbox | radio
+     */
+    type?: RowSelectionType;
 }
 
 export type TransformColumns<RecordType> = (
@@ -189,7 +307,15 @@ type TablePaginationPosition =
     | 'bottomRight';
 
 export interface TablePaginationConfig extends Omit<PaginationProps, 'total'> {
+    /**
+     * Specify the position of Table Pagination.
+     * [topLeft | topCenter | topRight |bottomLeft | bottomCenter | bottomRight]
+     * @default [bottomRight]
+     */
     position?: TablePaginationPosition[];
+    /**
+     * Specify the Table Pagination total.
+     */
     total?: number;
 }
 
@@ -215,51 +341,179 @@ export interface ChangeEventInfo<RecordType> {
 export interface TableProps<RecordType>
     extends Omit<
         OcTableProps<RecordType>,
-        'data' | 'columns' | 'scroll' | 'emptyText'
+        'data' | 'columns' | 'scroll' | 'emptyText' | 'transformColumns'
     > {
+    /**
+     * The Table Row background colors alternate.
+     * @default true
+     */
     alternateRowColor?: boolean;
+    /**
+     * Show all Table borders.
+     * @default false
+     */
     bordered?: boolean;
+    /**
+     * The Table cancel sort text.
+     * @default 'Click to cancel sorting'
+     */
     cancelSortText?: string;
+    /**
+     * Show only the Table body cell borders.
+     */
     cellBordered?: boolean;
+    /**
+     * The Table collapse text.
+     * @default 'Collapse row'
+     */
     collapseText?: string;
+    /**
+     * The Table columns.
+     */
     columns?: ColumnsType<RecordType>;
+    /**
+     * The Table Data record array to be displayed.
+     */
     dataSource?: OcTableProps<RecordType>['data'];
+    /**
+     * The Table empty text renderer.
+     */
     emptyText?: React.ReactNode | (() => React.ReactNode);
+    /**
+     * The Table empty text details.
+     * Use this to display more information when the Tabel is empty.
+     * @default 'Short Message Here'
+     */
     emptyTextDetails?: string;
+    /**
+     * The Table expand text.
+     * @default 'Expand row'
+     */
     expandText?: string;
-    innerBordered?: boolean;
-    loading?: boolean | SpinnerProps;
-    pagination?: false | TablePaginationConfig;
+    /**
+     * The Table filter checkall text.
+     * @default 'Select all items'
+     */
     filterCheckallText?: string;
+    /**
+     * The Table filter confirm text.
+     * @default 'OK'
+     */
     filterConfirmText?: string;
+    /**
+     * The Table filter empty text.
+     * @default 'No filters'
+     */
     filterEmptyText?: string;
+    /**
+     * The Table filter reset text.
+     * @default 'Reset'
+     */
     filterResetText?: string;
+    /**
+     * The Table filter search placeholder text.
+     * @default 'Search in filters'
+     */
     filterSearchPlaceholderText?: string;
+    /**
+     * The render container of Table dropdowns.
+     */
     getPopupContainer?: GetPopupContainer;
+    /**
+     * Show only the Table inner header cell borders.
+     */
     headerBordered?: boolean;
     /**
-     * Adds border to the bottom of the header
+     * Show only the Table inner header cell bottom borders.
+     * headerBordered must be `false`
      * @default false
      */
     headerBottomBordered?: boolean;
+    /**
+     * Show only the Table header and body cell inner borders.
+     */
+    innerBordered?: boolean;
+    /**
+     * The Table loading state.
+     */
+    loading?: boolean | SpinnerProps;
+    /**
+     * Callback executed when Table pagination, filters, or sort is changed.
+     */
     onChange?: (
         pagination: TablePaginationConfig,
         filters: Record<string, FilterValue | null>,
         sorter: SorterResult<RecordType> | SorterResult<RecordType>[],
         extra: TableCurrentDataSource<RecordType>
     ) => void;
+    /**
+     * Show only the Table outer border.
+     */
     outerBordered?: boolean;
+    /**
+     * Configure Table pagination.
+     * May be hidden if `false`.
+     */
+    pagination?: false | TablePaginationConfig;
+    /**
+     * Show only the Table cell bottom borders.
+     */
     rowBordered?: boolean;
+    /**
+     * Configure Table Row selection.
+     */
     rowSelection?: TableRowSelection<RecordType>;
+    /**
+     * Set if the Table is scrollable.
+     * `scrollToFirstRowOnChange` determines whether to scroll to
+     * the top of the table when paging, sorting, filtering changes.
+     * `x` sets horizontal scrolling, can also be used to specify the width of
+     * the scroll area, could be number, percent value, true and 'max-content'.
+     * `y` sets vertical scrolling, can also be used to specify the height of
+     * the scroll area, could be string or number.
+     */
     scroll?: OcTableProps<RecordType>['scroll'] & {
         scrollToFirstRowOnChange?: boolean;
     };
+    /**
+     * The Table select all text.
+     * @default 'Select all data'
+     */
     selectionAllText?: string;
+    /**
+     * The Table invert select text.
+     * @default 'Invert current page'
+     */
     selectInvertText?: string;
+    /**
+     * The Table select none text.
+     * @default 'Clear all data'
+     */
     selectNoneText?: string;
+    /**
+     * The Table header column show next sorter direction tooltip.
+     * Set as the property of Tooltip if its type is object.
+     * @default true
+     */
     showSorterTooltip?: boolean | TooltipProps;
+    /**
+     * The Table size.
+     * @default TableSize.Medium
+     */
     size?: TableSize | Size;
+    /**
+     * The Table column sort directions.
+     * options: `ascend`, `descend`.
+     */
     sortDirections?: SortOrder[];
+    /**
+     * The Table trigger sort ascending text.
+     * @default 'Click to sort ascending'
+     */
     triggerAscText?: string;
+    /**
+     * The Table trigger sort descending text.
+     * @default 'Click to sort descending'
+     */
     triggerDescText?: string;
 }


### PR DESCRIPTION
## SUMMARY:
The Octuple Table was missing its type annotations. Also needed to omit a private transfomColumns property

## JIRA TASK (Eightfold Employees Only):
ENG-29039

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:
N/A

## TEST PLAN:
Run `yarn` and `yarn storybook`. Verify the Table stories behave as expected.