### PR TITLE
feat: label: add support for custom buttons and type clean up

### DIFF
--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Label, LabelSize } from './index';
+import { ButtonShape } from '../Button';
 
 export default {
     title: 'Label',
@@ -67,15 +68,46 @@ export default {
 
 const Label_Story: ComponentStory<typeof Label> = (args) => <Label {...args} />;
 
-export const Labels = Label_Story.bind({});
+export const Basic = Label_Story.bind({});
+export const Default_Info_Button = Label_Story.bind({});
+export const Custom_Button = Label_Story.bind({});
 
-Labels.args = {
+Basic.args = {
+    text: 'This is a label',
+    size: LabelSize.Medium,
+    classNames: 'my-label-class',
+    colon: false,
+    htmlFor: '',
+};
+
+Default_Info_Button.args = {
     text: 'This is a label',
     size: LabelSize.Medium,
     labelIconButtonProps: {
         show: true,
         toolTipContent: 'A tooltip',
         toolTipPlacement: 'right',
+        onClick: () => _alertClicked(),
+    },
+    classNames: 'my-label-class',
+    colon: false,
+    htmlFor: '',
+};
+
+Custom_Button.args = {
+    text: 'This is a label',
+    size: LabelSize.Medium,
+    labelIconButtonProps: {
+        iconProps: {
+            path: null,
+        },
+        shape: ButtonShape.Pill,
+        show: true,
+        style: {
+            marginLeft: 8,
+            marginTop: -8,
+        },
+        text: 'Learn more',
         onClick: () => _alertClicked(),
     },
     classNames: 'my-label-class',

--- a/src/components/Label/Label.test.tsx
+++ b/src/components/Label/Label.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { Label } from './index';
+import { ButtonShape } from '../Button';
 import MatchMediaMock from 'jest-matchmedia-mock';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -19,6 +20,39 @@ describe('Label', () => {
 
     test('label renders', () => {
         const wrapper = mount(<Label text="Test label" />);
+        expect(wrapper.containsMatchingElement(<Label />)).toEqual(true);
+    });
+    test('label renders with default button', () => {
+        const wrapper = mount(
+            <Label
+                labelIconButtonProps={{
+                    show: true,
+                    toolTipContent: 'A tooltip',
+                    toolTipPlacement: 'right',
+                }}
+                text="Test label"
+            />
+        );
+        expect(wrapper.containsMatchingElement(<Label />)).toEqual(true);
+    });
+    test('label renders with custom button', () => {
+        const wrapper = mount(
+            <Label
+                labelIconButtonProps={{
+                    iconProps: {
+                        path: null,
+                    },
+                    shape: ButtonShape.Pill,
+                    show: true,
+                    style: {
+                        marginLeft: 8,
+                        marginTop: -8,
+                    },
+                    text: 'Learn more',
+                }}
+                text="Test label"
+            />
+        );
         expect(wrapper.containsMatchingElement(<Label />)).toEqual(true);
     });
 });

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useContext } from 'react';
-import { ButtonSize, DefaultButton } from '../Button';
+import { ButtonSize, ButtonShape, DefaultButton } from '../Button';
 import { SizeContext, Size } from '../ConfigProvider';
 import { IconName } from '../Icon/index';
-import { LabelProps, LabelSize } from './index';
+import { LabelIconButtonProps, LabelProps, LabelSize } from './index';
 import { Tooltip } from '../Tooltip';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
@@ -63,6 +63,23 @@ export const Label: FC<LabelProps> = ({
         styles.fieldLabelIconButton,
         sizeClassNames,
     ]);
+    const defaultIconButtonStyles = (
+        labelIconButtonProps: LabelIconButtonProps
+    ): React.CSSProperties => {
+        let styles: React.CSSProperties = null;
+        // If any of the defaults are overriden don't style the button height or padding.
+        if (
+            !labelIconButtonProps.size &&
+            !labelIconButtonProps.shape &&
+            !labelIconButtonProps.text
+        ) {
+            styles = {
+                height: 16,
+                padding: 0,
+            };
+        }
+        return styles;
+    };
     return (
         <div {...rest} className={labelClassNames}>
             {text && (
@@ -85,24 +102,20 @@ export const Label: FC<LabelProps> = ({
                         theme={labelIconButtonProps?.toolTipTheme}
                     >
                         <DefaultButton
-                            allowDisabledFocus={
-                                labelIconButtonProps?.allowDisabledFocus
-                            }
-                            ariaLabel={labelIconButtonProps?.ariaLabel}
                             classNames={styles.labelIconButton}
-                            disabled={labelIconButtonProps?.disabled}
+                            htmlType={'button'}
+                            shape={ButtonShape.Round}
+                            size={ButtonSize.Small}
+                            style={defaultIconButtonStyles(
+                                labelIconButtonProps
+                            )}
+                            {...labelIconButtonProps}
                             iconProps={{
-                                ...labelIconButtonProps,
                                 path:
                                     labelIconButtonProps?.iconProps?.path ||
                                     IconName.mdiInformation,
+                                ...labelIconButtonProps.iconProps,
                             }}
-                            onClick={
-                                !labelIconButtonProps?.allowDisabledFocus
-                                    ? labelIconButtonProps?.onClick
-                                    : null
-                            }
-                            size={ButtonSize.Small}
                         />
                     </Tooltip>
                 </span>

--- a/src/components/Label/Label.types.ts
+++ b/src/components/Label/Label.types.ts
@@ -1,9 +1,8 @@
-import { ButtonIconAlign, ButtonTextAlign } from '../Button';
+import { ButtonProps } from '../Button';
 import { Placement, Strategy } from '@floating-ui/react-dom';
 import { TooltipTheme } from '../Tooltip';
 import { OcBaseProps } from '../OcBase';
 import { Size } from '../ConfigProvider';
-import { IconProps } from '../Icon';
 
 export enum LabelSize {
     Flex = 'flex',
@@ -12,9 +11,9 @@ export enum LabelSize {
     Small = 'small',
 }
 
-export interface LabelIconButtonProps {
+export interface LabelIconButtonProps extends ButtonProps {
     /**
-     * The label icon button is shown.
+     * The label icon button is shown
      * @default false
      */
     show?: boolean;
@@ -22,11 +21,6 @@ export interface LabelIconButtonProps {
      * Content to show on the tooltip
      */
     toolTipContent?: React.ReactNode;
-    /**
-     * Theme of the tooltip
-     * @default light
-     */
-    toolTipTheme?: TooltipTheme;
     /**
      * Placement of the tooltip
      * @default top
@@ -38,75 +32,10 @@ export interface LabelIconButtonProps {
      */
     toolTipPositionStrategy?: Strategy;
     /**
-     * Allows focus on the button when it's disabled.
+     * Theme of the tooltip
+     * @default light
      */
-    allowDisabledFocus?: boolean;
-    /**
-     * The button icon alignment.
-     * @default ButtonIconAlign.Left
-     */
-    alignIcon?: ButtonIconAlign;
-    /**
-     * The button text alignment.
-     * @default ButtonTextAlign.Center
-     */
-    alignText?: ButtonTextAlign;
-    /**
-     * The button aria-label text.
-     */
-    ariaLabel?: string;
-    /**
-     * The button class names.
-     */
-    classNames?: string;
-    /**
-     * The button counter string.
-     */
-    counter?: string;
-    /**
-     * The button disabled state.
-     * @default false
-     */
-    disabled?: boolean;
-    /**
-     * The button disruptive state.
-     * @default false
-     */
-    disruptive?: boolean;
-    /**
-     * The button drop shadow state.
-     * @default false
-     */
-    dropShadow?: boolean;
-    /**
-     * The button icon props.
-     */
-    iconProps?: IconProps;
-    /**
-     * The button id.
-     */
-    id?: string;
-    /**
-     * The button onClick event handler.
-     */
-    onClick?: React.MouseEventHandler<HTMLButtonElement>;
-    /**
-     * The button style.
-     */
-    style?: React.CSSProperties;
-    /**
-     * The button text.
-     */
-    text?: string;
-    /**
-     * The button will remain transparent
-     * @default false
-     */
-    transparent?: boolean;
-    /**
-     * If the button is in loading state
-     */
-    loading?: boolean;
+    toolTipTheme?: TooltipTheme;
     /**
      * Unique id used to target element for testing
      */
@@ -138,6 +67,7 @@ export interface LabelProps extends OcBaseProps<HTMLDivElement> {
     labelIconButtonProps?: LabelIconButtonProps;
     /**
      * The label size.
+     * @default LabelSize.Medium
      */
     size?: LabelSize | Size;
     /**

--- a/src/components/Label/label.module.scss
+++ b/src/components/Label/label.module.scss
@@ -81,18 +81,20 @@
     }
 
     .label-icon-button {
-        border-radius: 100%;
         box-sizing: border-box;
         border-width: 1px;
-        height: 16px;
-        padding: 0;
+    }
+}
 
-        &:active,
-        &:focus-visible {
-            background-color: transparent;
-            outline: 2px solid var(--primary-color-40);
-            outline-offset: -2px;
-            padding: 0;
+:global(.focus-visible) {
+    .field-label-icon-button {
+        .label-icon-button {
+            &:focus-visible {
+                background-color: transparent;
+                outline: 2px solid var(--primary-color-40);
+                outline-offset: -2px;
+                padding: 0;
+            }
         }
     }
 }

--- a/src/src/components/Dialog/__snapshots__/Dialog.stories.storyshot
+++ b/src/src/components/Dialog/__snapshots__/Dialog.stories.storyshot
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Dialog Dialog Helper 1`] = `
+<button
+  aria-disabled={false}
+  className="button button-primary button-medium pill-shape"
+  defaultChecked={false}
+  disabled={false}
+  onClick={[Function]}
+>
+  <span
+    className="button-text-medium"
+  >
+    Open dialog
+  </span>
+</button>
+`;
+
 exports[`Storyshots Dialog Medium 1`] = `
 <button
   aria-disabled={false}

--- a/src/src/components/Inputs/SearchBox/__snapshots__/SearchBox.stories.storyshot
+++ b/src/src/components/Inputs/SearchBox/__snapshots__/SearchBox.stories.storyshot
@@ -29,9 +29,18 @@ exports[`Storyshots Input Search Box 1`] = `
         >
           <button
             aria-disabled={false}
-            className="label-icon-button button button-default button-small pill-shape icon-left"
+            className="label-icon-button button button-default button-small round-shape icon-left"
             defaultChecked={false}
             disabled={false}
+            show={true}
+            style={
+              Object {
+                "height": 16,
+                "padding": 0,
+              }
+            }
+            toolTipContent="tooltip"
+            type="button"
           >
             <span
               aria-hidden={false}

--- a/src/src/components/Inputs/TextArea/__snapshots__/TextArea.stories.storyshot
+++ b/src/src/components/Inputs/TextArea/__snapshots__/TextArea.stories.storyshot
@@ -25,9 +25,18 @@ exports[`Storyshots Input Text Area 1`] = `
       >
         <button
           aria-disabled={false}
-          className="label-icon-button button button-default button-small pill-shape icon-left"
+          className="label-icon-button button button-default button-small round-shape icon-left"
           defaultChecked={false}
           disabled={false}
+          show={true}
+          style={
+            Object {
+              "height": 16,
+              "padding": 0,
+            }
+          }
+          toolTipContent="tooltip"
+          type="button"
         >
           <span
             aria-hidden={false}

--- a/src/src/components/Inputs/TextInput/__snapshots__/TextInput.stories.storyshot
+++ b/src/src/components/Inputs/TextInput/__snapshots__/TextInput.stories.storyshot
@@ -25,9 +25,18 @@ exports[`Storyshots Input Text Input 1`] = `
       >
         <button
           aria-disabled={false}
-          className="label-icon-button button button-default button-small pill-shape icon-left"
+          className="label-icon-button button button-default button-small round-shape icon-left"
           defaultChecked={false}
           disabled={false}
+          show={true}
+          style={
+            Object {
+              "height": 16,
+              "padding": 0,
+            }
+          }
+          toolTipContent="tooltip"
+          type="button"
         >
           <span
             aria-hidden={false}

--- a/src/src/components/Label/__snapshots__/Label.stories.storyshot
+++ b/src/src/components/Label/__snapshots__/Label.stories.storyshot
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Label Labels 1`] = `
+exports[`Storyshots Label Basic 1`] = `
+<div
+  className="field-label medium my-label-class"
+>
+  <label
+    className="text-style medium"
+    htmlFor=""
+  >
+    This is a label
+  </label>
+</div>
+`;
+
+exports[`Storyshots Label Custom Button 1`] = `
 <div
   className="field-label medium my-label-class"
 >
@@ -27,6 +40,65 @@ exports[`Storyshots Label Labels 1`] = `
         defaultChecked={false}
         disabled={false}
         onClick={[Function]}
+        show={true}
+        style={
+          Object {
+            "marginLeft": 8,
+            "marginTop": -8,
+          }
+        }
+        type="button"
+      >
+        <span>
+          <span
+            className="button-text-small"
+          >
+            Learn more
+          </span>
+        </span>
+      </button>
+    </div>
+  </span>
+</div>
+`;
+
+exports[`Storyshots Label Default Info Button 1`] = `
+<div
+  className="field-label medium my-label-class"
+>
+  <label
+    className="text-style medium"
+    htmlFor=""
+  >
+    This is a label
+  </label>
+  <span
+    className="field-label-icon-button medium"
+  >
+    <div
+      className="reference-wrapper"
+      id="4fzzzxj"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+    >
+      <button
+        aria-disabled={false}
+        className="label-icon-button button button-default button-small round-shape icon-left"
+        defaultChecked={false}
+        disabled={false}
+        onClick={[Function]}
+        show={true}
+        style={
+          Object {
+            "height": 16,
+            "padding": 0,
+          }
+        }
+        toolTipContent="A tooltip"
+        toolTipPlacement="right"
+        type="button"
       >
         <span
           aria-hidden={false}

--- a/src/src/components/Skeleton/__snapshots__/Skeleton.stories.storyshot
+++ b/src/src/components/Skeleton/__snapshots__/Skeleton.stories.storyshot
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Skeleton Child Wrapper 1`] = `
+<div
+  className="skeleton-container"
+>
+  <button
+    aria-disabled={false}
+    className="button button-default button-medium pill-shape"
+    defaultChecked={false}
+    disabled={false}
+  >
+    <span
+      className="button-text-medium"
+    >
+      Sample button
+    </span>
+  </button>
+  <div
+    className="skeleton wave pill children"
+    style={
+      Object {
+        "height": undefined,
+        "width": undefined,
+      }
+    }
+    tabIndex={-1}
+  />
+</div>
+`;
+
+exports[`Storyshots Skeleton Default 1`] = `
+<div
+  className="skeleton wave"
+  style={
+    Object {
+      "height": 80,
+      "width": 80,
+    }
+  }
+  tabIndex={-1}
+/>
+`;
+
+exports[`Storyshots Skeleton Sample Usage 1`] = `
+<div
+  className="stack vertical xs"
+  style={
+    Object {
+      "alignItems": undefined,
+      "flexWrap": undefined,
+      "justifyContent": undefined,
+      "width": 210,
+    }
+  }
+>
+  <div
+    className="skeleton wave rounded"
+    style={
+      Object {
+        "height": 10,
+        "width": 210,
+      }
+    }
+    tabIndex={-1}
+  />
+  <div
+    className="skeleton wave circular"
+    style={
+      Object {
+        "height": 40,
+        "width": 40,
+      }
+    }
+    tabIndex={-1}
+  />
+  <div
+    className="skeleton wave"
+    style={
+      Object {
+        "height": 60,
+        "width": 210,
+      }
+    }
+    tabIndex={-1}
+  />
+  <div
+    className="skeleton wave"
+    style={
+      Object {
+        "height": 60,
+        "width": 210,
+      }
+    }
+    tabIndex={-1}
+  />
+  <div
+    className="stack full-width horizontal xs"
+    style={
+      Object {
+        "alignItems": undefined,
+        "flexWrap": undefined,
+        "justifyContent": "flex-end",
+      }
+    }
+  >
+    <div
+      className="skeleton wave button-small"
+      style={
+        Object {
+          "width": 60,
+        }
+      }
+      tabIndex={-1}
+    />
+    <div
+      className="skeleton wave button-small"
+      style={
+        Object {
+          "width": 60,
+        }
+      }
+      tabIndex={-1}
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
## SUMMARY:
The info button of the Label was rather brittle, this improves it a bit and add support for custom buttons.


https://user-images.githubusercontent.com/99700808/189709781-dc9ce155-c3ce-4a0f-bded-dc768c76f96e.mp4



## JIRA TASK (Eightfold Employees Only):
ENG-29160

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [X] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and do `yarn` and `yarn storybook`. Verify the Label stories behave as expected