### PR TITLE
fix: remove flex style from link

### DIFF
--- a/src/components/Link/link.module.scss
+++ b/src/components/Link/link.module.scss
@@ -1,8 +1,5 @@
 .link-style {
-    align-items: center;
     cursor: pointer;
-    display: flex;
-    flex-direction: row;
     font-family: $octuple-font-family;
     font-size: $text-font-size-2;
 


### PR DESCRIPTION
## SUMMARY:
fix: remove flex style from link

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
