### PR TITLE
fix: button: fixes floating icon button distortion in some versions of safari

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -222,6 +222,12 @@ const Split_Button_Story: ComponentStory<typeof PrimaryButton> = (args) => (
 export const Split = Split_Button_Story.bind({});
 export const Split_With_Counter = Split_Button_Story.bind({});
 
+const Floating_Button_Story: ComponentStory<typeof PrimaryButton> = (args) => (
+    <PrimaryButton {...args} />
+);
+
+export const Floating_Button = Floating_Button_Story.bind({});
+
 const buttonArgs: Object = {
     alignIcon: ButtonIconAlign.Left,
     alignText: ButtonTextAlign.Center,
@@ -362,4 +368,13 @@ Split_With_Counter.args = {
     split: true,
     splitButtonChecked: false,
     text: 'Split Button',
+};
+
+Floating_Button.args = {
+    ...buttonArgs,
+    floatingButtonProps: {
+        enabled: true,
+    },
+    shape: ButtonShape.Round,
+    text: null,
 };

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -143,17 +143,32 @@
     &-large {
         height: 44px;
         padding: $button-padding-vertical-large $button-padding-horizontal-large;
+
+        &.floating.round-shape {
+            width: 44px;
+            height: 44px;
+        }
     }
 
     &-medium {
         height: 36px;
         padding: $button-padding-vertical-medium
             $button-padding-horizontal-medium;
+
+        &.floating.round-shape {
+            width: 36px;
+            height: 36px;
+        }
     }
 
     &-small {
         height: 28px;
         padding: $button-padding-vertical-small $button-padding-horizontal-small;
+
+        &.floating.round-shape {
+            width: 28px;
+            height: 28px;
+        }
     }
 
     &:disabled,

--- a/src/src/components/Button/__snapshots__/Button.stories.storyshot
+++ b/src/src/components/Button/__snapshots__/Button.stories.storyshot
@@ -103,6 +103,48 @@ exports[`Storyshots Button Default 1`] = `
 </button>
 `;
 
+exports[`Storyshots Button Floating Button 1`] = `
+<button
+  aria-disabled={false}
+  aria-label="Button"
+  className="my-btn-class button button-primary button-medium round-shape floating icon-left"
+  data-test-id="my-btn-test-id"
+  defaultChecked={false}
+  disabled={false}
+  id="myButton"
+  style={Object {}}
+  type="button"
+>
+  <span
+    aria-hidden={true}
+    className="icon my-btn-icon icon-wrapper"
+    data-test-id="myButtonIconTestId"
+    id="myButtonIcon"
+    role="presentation"
+  >
+    <svg
+      role="presentation"
+      style={
+        Object {
+          "height": "20px",
+          "width": "20px",
+        }
+      }
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+        style={
+          Object {
+            "fill": "currentColor",
+          }
+        }
+      />
+    </svg>
+  </span>
+</button>
+`;
+
 exports[`Storyshots Button Neutral 1`] = `
 <button
   aria-disabled={false}

--- a/src/src/components/Icon/__snapshots__/Icon.stories.storyshot
+++ b/src/src/components/Icon/__snapshots__/Icon.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Icon Basic 1`] = `
   role="presentation"
 >
   <svg
-    aria-labelledby="icon_labelledby_157 icon_describedby_157"
+    aria-labelledby="icon_labelledby_158 icon_describedby_158"
     style={
       Object {
         "height": "20px",
@@ -19,12 +19,12 @@ exports[`Storyshots Icon Basic 1`] = `
     viewBox="0 0 24 24"
   >
     <title
-      id="icon_labelledby_157"
+      id="icon_labelledby_158"
     >
       My icon title.
     </title>
     <desc
-      id="icon_describedby_157"
+      id="icon_describedby_158"
     >
       My icon description.
     </desc>


### PR DESCRIPTION
## SUMMARY:
The floating, fixed round icon button not having a width caused distortion in some versions of Safari. This change adds a set width and height to floating buttons.

![floatingButton](https://user-images.githubusercontent.com/99700808/190025036-1d468851-e7e8-4624-8680-51e46d75e528.png)

## JIRA TASK (Eightfold Employees Only):
ENG-29154

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [X] I have added snapshot tests for this change

## TEST PLAN:
pull the pr branch and do `yarn`, then `yarn storybook`. Verify the floating button story behaves as expected.