### PR TITLE
fix: table: add page sizes prop to table pagination

### DIFF
--- a/src/components/Table/Hooks/usePagination.ts
+++ b/src/components/Table/Hooks/usePagination.ts
@@ -87,9 +87,7 @@ export default function usePagination(
     if (pages) {
         for (let i: number = 0; i < pages.length; ++i) {
             if (mergedPagination.pageSize === pages[i]) {
-                console.log('usePagination pages: ' + pages[i]);
                 maxPage = Math.ceil((paginationTotal || total) / pages[i]!);
-                console.log('usePagination maxPage: ' + maxPage);
             }
         }
     } else {
@@ -144,10 +142,6 @@ export default function usePagination(
                 if (size === pages[i]) {
                     mergedPagination.onSizeChange?.(
                         mergedPagination?.pageSizes[i]
-                    );
-                    console.log(
-                        'onInternalSizeChange pageSize: ' +
-                            mergedPagination?.pageSizes[i]
                     );
                     refreshPagination(
                         mergedPagination?.currentPage,

--- a/src/components/Table/Hooks/usePagination.ts
+++ b/src/components/Table/Hooks/usePagination.ts
@@ -141,23 +141,27 @@ export default function usePagination(
         const pages: number[] = mergedPagination?.pageSizes;
         if (pages) {
             for (let i: number = 0; i < pages.length; ++i) {
-                mergedPagination.onSizeChange?.(mergedPagination?.pageSizes[i]);
-                console.log(
-                    'onInternalSizeChange pageSize: ' +
+                if (size === pages[i]) {
+                    mergedPagination.onSizeChange?.(
                         mergedPagination?.pageSizes[i]
-                );
-                refreshPagination(
-                    mergedPagination?.currentPage,
-                    size,
-                    mergedPagination?.pageSizes!,
-                    mergedPagination?.total
-                );
-                onChange(
-                    mergedPagination?.currentPage,
-                    size || mergedPagination?.pageSizes[i]!,
-                    mergedPagination?.pageSizes!,
-                    mergedPagination?.total
-                );
+                    );
+                    console.log(
+                        'onInternalSizeChange pageSize: ' +
+                            mergedPagination?.pageSizes[i]
+                    );
+                    refreshPagination(
+                        mergedPagination?.currentPage,
+                        size,
+                        mergedPagination?.pageSizes!,
+                        mergedPagination?.total
+                    );
+                    onChange(
+                        mergedPagination?.currentPage,
+                        size || mergedPagination?.pageSizes[i]!,
+                        mergedPagination?.pageSizes!,
+                        mergedPagination?.total
+                    );
+                }
             }
         } else {
             mergedPagination.onSizeChange?.(mergedPagination?.pageSize);

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1324,7 +1324,7 @@ const VirtualTable = (props: Parameters<typeof Table>[0]) => {
     );
 };
 
-const Debug_Story: ComponentStory<typeof Table> = (args) => {
+const Page_Sizes_Story: ComponentStory<typeof Table> = (args) => {
     const n: any[] = [];
     const total = 1000;
 
@@ -1341,7 +1341,6 @@ const Debug_Story: ComponentStory<typeof Table> = (args) => {
                 dataIndex: 'key',
                 width: 300,
                 render: (value: any) => {
-                    // This prints 1000 statements even if there are only 5 elements in a page
                     console.log('row rendered');
                     return value;
                 },
@@ -1350,16 +1349,17 @@ const Debug_Story: ComponentStory<typeof Table> = (args) => {
     };
     return (
         <Table
+            {...args}
             title={() => (
                 <div className="i18n-messages-table-title">
-                    <h3>{'Translations'}</h3>
+                    <h3>{'Data'}</h3>
                 </div>
             )}
             dataSource={r}
             sticky
             columns={getColumns()}
             emptyTextDetails=""
-            emptyText={'No translations found'}
+            emptyText={'No data found'}
             pagination={{
                 layout: [
                     PaginationLayoutOptions.Sizes,
@@ -1368,7 +1368,6 @@ const Debug_Story: ComponentStory<typeof Table> = (args) => {
                     PaginationLayoutOptions.Previous,
                     PaginationLayoutOptions.Pager,
                 ],
-                // pageSize: 5,
                 pageSizes: [5, 10, 20],
                 total: r?.length,
             }}
@@ -1378,8 +1377,6 @@ const Debug_Story: ComponentStory<typeof Table> = (args) => {
         />
     );
 };
-
-export const Debug = Debug_Story.bind({});
 
 export const Basic = Table_Base_Story.bind({});
 export const Bordered = Table_Base_Story.bind({});
@@ -1410,6 +1407,7 @@ export const Ellipsis_With_Tooltip = Table_Base_Story.bind({});
 export const Responsive = Table_Base_Story.bind({});
 export const Tree = Table_Base_Story.bind({});
 export const Nested = Table_Base_Story.bind({});
+export const Page_Sizes = Page_Sizes_Story.bind({});
 
 export const Virtual_List: FC = () => {
     return (
@@ -1638,4 +1636,8 @@ Nested.args = {
     expandableConfig: {
         expandedRowRender,
     },
+};
+
+Page_Sizes.args = {
+    ...tableArgs,
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1324,6 +1324,63 @@ const VirtualTable = (props: Parameters<typeof Table>[0]) => {
     );
 };
 
+const Debug_Story: ComponentStory<typeof Table> = (args) => {
+    const n: any[] = [];
+    const total = 1000;
+
+    const [r, setR] = useState(n);
+
+    for (let i = 0; i < total; i++) {
+        n.push({ key: i });
+    }
+
+    const getColumns = () => {
+        return [
+            {
+                title: 'Key',
+                dataIndex: 'key',
+                width: 300,
+                render: (value: any) => {
+                    // This prints 1000 statements even if there are only 5 elements in a page
+                    console.log('row rendered');
+                    return value;
+                },
+            },
+        ];
+    };
+    return (
+        <Table
+            title={() => (
+                <div className="i18n-messages-table-title">
+                    <h3>{'Translations'}</h3>
+                </div>
+            )}
+            dataSource={r}
+            sticky
+            columns={getColumns()}
+            emptyTextDetails=""
+            emptyText={'No translations found'}
+            pagination={{
+                layout: [
+                    PaginationLayoutOptions.Sizes,
+                    PaginationLayoutOptions.Total,
+                    PaginationLayoutOptions.Next,
+                    PaginationLayoutOptions.Previous,
+                    PaginationLayoutOptions.Pager,
+                ],
+                // pageSize: 5,
+                pageSizes: [5, 10, 20],
+                total: r?.length,
+            }}
+            scroll={{
+                y: 2000,
+            }}
+        />
+    );
+};
+
+export const Debug = Debug_Story.bind({});
+
 export const Basic = Table_Base_Story.bind({});
 export const Bordered = Table_Base_Story.bind({});
 export const Cell_Bordered = Table_Base_Story.bind({});

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1369,6 +1369,7 @@ const Page_Sizes_Story: ComponentStory<typeof Table> = (args) => {
                     PaginationLayoutOptions.Pager,
                 ],
                 pageSizes: [5, 10, 20],
+                selfControlled: false,
                 total: r?.length,
             }}
             scroll={{

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -215,7 +215,6 @@ function InternalTable<RecordType extends object = any>(
                 const pages: number[] = changeInfo.pagination!.pageSizes!;
 
                 if (pages) {
-                    console.log('triggerOnChange pages: ' + pages);
                     for (let i: number = 0; i < pages.length; ++i) {
                         pagination.onSizeChange?.(
                             changeInfo.pagination!.pageSizes[i]
@@ -333,13 +332,6 @@ function InternalTable<RecordType extends object = any>(
         pageSize: number,
         pageSizes: number[]
     ) => {
-        console.log(
-            'onPaginationChange pageSize: ' +
-                pageSize +
-                ' ' +
-                'onPaginationChange pageSizes: ' +
-                pageSizes
-        );
         triggerOnChange(
             {
                 pagination: {
@@ -376,7 +368,9 @@ function InternalTable<RecordType extends object = any>(
         }
 
         const {
-            currentPage = 1,
+            currentPage = mergedPagination.pageSizes
+                ? mergedPagination.currentPage || 1
+                : 1,
             total,
             pageSize = mergedPagination.pageSizes
                 ? mergedPagination.pageSizes[0]
@@ -386,16 +380,9 @@ function InternalTable<RecordType extends object = any>(
 
         // Dynamic table data
         if (pageSizes) {
-            console.log('Dynamic table data pageSizes: ' + pageSizes);
             for (let i: number = 0; i < pageSizes.length; ++i) {
                 if (pageSize === pageSizes[i]) {
                     mergedPagination.pageSize = pageSizes[i];
-                    console.log(
-                        'Dynamic table data pageSizes[' +
-                            i +
-                            '] value: ' +
-                            pageSizes[i]
-                    );
                     if (mergedData.length < total!) {
                         if (mergedData.length > pageSizes[i]) {
                             return mergedData.slice(
@@ -406,15 +393,6 @@ function InternalTable<RecordType extends object = any>(
                         return mergedData;
                     }
 
-                    // This is not getting logged unless the page size is updated twice
-                    // after changing page size then paging to a new page.
-                    console.log(
-                        mergedData.slice(
-                            (currentPage - 1) * pageSizes[i],
-                            currentPage * pageSizes[i]
-                        )
-                    );
-
                     return mergedData.slice(
                         (currentPage - 1) * pageSizes[i],
                         currentPage * pageSizes[i]
@@ -422,7 +400,6 @@ function InternalTable<RecordType extends object = any>(
                 }
             }
         } else {
-            console.log('Dynamic table data pageSize: ' + pageSize);
             if (mergedData.length < total!) {
                 if (mergedData.length > pageSize) {
                     return mergedData.slice(
@@ -525,13 +502,11 @@ function InternalTable<RecordType extends object = any>(
         let paginationSizes: TablePaginationConfig['pageSizes'];
 
         if (mergedPagination.pageSize) {
-            console.log('Table pageSize: ' + mergedPagination.pageSize);
             paginationSize = mergedPagination.pageSize;
         } else {
             paginationSize = undefined;
         }
         if (mergedPagination.pageSizes) {
-            console.log('Table pageSizes: ' + mergedPagination.pageSizes);
             paginationSizes = mergedPagination.pageSizes;
         } else {
             paginationSizes = undefined;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -378,19 +378,18 @@ function InternalTable<RecordType extends object = any>(
         const {
             currentPage = 1,
             total,
-            pageSize = DEFAULT_PAGE_SIZE,
+            pageSize = mergedPagination.pageSizes
+                ? mergedPagination.pageSizes[0]
+                : DEFAULT_PAGE_SIZE,
             pageSizes,
         } = mergedPagination;
 
         // Dynamic table data
         if (pageSizes) {
-            // Set the default when pageSizes
-            mergedPagination.pageSize = pageSizes[0];
-
             console.log('Dynamic table data pageSizes: ' + pageSizes);
             for (let i: number = 0; i < pageSizes.length; ++i) {
                 if (pageSize === pageSizes[i]) {
-                    // This is not getting called unless the page size is updated twice.
+                    mergedPagination.pageSize = pageSizes[i];
                     console.log(
                         'Dynamic table data pageSizes[' +
                             i +
@@ -407,6 +406,8 @@ function InternalTable<RecordType extends object = any>(
                         return mergedData;
                     }
 
+                    // This is not getting logged unless the page size is updated twice
+                    // after changing page size then paging to a new page.
                     console.log(
                         mergedData.slice(
                             (currentPage - 1) * pageSizes[i],

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -384,9 +384,9 @@ function InternalTable<RecordType extends object = any>(
 
         // Dynamic table data
         if (pageSizes) {
-            // Need to figure out why this isn't changing.
             console.log('Dynamic table data pageSizes: ' + pageSizes);
             for (let i: number = 0; i < pageSizes.length; ++i) {
+                // For whatever reason this log stays the same.
                 console.log(
                     'Dynamic table data pageSizes[' +
                         i +
@@ -404,7 +404,6 @@ function InternalTable<RecordType extends object = any>(
                 }
 
                 // For whatever reason this log stays the same.
-                // We currently do useMemo, so might need to move this into useEffect?
                 console.log(
                     mergedData.slice(
                         (currentPage - 1) * pageSizes[i],

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -211,7 +211,19 @@ function InternalTable<RecordType extends object = any>(
                 pagination.onCurrentChange?.(
                     changeInfo.pagination!.currentPage!
                 );
-                pagination.onSizeChange?.(changeInfo.pagination!.pageSize!);
+
+                const pages: number[] = changeInfo.pagination!.pageSizes!;
+
+                if (pages) {
+                    console.log('triggerOnChange pages: ' + pages);
+                    for (let i: number = 0; i < pages.length; ++i) {
+                        pagination.onSizeChange?.(
+                            changeInfo.pagination!.pageSizes[i]
+                        );
+                    }
+                } else {
+                    pagination.onSizeChange?.(changeInfo.pagination!.pageSize!);
+                }
             }
         }
 
@@ -316,13 +328,25 @@ function InternalTable<RecordType extends object = any>(
     const [transformTitleColumns] = useTitleColumns(columnTitleProps);
 
     // ========================== Pagination ==========================
-    const onPaginationChange = (currentPage: number, pageSize: number) => {
+    const onPaginationChange = (
+        currentPage: number,
+        pageSize: number,
+        pageSizes: number[]
+    ) => {
+        console.log(
+            'onPaginationChange pageSize: ' +
+                pageSize +
+                ' ' +
+                'onPaginationChange pageSizes: ' +
+                pageSizes
+        );
         triggerOnChange(
             {
                 pagination: {
                     ...changeEventInfo.pagination,
                     currentPage,
                     pageSize,
+                    pageSizes,
                 },
             },
             'paginate'
@@ -344,36 +368,79 @@ function InternalTable<RecordType extends object = any>(
 
     // ============================= Data =============================
     const pageData = useMemo<RecordType[]>(() => {
-        if (pagination === false || !mergedPagination.pageSize) {
+        if (
+            pagination === false ||
+            (!mergedPagination.pageSize && !mergedPagination.pageSizes)
+        ) {
             return mergedData;
         }
 
         const {
             currentPage = 1,
             total,
-            pageSize = DEFAULT_PAGE_SIZE,
+            pageSize = DEFAULT_PAGE_SIZE, // Need to figure out how to update this value
+            pageSizes,
         } = mergedPagination;
 
         // Dynamic table data
-        if (mergedData.length < total!) {
-            if (mergedData.length > pageSize) {
+        if (pageSizes) {
+            // Need to figure out why this isn't changing.
+            console.log('Dynamic table data pageSizes: ' + pageSizes);
+            for (let i: number = 0; i < pageSizes.length; ++i) {
+                console.log(
+                    'Dynamic table data pageSizes[' +
+                        i +
+                        '] value: ' +
+                        pageSizes[i]
+                );
+                if (mergedData.length < total!) {
+                    if (mergedData.length > pageSizes[i]) {
+                        return mergedData.slice(
+                            (currentPage - 1) * pageSizes[i],
+                            currentPage * pageSizes[i]
+                        );
+                    }
+                    return mergedData;
+                }
+
+                // For whatever reason this log stays the same.
+                // We currently do useMemo, so might need to move this into useEffect?
+                console.log(
+                    mergedData.slice(
+                        (currentPage - 1) * pageSizes[i],
+                        currentPage * pageSizes[i]
+                    )
+                );
+
                 return mergedData.slice(
-                    (currentPage - 1) * pageSize,
-                    currentPage * pageSize
+                    (currentPage - 1) * pageSizes[i],
+                    currentPage * pageSizes[i]
                 );
             }
-            return mergedData;
-        }
+        } else {
+            console.log('Dynamic table data pageSize: ' + pageSize);
+            if (mergedData.length < total!) {
+                if (mergedData.length > pageSize) {
+                    return mergedData.slice(
+                        (currentPage - 1) * pageSize,
+                        currentPage * pageSize
+                    );
+                }
+                return mergedData;
+            }
 
-        return mergedData.slice(
-            (currentPage - 1) * pageSize,
-            currentPage * pageSize
-        );
+            return mergedData.slice(
+                (currentPage - 1) * pageSize,
+                currentPage * pageSize
+            );
+        }
+        return null;
     }, [
         !!pagination,
         mergedData,
         mergedPagination?.currentPage,
         mergedPagination?.pageSize,
+        mergedPagination?.pageSizes,
         mergedPagination?.total,
     ]);
 
@@ -448,12 +515,22 @@ function InternalTable<RecordType extends object = any>(
 
     let topPaginationNode: React.ReactNode;
     let bottomPaginationNode: React.ReactNode;
+
     if (pagination !== false && mergedPagination?.total) {
         let paginationSize: TablePaginationConfig['pageSize'];
+        let paginationSizes: TablePaginationConfig['pageSizes'];
+
         if (mergedPagination.pageSize) {
+            console.log('Table pageSize: ' + mergedPagination.pageSize);
             paginationSize = mergedPagination.pageSize;
         } else {
             paginationSize = undefined;
+        }
+        if (mergedPagination.pageSizes) {
+            console.log('Table pageSizes: ' + mergedPagination.pageSizes);
+            paginationSizes = mergedPagination.pageSizes;
+        } else {
+            paginationSizes = undefined;
         }
 
         const renderPagination = (position: string) => (
@@ -476,6 +553,7 @@ function InternalTable<RecordType extends object = any>(
                     mergedPagination.className,
                 ])}
                 pageSize={paginationSize}
+                pageSizes={paginationSizes}
                 total={mergedPagination?.total}
             />
         );

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -378,15 +378,19 @@ function InternalTable<RecordType extends object = any>(
         const {
             currentPage = 1,
             total,
-            pageSize = DEFAULT_PAGE_SIZE, // Need to figure out how to update this value
+            pageSize = DEFAULT_PAGE_SIZE,
             pageSizes,
         } = mergedPagination;
 
         // Dynamic table data
         if (pageSizes) {
+            // Set the default when pageSizes
+            mergedPagination.pageSize = pageSizes[0];
+
             console.log('Dynamic table data pageSizes: ' + pageSizes);
             for (let i: number = 0; i < pageSizes.length; ++i) {
                 if (pageSize === pageSizes[i]) {
+                    // This is not getting called unless the page size is updated twice.
                     console.log(
                         'Dynamic table data pageSizes[' +
                             i +

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -386,35 +386,35 @@ function InternalTable<RecordType extends object = any>(
         if (pageSizes) {
             console.log('Dynamic table data pageSizes: ' + pageSizes);
             for (let i: number = 0; i < pageSizes.length; ++i) {
-                // For whatever reason this log stays the same.
-                console.log(
-                    'Dynamic table data pageSizes[' +
-                        i +
-                        '] value: ' +
-                        pageSizes[i]
-                );
-                if (mergedData.length < total!) {
-                    if (mergedData.length > pageSizes[i]) {
-                        return mergedData.slice(
+                if (pageSize === pageSizes[i]) {
+                    console.log(
+                        'Dynamic table data pageSizes[' +
+                            i +
+                            '] value: ' +
+                            pageSizes[i]
+                    );
+                    if (mergedData.length < total!) {
+                        if (mergedData.length > pageSizes[i]) {
+                            return mergedData.slice(
+                                (currentPage - 1) * pageSizes[i],
+                                currentPage * pageSizes[i]
+                            );
+                        }
+                        return mergedData;
+                    }
+
+                    console.log(
+                        mergedData.slice(
                             (currentPage - 1) * pageSizes[i],
                             currentPage * pageSizes[i]
-                        );
-                    }
-                    return mergedData;
-                }
+                        )
+                    );
 
-                // For whatever reason this log stays the same.
-                console.log(
-                    mergedData.slice(
+                    return mergedData.slice(
                         (currentPage - 1) * pageSizes[i],
                         currentPage * pageSizes[i]
-                    )
-                );
-
-                return mergedData.slice(
-                    (currentPage - 1) * pageSizes[i],
-                    currentPage * pageSizes[i]
-                );
+                    );
+                }
             }
         } else {
             console.log('Dynamic table data pageSize: ' + pageSize);

--- a/src/components/Table/Table.types.tsx
+++ b/src/components/Table/Table.types.tsx
@@ -341,6 +341,7 @@ export interface ChangeEventInfo<RecordType> {
     pagination: {
         currentPage?: number;
         pageSize?: number;
+        pageSizes?: number[];
         total: number;
     };
     /**


### PR DESCRIPTION
## SUMMARY:
The Table pagination props didn't yet support pageSizes, this change adds support.


https://user-images.githubusercontent.com/99700808/192438187-b700821b-64ce-49d7-803c-0bf90ecee3ca.mp4



## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/388

## JIRA TASK (Eightfold Employees Only):
ENG-30331

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [X] I have added unittests/snapshots for this change

## TEST PLAN:
pull the pr branch and do `yarn` and `yarn storybook` verify the Table Page Sizes story behaves as expected.