### PR TITLE
fix: pagination: update base props type from HTMLElement to HTMLDivElement

### DIFF
--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -32,38 +32,38 @@ export interface MenuProps
         'renderItem' | 'role' | 'itemRole' | 'footer'
     > {
     /**
-     * Variant of the menu item
-     * @default MenuVariant.neutral
+     * Props for the cancel button
      */
-    variant?: MenuVariant;
+    cancelButtonProps?: ButtonProps;
     /**
-     * Size of the menu
-     * @default MenuSize.Medium
+     * Props for the ok button
      */
-    size?: MenuSize;
+    okButtonProps?: ButtonProps;
+    /**
+     * Callback when cancel button is clicked
+     */
+    onCancel?: React.MouseEventHandler<HTMLButtonElement>;
     /**
      * On change callback when menu item is clicked
      * @param value
      */
     onChange?: (value: any) => void;
     /**
-     * SubHeader of the menu
-     */
-    subHeader?: string;
-    /**
-     * Props for the ok button
-     */
-    okButtonProps?: ButtonProps;
-    /**
-     * Props for the cancel button
-     */
-    cancelButtonProps?: ButtonProps;
-    /**
      * Callback when ok button is clicked
      */
     onOk?: React.MouseEventHandler<HTMLButtonElement>;
     /**
-     * Callback when cancel button is clicked
+     * Size of the menu
+     * @default MenuSize.Medium
      */
-    onCancel?: React.MouseEventHandler<HTMLButtonElement>;
+    size?: MenuSize;
+    /**
+     * SubHeader of the menu
+     */
+    subHeader?: string;
+    /**
+     * Variant of the menu item
+     * @default MenuVariant.neutral
+     */
+    variant?: MenuVariant;
 }

--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -13,6 +13,16 @@ export enum MenuItemType {
 
 export interface MenuItemProps {
     /**
+     * Size of the menu
+     * @default MenuSize.Medium
+     */
+    size?: MenuSize;
+    /**
+     * Type of the menu
+     * @default MenuType.button
+     */
+    type?: MenuItemType;
+    /**
      * Value of the menu item
      */
     value: any;
@@ -21,16 +31,6 @@ export interface MenuItemProps {
      * @default MenuVariant.neutral
      */
     variant?: MenuVariant;
-    /**
-     * Type of the menu
-     * @default MenuType.button
-     */
-    type?: MenuItemType;
-    /**
-     * Size of the menu
-     * @default MenuSize.Medium
-     */
-    size?: MenuSize;
 }
 
 type NativeMenuButtonProps = Omit<OcBaseProps<HTMLButtonElement>, 'children'>;
@@ -39,36 +39,49 @@ export interface MenuItemButtonProps
     extends MenuItemProps,
         NativeMenuButtonProps {
     /**
-     * Menu item icon props
+     * If the menu item is active or not
+     * @default false
      */
-    iconProps?: IconProps;
+    active?: boolean;
     /**
-     * Display label of the menu item
+     * The counter string.
      */
-    text?: string;
+    counter?: string;
     /**
      * If menu item is disabled or not
      */
     disabled?: boolean;
+    /**
+     * Menu item icon props
+     */
+    iconProps?: IconProps;
     /**
      * On Click handler of the menu item
      * @param value
      */
     onClick?: (value: any) => void;
     /**
-     * The counter string.
+     * Display label of the menu item
      */
-    counter?: string;
-    /**
-     * If the menu item is active or not
-     * @default false
-     */
-    active?: boolean;
+    text?: string;
 }
 
 export interface MenuItemLinkProps
     extends MenuItemProps,
         Omit<LinkProps, 'variant' | 'type'> {
+    /**
+     * If the menu item is active or not
+     * @default false
+     */
+    active?: boolean;
+    /**
+     * The counter string.
+     */
+    counter?: string;
+    /**
+     * If menu item is disabled or not
+     */
+    disabled?: boolean;
     /**
      * Menu item icon props
      */
@@ -77,19 +90,6 @@ export interface MenuItemLinkProps
      * Display label of the menu item
      */
     text?: string;
-    /**
-     * If menu item is disabled or not
-     */
-    disabled?: boolean;
-    /**
-     * The counter string.
-     */
-    counter?: string;
-    /**
-     * If the menu item is active or not
-     * @default false
-     */
-    active?: boolean;
 }
 
 export interface MenuItemSubHeaderProps

--- a/src/components/Modal/Modal.types.ts
+++ b/src/components/Modal/Modal.types.ts
@@ -14,16 +14,16 @@ export interface ModalProps
         'dialogWrapperClassName' | 'dialogClassName'
     > {
     /**
-     * Size of the modal
-     * @default medium
+     * Custom class for the modal
      */
-    size?: ModalSize;
+    modalClassNames?: string;
     /**
      * Custom class for the modal wrapper
      */
     modalWrapperClassNames?: string;
     /**
-     * Custom class for the modal
+     * Size of the modal
+     * @default medium
      */
-    modalClassNames?: string;
+    size?: ModalSize;
 }

--- a/src/components/Navbar/Navbar.types.ts
+++ b/src/components/Navbar/Navbar.types.ts
@@ -1,11 +1,11 @@
 import { OcBaseProps } from '../OcBase';
 import { Value } from '../ConfigProvider';
 
-export interface NavbarProps extends OcBaseProps<HTMLDivElement> {}
-
 export interface NavbarTheme {
     background?: Value;
     textColor?: Value;
     textHoverBackground?: Value;
     textHoverColor?: Value;
 }
+
+export interface NavbarProps extends OcBaseProps<HTMLDivElement> {}

--- a/src/components/Pagination/Pagination.types.ts
+++ b/src/components/Pagination/Pagination.types.ts
@@ -24,7 +24,7 @@ export interface PagerProps
         | 'totalText'
     > {}
 
-export interface PaginationProps extends OcBaseProps<HTMLElement> {
+export interface PaginationProps extends OcBaseProps<HTMLDivElement> {
     /**
      * The current page.
      * @default 1
@@ -98,6 +98,11 @@ export interface PaginationProps extends OcBaseProps<HTMLElement> {
      */
     quickPreviousIconButtonAriaLabel?: string;
     /**
+     * The Page change is controlled internally.
+     * @default true
+     */
+    selfControlled?: boolean;
+    /**
      * Pagination simplified mode.
      * @default false
      */
@@ -112,9 +117,4 @@ export interface PaginationProps extends OcBaseProps<HTMLElement> {
      * @default 'Total'
      */
     totalText?: string;
-    /**
-     * The Page change is controlled internally.
-     * @default true
-     */
-    selfControlled?: boolean;
 }


### PR DESCRIPTION
## SUMMARY:
The derived element type was wrong and didn't match the ref type. Cleans up other type annotations and alphabetizes them.

## JIRA TASK (Eightfold Employees Only):
ENG-29250

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:
N/A type clean-up

## TEST PLAN:
Pull the pr branch and do `yarn` and `yarn storybook`. Verify the Pagination, Menu, and Navbar stories behave as expected.