### PR TITLE
feat: picker: add localization support to date and time pickers

### DIFF
--- a/src/components/DateTimePicker/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DateTimePicker/DatePicker/DatePicker.stories.tsx
@@ -7,7 +7,6 @@ import DatePicker from './';
 import { DatePickerShape, DatePickerSize } from './';
 import type { DatePickerProps, RangePickerProps } from './';
 import { Stack } from '../../Stack';
-import locale from './Locale/en_US';
 
 export default {
     title: 'Date Picker',
@@ -510,7 +509,6 @@ export const Range_Status = Range_Status_Story.bind({});
 const pickerArgs: Object = {
     classNames: 'my-picker-class',
     id: 'myPickerInputId',
-    locale: locale,
     shape: DatePickerShape.Rectangle,
     size: DatePickerSize.Medium,
 };

--- a/src/components/DateTimePicker/DatePicker/Generate/generateSinglePicker.tsx
+++ b/src/components/DateTimePicker/DatePicker/Generate/generateSinglePicker.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, useContext, useImperativeHandle } from 'react';
+import React, {
+    forwardRef,
+    useContext,
+    useEffect,
+    useImperativeHandle,
+    useState,
+} from 'react';
 import DisabledContext, {
     Disabled,
 } from '../../../ConfigProvider/DisabledContext';
@@ -28,7 +34,9 @@ import type {
     PickerTimeProps,
 } from './Generate.types';
 import { Components } from './Generate.types';
-import LocaleReceiver from '../../../LocaleProvider/LocaleReceiver';
+import LocaleReceiver, {
+    useLocaleReceiver,
+} from '../../../LocaleProvider/LocaleReceiver';
 import enUS from '../Locale/en_US';
 import { getPlaceholder, transPlacement2DropdownAlign } from '../util';
 import { Icon, IconName, IconSize } from '../../../Icon';
@@ -56,22 +64,26 @@ export default function generatePicker<DateType>(
             InnerPickerProps
         >((props, ref) => {
             const {
-                getPopupContainer,
+                bordered = true,
                 classNames,
+                clearIconAriaLabelText: defaultClearIconAriaLabelText,
                 configContextProps = {
                     noDisabledContext: false,
                     noShapeContext: false,
                     noSizeContext: false,
                 },
+                disabled = false,
                 formItemInput = false,
+                getPopupContainer,
                 id,
+                nowText: defaultNowText,
+                okText: defaultOkText,
+                placeholder,
+                popupPlacement,
                 shape = DatePickerShape.Rectangle,
                 size = DatePickerSize.Medium,
-                bordered = true,
-                popupPlacement,
-                placeholder,
-                disabled = false,
                 status,
+                todayText: defaultTodayText,
                 ...rest
             } = props;
             const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
@@ -140,6 +152,40 @@ export default function generatePicker<DateType>(
                 ? size
                 : contextuallySized || size;
 
+            // ============================ Strings ===========================
+            const [pickerLocale] = useLocaleReceiver('DatePicker');
+            let mergedLocale: PickerLocale;
+
+            if (props.locale) {
+                mergedLocale = props.locale;
+            } else {
+                mergedLocale = pickerLocale || props.locale;
+            }
+
+            const [clearIconAriaLabelText, setClearIconAriaLabelText] =
+                useState<string>(defaultClearIconAriaLabelText);
+            const [nowText, setNowText] = useState<string>(defaultNowText);
+            const [okText, setOkText] = useState<string>(defaultOkText);
+            const [todayText, setTodayText] =
+                useState<string>(defaultTodayText);
+
+            // Locs: if the prop isn't provided use the loc defaults.
+            // If the mergedLocale is changed, update.
+            useEffect(() => {
+                setClearIconAriaLabelText(
+                    props.clearIconAriaLabelText
+                        ? props.clearIconAriaLabelText
+                        : mergedLocale.lang!.clear
+                );
+                setNowText(
+                    props.nowText ? props.nowText : mergedLocale.lang!.now
+                );
+                setOkText(props.okText ? props.okText : mergedLocale.lang!.ok);
+                setTodayText(
+                    props.todayText ? props.todayText : mergedLocale.lang!.today
+                );
+            }, [mergedLocale]);
+
             const getIconSize = (): IconSize => {
                 let iconSize: IconSize;
                 if (largeScreenActive) {
@@ -180,12 +226,13 @@ export default function generatePicker<DateType>(
                     defaultLocale={enUS}
                 >
                     {(contextLocale: PickerLocale) => {
-                        const locale = { ...contextLocale, ...props.locale };
+                        const locale = { ...contextLocale, ...mergedLocale };
 
                         return (
                             <OcPicker<DateType>
                                 ref={innerRef}
                                 bordered={bordered}
+                                clearIconAriaLabelText={clearIconAriaLabelText}
                                 id={id}
                                 placeholder={getPlaceholder(
                                     mergedPicker,
@@ -225,6 +272,9 @@ export default function generatePicker<DateType>(
                                         )}
                                     />
                                 }
+                                nowText={nowText}
+                                okText={okText}
+                                todayText={todayText}
                                 prevIcon={IconName.mdiChevronLeft}
                                 nextIcon={IconName.mdiChevronRight}
                                 superPrevIcon={IconName.mdiChevronDoubleLeft}

--- a/src/components/DateTimePicker/DatePicker/Locale/cs_CZ.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/cs_CZ.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/cs_CZ';
 import TimePickerLocale from '../../TimePicker/Locale/cs_CZ';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Vybrat datum',

--- a/src/components/DateTimePicker/DatePicker/Locale/da_DK.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/da_DK.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/da_DK';
 import TimePickerLocale from '../../TimePicker/Locale/da_DK';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Vælg dato',

--- a/src/components/DateTimePicker/DatePicker/Locale/de_DE.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/de_DE.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/de_DE';
 import TimePickerLocale from '../../TimePicker/Locale/de_DE';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Datum auswählen',

--- a/src/components/DateTimePicker/DatePicker/Locale/el_GR.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/el_GR.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/el_GR';
 import TimePickerLocale from '../../TimePicker/Locale/el_GR';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Επιλέξτε ημερομηνία',

--- a/src/components/DateTimePicker/DatePicker/Locale/en_GB.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/en_GB.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/en_GB';
 import TimePickerLocale from '../../TimePicker/Locale/en_GB';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Select date',

--- a/src/components/DateTimePicker/DatePicker/Locale/en_US.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/en_US.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/en_US';
 import TimePickerLocale from '../../TimePicker/Locale/en_US';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Select date',

--- a/src/components/DateTimePicker/DatePicker/Locale/es_DO.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/es_DO.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/es_DO';
 import TimePickerLocale from '../../TimePicker/Locale/es_DO';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Seleccionar fecha',

--- a/src/components/DateTimePicker/DatePicker/Locale/es_ES.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/es_ES.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/es_ES';
 import TimePickerLocale from '../../TimePicker/Locale/es_ES';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Seleccionar fecha',

--- a/src/components/DateTimePicker/DatePicker/Locale/es_MX.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/es_MX.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/es_MX';
 import TimePickerLocale from '../../TimePicker/Locale/es_MX';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Seleccionar fecha',

--- a/src/components/DateTimePicker/DatePicker/Locale/fi_FI.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/fi_FI.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/fi_FI';
 import TimePickerLocale from '../../TimePicker/Locale/fi_FI';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Valitse päivä',

--- a/src/components/DateTimePicker/DatePicker/Locale/fr_BE.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/fr_BE.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/fr_BE';
 import TimePickerLocale from '../../TimePicker/Locale/fr_BE';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Sélectionner une date',

--- a/src/components/DateTimePicker/DatePicker/Locale/fr_CA.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/fr_CA.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/fr_CA';
 import TimePickerLocale from '../../TimePicker/Locale/fr_CA';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Sélectionner une date',

--- a/src/components/DateTimePicker/DatePicker/Locale/fr_FR.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/fr_FR.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/fr_FR';
 import TimePickerLocale from '../../TimePicker/Locale/fr_FR';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Sélectionner une date',

--- a/src/components/DateTimePicker/DatePicker/Locale/he_IL.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/he_IL.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/he_IL';
 import TimePickerLocale from '../../TimePicker/Locale/he_IL';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'בחר תאריך',

--- a/src/components/DateTimePicker/DatePicker/Locale/hr_HR.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/hr_HR.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/hr_HR';
 import TimePickerLocale from '../../TimePicker/Locale/hr_HR';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Odaberite datum',

--- a/src/components/DateTimePicker/DatePicker/Locale/ht_HT.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/ht_HT.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/ht_HT';
 import TimePickerLocale from '../../TimePicker/Locale/ht_HT';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Chwazi dat',

--- a/src/components/DateTimePicker/DatePicker/Locale/hu_HU.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/hu_HU.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/hu_HU';
 import TimePickerLocale from '../../TimePicker/Locale/hu_HU';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Válasszon dátumot',

--- a/src/components/DateTimePicker/DatePicker/Locale/it_IT.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/it_IT.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/it_IT';
 import TimePickerLocale from '../../TimePicker/Locale/it_IT';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Selezionare la data',

--- a/src/components/DateTimePicker/DatePicker/Locale/ja_JP.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/ja_JP.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/ja_JP';
 import TimePickerLocale from '../../TimePicker/Locale/ja_JP';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: '日付を選択',

--- a/src/components/DateTimePicker/DatePicker/Locale/ko_KR.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/ko_KR.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/ko_KR';
 import TimePickerLocale from '../../TimePicker/Locale/ko_KR';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: '날짜 선택',

--- a/src/components/DateTimePicker/DatePicker/Locale/ms_MY.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/ms_MY.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/ms_MY';
 import TimePickerLocale from '../../TimePicker/Locale/ms_MY';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Pilih tarikh',

--- a/src/components/DateTimePicker/DatePicker/Locale/nb_NO.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/nb_NO.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/nb_NO';
 import TimePickerLocale from '../../TimePicker/Locale/nb_NO';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Velg dato',

--- a/src/components/DateTimePicker/DatePicker/Locale/nl_BE.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/nl_BE.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/nl_BE';
 import TimePickerLocale from '../../TimePicker/Locale/nl_BE';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         monthPlaceholder: 'Selecteer maand',

--- a/src/components/DateTimePicker/DatePicker/Locale/nl_NL.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/nl_NL.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/nl_NL';
 import TimePickerLocale from '../../TimePicker/Locale/nl_NL';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         monthPlaceholder: 'Selecteer maand',

--- a/src/components/DateTimePicker/DatePicker/Locale/pl_PL.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/pl_PL.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/pl_PL';
 import TimePickerLocale from '../../TimePicker/Locale/pl_PL';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Wybierz datę',

--- a/src/components/DateTimePicker/DatePicker/Locale/pt_BR.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/pt_BR.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/pt_BR';
 import TimePickerLocale from '../../TimePicker/Locale/pt_BR';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Selecionar data',

--- a/src/components/DateTimePicker/DatePicker/Locale/pt_PT.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/pt_PT.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/pt_PT';
 import TimePickerLocale from '../../TimePicker/Locale/pt_PT';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         ...CalendarLocale,

--- a/src/components/DateTimePicker/DatePicker/Locale/ru_RU.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/ru_RU.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/ru_RU';
 import TimePickerLocale from '../../TimePicker/Locale/ru_RU';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Выберите дату',

--- a/src/components/DateTimePicker/DatePicker/Locale/sv_SE.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/sv_SE.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/sv_SE';
 import TimePickerLocale from '../../TimePicker/Locale/sv_SE';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Välj datum',

--- a/src/components/DateTimePicker/DatePicker/Locale/th_TH.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/th_TH.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/th_TH';
 import TimePickerLocale from '../../TimePicker/Locale/th_TH';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'เลือกวันที่',

--- a/src/components/DateTimePicker/DatePicker/Locale/tr_TR.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/tr_TR.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/tr_TR';
 import TimePickerLocale from '../../TimePicker/Locale/tr_TR';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Tarih seç',

--- a/src/components/DateTimePicker/DatePicker/Locale/uk_UA.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/uk_UA.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/uk_UA';
 import TimePickerLocale from '../../TimePicker/Locale/uk_UA';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// Merge into a locale object
 const locale: PickerLocale = {
     lang: {
         placeholder: 'Оберіть дату',

--- a/src/components/DateTimePicker/DatePicker/Locale/zh_CN.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/zh_CN.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/zh_CN';
 import TimePickerLocale from '../../TimePicker/Locale/zh_CN';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// 统一合并为完整的 Locale
 const locale: PickerLocale = {
     lang: {
         placeholder: '请选择日期',

--- a/src/components/DateTimePicker/DatePicker/Locale/zh_TW.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/zh_TW.tsx
@@ -2,7 +2,6 @@ import CalendarLocale from '../../Internal/Locale/zh_TW';
 import TimePickerLocale from '../../TimePicker/Locale/zh_TW';
 import type { PickerLocale } from '../Generate/Generate.types';
 
-// 统一合并为完整的 Locale
 const locale: PickerLocale = {
     lang: {
         placeholder: '請選擇日期',

--- a/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.date.shot
+++ b/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.date.shot
@@ -105,6 +105,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
+                  "aria-label": "Clear",
                   "class": "picker-clear",
                   "role": "button",
                 },
@@ -188,10 +189,12 @@ LoadedCheerio {
                 "prev": [Circular],
                 "type": "tag",
                 "x-attribsNamespace": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
                 "x-attribsPrefix": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
@@ -307,6 +310,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
+                "aria-label": "Clear",
                 "class": "picker-clear",
                 "role": "button",
               },
@@ -390,10 +394,12 @@ LoadedCheerio {
               "prev": [Circular],
               "type": "tag",
               "x-attribsNamespace": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
               "x-attribsPrefix": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
@@ -442,6 +448,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
+              "aria-label": "Clear",
               "class": "picker-clear",
               "role": "button",
             },
@@ -646,10 +653,12 @@ LoadedCheerio {
             },
             "type": "tag",
             "x-attribsNamespace": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },
             "x-attribsPrefix": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },

--- a/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.dateTime.shot
+++ b/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.dateTime.shot
@@ -105,6 +105,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
+                  "aria-label": "Clear",
                   "class": "picker-clear",
                   "role": "button",
                 },
@@ -188,10 +189,12 @@ LoadedCheerio {
                 "prev": [Circular],
                 "type": "tag",
                 "x-attribsNamespace": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
                 "x-attribsPrefix": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
@@ -307,6 +310,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
+                "aria-label": "Clear",
                 "class": "picker-clear",
                 "role": "button",
               },
@@ -390,10 +394,12 @@ LoadedCheerio {
               "prev": [Circular],
               "type": "tag",
               "x-attribsNamespace": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
               "x-attribsPrefix": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
@@ -442,6 +448,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
+              "aria-label": "Clear",
               "class": "picker-clear",
               "role": "button",
             },
@@ -646,10 +653,12 @@ LoadedCheerio {
             },
             "type": "tag",
             "x-attribsNamespace": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },
             "x-attribsPrefix": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },

--- a/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.locale.shot
+++ b/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.locale.shot
@@ -105,6 +105,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
+                  "aria-label": "Изчистване",
                   "class": "picker-clear",
                   "role": "button",
                 },
@@ -188,10 +189,12 @@ LoadedCheerio {
                 "prev": [Circular],
                 "type": "tag",
                 "x-attribsNamespace": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
                 "x-attribsPrefix": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
@@ -307,6 +310,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
+                "aria-label": "Изчистване",
                 "class": "picker-clear",
                 "role": "button",
               },
@@ -390,10 +394,12 @@ LoadedCheerio {
               "prev": [Circular],
               "type": "tag",
               "x-attribsNamespace": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
               "x-attribsPrefix": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
@@ -442,6 +448,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
+              "aria-label": "Изчистване",
               "class": "picker-clear",
               "role": "button",
             },
@@ -646,10 +653,12 @@ LoadedCheerio {
             },
             "type": "tag",
             "x-attribsNamespace": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },
             "x-attribsPrefix": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },

--- a/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.month.shot
+++ b/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.month.shot
@@ -105,6 +105,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
+                  "aria-label": "Clear",
                   "class": "picker-clear",
                   "role": "button",
                 },
@@ -188,10 +189,12 @@ LoadedCheerio {
                 "prev": [Circular],
                 "type": "tag",
                 "x-attribsNamespace": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
                 "x-attribsPrefix": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
@@ -307,6 +310,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
+                "aria-label": "Clear",
                 "class": "picker-clear",
                 "role": "button",
               },
@@ -390,10 +394,12 @@ LoadedCheerio {
               "prev": [Circular],
               "type": "tag",
               "x-attribsNamespace": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
               "x-attribsPrefix": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
@@ -442,6 +448,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
+              "aria-label": "Clear",
               "class": "picker-clear",
               "role": "button",
             },
@@ -646,10 +653,12 @@ LoadedCheerio {
             },
             "type": "tag",
             "x-attribsNamespace": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },
             "x-attribsPrefix": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },

--- a/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.week.shot
+++ b/src/components/DateTimePicker/DatePicker/Tests/__snapshots__/DatePicker.week.shot
@@ -105,6 +105,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
+                  "aria-label": "Clear",
                   "class": "picker-clear",
                   "role": "button",
                 },
@@ -188,10 +189,12 @@ LoadedCheerio {
                 "prev": [Circular],
                 "type": "tag",
                 "x-attribsNamespace": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
                 "x-attribsPrefix": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
@@ -307,6 +310,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
+                "aria-label": "Clear",
                 "class": "picker-clear",
                 "role": "button",
               },
@@ -390,10 +394,12 @@ LoadedCheerio {
               "prev": [Circular],
               "type": "tag",
               "x-attribsNamespace": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
               "x-attribsPrefix": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
@@ -442,6 +448,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
+              "aria-label": "Clear",
               "class": "picker-clear",
               "role": "button",
             },
@@ -646,10 +653,12 @@ LoadedCheerio {
             },
             "type": "tag",
             "x-attribsNamespace": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },
             "x-attribsPrefix": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },

--- a/src/components/DateTimePicker/Internal/OcPicker.tsx
+++ b/src/components/DateTimePicker/Internal/OcPicker.tsx
@@ -40,53 +40,57 @@ type MergedOcPickerProps<DateType> = {
 
 function InnerPicker<DateType>(props: OcPickerProps<DateType>) {
     const {
-        id,
-        tabIndex,
-        style,
+        allowClear,
+        autoComplete = 'off',
+        autoFocus,
         bordered = true,
         classNames,
-        dropdownClassNames,
-        dropdownAlign,
-        popupStyle,
-        generateConfig,
-        locale,
-        inputReadOnly,
-        allowClear,
-        autoFocus,
-        showTime,
-        picker = 'date',
-        format,
-        use12Hours,
-        value,
-        defaultValue,
-        open,
-        defaultOpen,
-        suffixIcon,
         clearIcon,
+        clearIconAriaLabelText,
+        defaultOpen,
+        defaultValue,
+        direction,
         disabled,
         disabledDate,
-        placeholder,
+        dropdownAlign,
+        dropdownClassNames,
+        format,
+        generateConfig,
         getPopupContainer,
-        pickerRef,
-        partialRender,
-        onChange,
-        onOpenChange,
-        onFocus,
+        id,
+        inputReadOnly,
+        inputRender,
+        locale,
+        nowText,
+        okText,
         onBlur,
+        onChange,
+        onClick,
+        onContextMenu,
+        onFocus,
+        onKeyDown,
         onMouseDown,
-        onMouseUp,
         onMouseEnter,
         onMouseLeave,
-        onContextMenu,
-        onClick,
-        onKeyDown,
+        onMouseUp,
+        onOpenChange,
         onSelect,
+        open,
+        partialRender,
+        picker = 'date',
+        pickerRef,
+        placeholder,
         popupPlacement,
-        direction,
-        autoComplete = 'off',
-        inputRender,
+        popupStyle,
         shape = DatePickerShape.Rectangle,
+        showTime,
         size = DatePickerSize.Medium,
+        style,
+        suffixIcon,
+        tabIndex,
+        todayText,
+        use12Hours,
+        value,
     } = props as MergedOcPickerProps<DateType>;
 
     const inputRef: React.MutableRefObject<HTMLInputElement> =
@@ -305,7 +309,7 @@ function InnerPicker<DateType>(props: OcPickerProps<DateType>) {
         onPickerValueChange: any;
         onChange: any;
     } = {
-        // Remove `picker` & `format` here since TimePicker is little different with other partial
+        // Remove `picker` & `format` here since TimePicker partial isn't much different than other partials.
         ...(props as Omit<MergedOcPickerProps<DateType>, 'picker' | 'format'>),
         classNames: undefined,
         style: undefined,
@@ -324,6 +328,9 @@ function InnerPicker<DateType>(props: OcPickerProps<DateType>) {
             value={selectedValue}
             locale={locale}
             tabIndex={-1}
+            nowText={nowText}
+            okText={okText}
+            todayText={todayText}
             onSelect={(date: DateType) => {
                 onSelect?.(date);
                 setSelectedValue(date);
@@ -362,6 +369,7 @@ function InnerPicker<DateType>(props: OcPickerProps<DateType>) {
     if (allowClear && mergedValue && !disabled) {
         clearNode = (
             <span
+                aria-label={clearIconAriaLabelText}
                 onMouseDown={(e) => {
                     e.preventDefault();
                     e.stopPropagation();

--- a/src/components/DateTimePicker/Internal/OcPicker.types.ts
+++ b/src/components/DateTimePicker/Internal/OcPicker.types.ts
@@ -7,7 +7,6 @@ import { IconName } from '../../Icon';
 import { tuple } from '../../../shared/utilities';
 import { ConfigContextProps, Shape, Size } from '../../ConfigProvider';
 
-// TODO: move to ./Locale and use the provider.
 export type Locale = {
     /**
      * The picker locale.
@@ -262,8 +261,9 @@ export type PartialSharedProps<DateType> = {
     generateConfig: GenerateConfig<DateType>;
     /**
      * Localization configuration.
+     * @default enUS
      */
-    locale: Locale;
+    locale?: Locale;
     /**
      * The custom next icon.
      */
@@ -410,6 +410,7 @@ export type OcPickerPartialSharedProps<DateType> = {
     generateConfig: GenerateConfig<DateType>;
     /**
      * Localization configuration.
+     * @default enUS
      */
     locale: Locale;
     /**
@@ -420,6 +421,16 @@ export type OcPickerPartialSharedProps<DateType> = {
      * Custom month cell content render method.
      */
     monthCellRender?: MonthCellRender<DateType>;
+    /**
+     * The 'Now' text string.
+     * @default 'Now'
+     */
+    nowText?: string;
+    /**
+     * The 'OK' text string.
+     * @default 'OK'
+     */
+    okText?: string;
     /**
      * 	Callback executed when the selected time is changing.
      */
@@ -464,6 +475,11 @@ export type OcPickerPartialSharedProps<DateType> = {
      * The partial tab index.
      */
     tabIndex?: number;
+    /**
+     * The 'Today' text string.
+     * @default 'Today'
+     */
+    todayText?: string;
     /**
      * The partial date value.
      */
@@ -560,6 +576,11 @@ export type OcPickerSharedProps<DateType> = {
      */
     bordered?: boolean;
     /**
+     * The clear icon 'Clear' aria label text string.
+     * @default 'Clear'
+     */
+    clearIconAriaLabelText?: string;
+    /**
      * Custom clear icon.
      */
     clearIcon?: React.ReactNode;
@@ -638,6 +659,16 @@ export type OcPickerSharedProps<DateType> = {
      * The custom next icon.
      */
     nextIcon?: IconName;
+    /**
+     * The 'Now' text string.
+     * @default 'Now'
+     */
+    nowText?: string;
+    /**
+     * The 'OK' text string.
+     * @default 'OK'
+     */
+    okText?: string;
     /**
      * Callback executes on picker blur event.
      */
@@ -737,6 +768,11 @@ export type OcPickerSharedProps<DateType> = {
      * The picker tab index.
      */
     tabIndex?: number;
+    /**
+     * The 'Today' text string.
+     * @default 'Today'
+     */
+    todayText?: string;
     /**
      * @private Internal usage, do not use in production.
      */

--- a/src/components/DateTimePicker/Internal/OcPicker.types.ts
+++ b/src/components/DateTimePicker/Internal/OcPicker.types.ts
@@ -263,7 +263,7 @@ export type PartialSharedProps<DateType> = {
      * Localization configuration.
      * @default enUS
      */
-    locale?: Locale;
+    locale: Locale;
     /**
      * The custom next icon.
      */

--- a/src/components/DateTimePicker/Internal/OcPickerPartial.tsx
+++ b/src/components/DateTimePicker/Internal/OcPickerPartial.tsx
@@ -45,34 +45,37 @@ type MergedPickerPartialProps<DateType> = {
 function OcPickerPartial<DateType>(props: OcPickerPartialProps<DateType>) {
     const {
         classNames,
-        style,
-        locale,
-        generateConfig,
-        value,
-        defaultValue,
-        pickerValue,
+        components,
         defaultPickerValue,
+        defaultValue,
+        direction,
         disabledDate,
+        generateConfig,
+        hideHeader,
+        hourStep = 1,
+        locale,
+        minuteStep = 1,
         mode,
+        okText,
+        nowText,
+        onChange,
+        onMouseDown,
+        onOk,
+        onPartialChange,
+        onPickerValueChange,
+        onSelect,
         picker = 'date',
-        tabIndex = 0,
+        pickerValue,
+        renderExtraFooter,
+        secondStep = 1,
         showNow,
         showTime,
         showToday,
-        renderExtraFooter,
-        hideHeader,
-        onSelect,
-        onChange,
-        onPartialChange,
-        onMouseDown,
-        onPickerValueChange,
-        onOk,
-        components,
-        direction,
-        hourStep = 1,
-        minuteStep = 1,
-        secondStep = 1,
         size = DatePickerSize.Medium,
+        style,
+        tabIndex = 0,
+        todayText,
+        value,
     } = props as MergedPickerPartialProps<DateType>;
     const largeScreenActive: boolean = useMatchMedia(Breakpoints.Large);
     const mediumScreenActive: boolean = useMatchMedia(Breakpoints.Medium);
@@ -267,6 +270,7 @@ function OcPickerPartial<DateType>(props: OcPickerPartialProps<DateType>) {
 
     const pickerProps = {
         ...(props as MergedPickerPartialProps<DateType>),
+        locale,
         operationRef: partialRef,
         viewDate,
         value: mergedValue,
@@ -413,10 +417,10 @@ function OcPickerPartial<DateType>(props: OcPickerPartialProps<DateType>) {
         rangesNode = getRanges({
             components,
             needConfirmButton,
+            nowText,
             okDisabled:
                 !mergedValue || (disabledDate && disabledDate(mergedValue)),
-            locale,
-            showNow,
+            okText,
             onNow: needConfirmButton && onNow,
             onOk: () => {
                 if (mergedValue) {
@@ -426,6 +430,7 @@ function OcPickerPartial<DateType>(props: OcPickerPartialProps<DateType>) {
                     }
                 }
             },
+            showNow,
             size: size,
         });
     }
@@ -458,7 +463,7 @@ function OcPickerPartial<DateType>(props: OcPickerPartialProps<DateType>) {
                     }
                 }}
                 size={datePickerSizeToButtonSizeMap.get(size)}
-                text={locale.today}
+                text={todayText}
             />
         );
     }

--- a/src/components/DateTimePicker/Internal/OcRangePicker.tsx
+++ b/src/components/DateTimePicker/Internal/OcRangePicker.tsx
@@ -102,63 +102,67 @@ type MergedOcRangePickerProps<DateType> = {
 
 function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
     const {
-        id,
-        style,
+        activePickerIndex,
+        allowClear,
+        allowEmpty,
+        autoComplete = 'off',
+        autoFocus,
         bordered = true,
         classNames,
-        popupStyle,
-        dropdownClassNames,
-        dropdownAlign,
-        getPopupContainer,
-        generateConfig,
-        locale,
-        placeholder,
-        autoFocus,
-        disabled,
-        format,
-        picker = 'date',
-        showTime,
-        use12Hours,
-        separator = ',',
-        value,
-        defaultValue,
-        defaultPickerValue,
-        open,
+        clearIconAriaLabelText,
+        clearIcon,
+        components,
+        dateRender,
         defaultOpen,
+        defaultPickerValue,
+        defaultValue,
+        direction,
+        disabled,
         disabledDate,
         disabledTime,
-        dateRender,
-        partialRender,
-        ranges,
-        allowEmpty,
-        allowClear,
-        suffixIcon,
-        clearIcon,
-        pickerRef,
+        dropdownAlign,
+        dropdownClassNames,
+        format,
+        generateConfig,
+        getPopupContainer,
+        id,
         inputReadOnly,
+        locale,
         mode,
-        renderExtraFooter,
-        onChange,
-        onOpenChange,
-        onPartialChange,
-        onCalendarChange,
-        onFocus,
+        nowText,
+        okText,
         onBlur,
+        onCalendarChange,
+        onChange,
+        onClick,
+        onFocus,
+        onKeyDown,
         onMouseDown,
-        onMouseUp,
         onMouseEnter,
         onMouseLeave,
-        onClick,
+        onMouseUp,
         onOk,
-        onKeyDown,
-        popupPlacement,
-        components,
+        onOpenChange,
+        onPartialChange,
+        open,
         order,
-        direction,
-        activePickerIndex,
-        autoComplete = 'off',
+        partialRender,
+        picker = 'date',
+        pickerRef,
+        placeholder,
+        popupPlacement,
+        popupStyle,
+        ranges,
+        renderExtraFooter,
+        separator = ',',
         shape = DatePickerShape.Rectangle,
+        showTime,
         size = DatePickerSize.Medium,
+        style,
+        suffixIcon,
+        use12Hours,
+        todayText,
+        value,
     } = props as MergedOcRangePickerProps<DateType>;
 
     const needConfirmButton: boolean =
@@ -872,6 +876,9 @@ function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
                         }
                         setViewDate(viewDate, mergedActivePickerIndex);
                     }}
+                    nowText={nowText}
+                    okText={okText}
+                    todayText={todayText}
                     onOk={null}
                     onSelect={undefined}
                     onChange={undefined}
@@ -933,8 +940,8 @@ function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
                 !getValue(selectedValue, mergedActivePickerIndex) ||
                 (disabledDate &&
                     disabledDate(selectedValue[mergedActivePickerIndex])),
-            locale,
-            rangeList,
+            nowText,
+            okText,
             onOk: () => {
                 if (getValue(selectedValue, mergedActivePickerIndex)) {
                     // triggerChangeOld(selectedValue);
@@ -944,6 +951,7 @@ function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
                     }
                 }
             },
+            rangeList,
             size: size,
         });
 
@@ -1060,6 +1068,7 @@ function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
     ) {
         clearNode = (
             <span
+                aria-label={clearIconAriaLabelText}
                 onMouseDown={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -1080,6 +1089,7 @@ function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
                     triggerOpen(false, mergedActivePickerIndex);
                 }}
                 className={styles.pickerClear}
+                role="button"
             >
                 {clearIcon || <span className={styles.pickerClearBtn} />}
             </span>

--- a/src/components/DateTimePicker/Internal/Tests/__snapshots__/range.test.tsx.snap
+++ b/src/components/DateTimePicker/Internal/Tests/__snapshots__/range.test.tsx.snap
@@ -135,6 +135,7 @@ LoadedCheerio {
                 "next": Node {
                   "attribs": Object {
                     "class": "picker-clear",
+                    "role": "button",
                   },
                   "children": Array [
                     Node {
@@ -164,9 +165,11 @@ LoadedCheerio {
                   "type": "tag",
                   "x-attribsNamespace": Object {
                     "class": undefined,
+                    "role": undefined,
                   },
                   "x-attribsPrefix": Object {
                     "class": undefined,
+                    "role": undefined,
                   },
                 },
                 "parent": [Circular],
@@ -311,6 +314,7 @@ LoadedCheerio {
               "next": Node {
                 "attribs": Object {
                   "class": "picker-clear",
+                  "role": "button",
                 },
                 "children": Array [
                   Node {
@@ -340,9 +344,11 @@ LoadedCheerio {
                 "type": "tag",
                 "x-attribsNamespace": Object {
                   "class": undefined,
+                  "role": undefined,
                 },
                 "x-attribsPrefix": Object {
                   "class": undefined,
+                  "role": undefined,
                 },
               },
               "parent": [Circular],
@@ -510,6 +516,7 @@ LoadedCheerio {
             "next": Node {
               "attribs": Object {
                 "class": "picker-clear",
+                "role": "button",
               },
               "children": Array [
                 Node {
@@ -539,9 +546,11 @@ LoadedCheerio {
               "type": "tag",
               "x-attribsNamespace": Object {
                 "class": undefined,
+                "role": undefined,
               },
               "x-attribsPrefix": Object {
                 "class": undefined,
+                "role": undefined,
               },
             },
             "parent": [Circular],
@@ -686,6 +695,7 @@ LoadedCheerio {
           "next": Node {
             "attribs": Object {
               "class": "picker-clear",
+              "role": "button",
             },
             "children": Array [
               Node {
@@ -715,9 +725,11 @@ LoadedCheerio {
             "type": "tag",
             "x-attribsNamespace": Object {
               "class": undefined,
+              "role": undefined,
             },
             "x-attribsPrefix": Object {
               "class": undefined,
+              "role": undefined,
             },
           },
           "parent": [Circular],
@@ -892,6 +904,7 @@ LoadedCheerio {
         "next": Node {
           "attribs": Object {
             "class": "picker-clear",
+            "role": "button",
           },
           "children": Array [
             Node {
@@ -921,9 +934,11 @@ LoadedCheerio {
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
+            "role": undefined,
           },
           "x-attribsPrefix": Object {
             "class": undefined,
+            "role": undefined,
           },
         },
         "parent": [Circular],
@@ -1080,6 +1095,7 @@ LoadedCheerio {
       Node {
         "attribs": Object {
           "class": "picker-clear",
+          "role": "button",
         },
         "children": Array [
           Node {
@@ -1286,9 +1302,11 @@ LoadedCheerio {
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
+          "role": undefined,
         },
         "x-attribsPrefix": Object {
           "class": undefined,
+          "role": undefined,
         },
       },
     ],

--- a/src/components/DateTimePicker/Internal/Utils/getRanges.tsx
+++ b/src/components/DateTimePicker/Internal/Utils/getRanges.tsx
@@ -1,36 +1,33 @@
 import React from 'react';
 import { Size } from '../../../ConfigProvider';
-import {
-    Components,
-    DatePickerSize,
-    RangeList,
-    Locale,
-} from '../OcPicker.types';
+import { Components, DatePickerSize, RangeList } from '../OcPicker.types';
 import { ButtonSize, DefaultButton, PrimaryButton } from '../../../Button';
 
 import styles from '../ocpicker.module.scss';
 
 export type RangesProps = {
-    rangeList?: RangeList;
     components?: Components;
     needConfirmButton: boolean;
+    nowText?: string;
+    okDisabled?: boolean;
+    okText?: string;
     onNow?: null | (() => void) | false;
     onOk?: null | (() => void) | false;
-    okDisabled?: boolean;
+    rangeList?: RangeList;
     showNow?: boolean;
-    locale: Locale;
     size?: DatePickerSize | Size;
 };
 
 export default function getRanges({
-    rangeList = [],
     components = {},
     needConfirmButton,
+    nowText,
+    okDisabled,
+    okText,
     onNow,
     onOk,
-    okDisabled,
+    rangeList = [],
     showNow,
-    locale,
     size = DatePickerSize.Medium,
 }: RangesProps) {
     let presetNode: React.ReactNode;
@@ -76,7 +73,7 @@ export default function getRanges({
                         classNames={'picker-now-btn'}
                         onClick={onNow}
                         size={datePickerSizeToButtonSizeMap.get(size)}
-                        text={locale.now}
+                        text={nowText}
                     />
                 </li>
             );
@@ -88,7 +85,7 @@ export default function getRanges({
                     disabled={okDisabled}
                     onClick={onOk as () => void}
                     size={datePickerSizeToButtonSizeMap.get(size)}
-                    text={locale.ok}
+                    text={okText}
                 />
             </li>
         );

--- a/src/components/DateTimePicker/TimePicker/Tests/__snapshots__/index.test.js.snap
+++ b/src/components/DateTimePicker/TimePicker/Tests/__snapshots__/index.test.js.snap
@@ -483,6 +483,7 @@ LoadedCheerio {
               "namespace": "http://www.w3.org/1999/xhtml",
               "next": Node {
                 "attribs": Object {
+                  "aria-label": "Clear",
                   "class": "picker-clear",
                   "role": "button",
                 },
@@ -566,10 +567,12 @@ LoadedCheerio {
                 "prev": [Circular],
                 "type": "tag",
                 "x-attribsNamespace": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
                 "x-attribsPrefix": Object {
+                  "aria-label": undefined,
                   "class": undefined,
                   "role": undefined,
                 },
@@ -685,6 +688,7 @@ LoadedCheerio {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": Node {
               "attribs": Object {
+                "aria-label": "Clear",
                 "class": "picker-clear",
                 "role": "button",
               },
@@ -768,10 +772,12 @@ LoadedCheerio {
               "prev": [Circular],
               "type": "tag",
               "x-attribsNamespace": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
               "x-attribsPrefix": Object {
+                "aria-label": undefined,
                 "class": undefined,
                 "role": undefined,
               },
@@ -820,6 +826,7 @@ LoadedCheerio {
           },
           Node {
             "attribs": Object {
+              "aria-label": "Clear",
               "class": "picker-clear",
               "role": "button",
             },
@@ -1024,10 +1031,12 @@ LoadedCheerio {
             },
             "type": "tag",
             "x-attribsNamespace": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },
             "x-attribsPrefix": Object {
+              "aria-label": undefined,
               "class": undefined,
               "role": undefined,
             },

--- a/src/components/DateTimePicker/TimePicker/TimePicker.stories.tsx
+++ b/src/components/DateTimePicker/TimePicker/TimePicker.stories.tsx
@@ -6,7 +6,6 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import TimePicker from './TimePicker';
 import { DatePickerShape, DatePickerSize } from '../DatePicker';
 import { Stack } from '../../Stack';
-import locale from './Locale/en_US';
 import { ButtonSize, PrimaryButton } from '../../Button';
 
 const { RangePicker } = TimePicker;
@@ -218,7 +217,6 @@ export const Range_Status = Range_Status_Story.bind({});
 const pickerArgs: Object = {
     classNames: 'my-picker-class',
     id: 'myPickerInputId',
-    locale: locale,
     shape: DatePickerShape.Rectangle,
     size: DatePickerSize.Medium,
 };

--- a/src/components/Locale/Default.tsx
+++ b/src/components/Locale/Default.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/en_US';
 import Table from '../Table/Locale/en_US';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/en_US';
 
 const typeTemplate = '${label} is not a valid ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Select',
     },
+    DatePicker,
     Form: {
         optional: '(optional)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/cs_CZ.tsx
+++ b/src/components/Locale/cs_CZ.tsx
@@ -1,12 +1,16 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/cs_CZ';
 import Table from '../Table/Locale/cs_CZ';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/cs_CZ';
 
 const localeValues: Locale = {
     locale: 'cs',
     global: {
         placeholder: 'Prosím vyber',
     },
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/da_DK.tsx
+++ b/src/components/Locale/da_DK.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/da_DK';
 import Table from '../Table/Locale/da_DK';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/da_DK';
 
 const localeValues: Locale = {
     locale: 'da',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/de_DE.tsx
+++ b/src/components/Locale/de_DE.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/de_DE';
 import Table from '../Table/Locale/de_DE';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/de_DE';
 
 const typeTemplate = '${label} ist nicht gültig. ${type} erwartet';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Bitte auswählen',
     },
+    DatePicker,
     Form: {
         defaultValidateMessages: {
             default: 'Feld-Validierungsfehler: ${label}',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/el_GR.tsx
+++ b/src/components/Locale/el_GR.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/el_GR';
 import Table from '../Table/Locale/el_GR';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/el_GR';
 
 const localeValues: Locale = {
     locale: 'el',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/en_GB.tsx
+++ b/src/components/Locale/en_GB.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/en_GB';
 import Table from '../Table/Locale/en_GB';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/en_GB';
 
 const typeTemplate = '${label} is not a valid ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Select',
     },
+    DatePicker,
     Form: {
         optional: '(optional)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/es_DO.tsx
+++ b/src/components/Locale/es_DO.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/es_DO';
 import Table from '../Table/Locale/es_DO';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/es_DO';
 
 const typeTemplate = '${label} no es un ${type} válido';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Seleccione',
     },
+    DatePicker,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/es_ES.tsx
+++ b/src/components/Locale/es_ES.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/es_ES';
 import Table from '../Table/Locale/es_ES';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/es_ES';
 
 const typeTemplate = '${label} no es un ${type} válido';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Seleccione',
     },
+    DatePicker,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/es_MX.tsx
+++ b/src/components/Locale/es_MX.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/es_MX';
 import Table from '../Table/Locale/es_MX';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/es_MX';
 
 const typeTemplate = '${label} no es un ${type} válido';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Seleccione',
     },
+    DatePicker,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/fi_FI.tsx
+++ b/src/components/Locale/fi_FI.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/fi_FI';
 import Table from '../Table/Locale/fi_FI';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/fi_FI';
 
 const localeValues: Locale = {
     locale: 'fi',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/fr_BE.tsx
+++ b/src/components/Locale/fr_BE.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_BE';
 import Table from '../Table/Locale/fr_BE';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_BE';
 
 const localeValues: Locale = {
     locale: 'fr',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/fr_CA.tsx
+++ b/src/components/Locale/fr_CA.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_CA';
 import Table from '../Table/Locale/fr_CA';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_CA';
 
 const localeValues: Locale = {
     locale: 'fr',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/fr_FR.tsx
+++ b/src/components/Locale/fr_FR.tsx
@@ -1,12 +1,15 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_FR';
 import Table from '../Table/Locale/fr_FR';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_FR';
 
 const typeTemplate =
     "La valeur du champ ${label} n'est pas valide pour le type ${type}";
 
 const localeValues: Locale = {
     locale: 'fr',
+    DatePicker,
     Form: {
         optional: '(optionnel)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/he_IL.tsx
+++ b/src/components/Locale/he_IL.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/he_IL';
 import Table from '../Table/Locale/he_IL';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/he_IL';
 
 const typeTemplate = '${label} הוא לא ${type} תקין';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'אנא בחר',
     },
+    DatePicker,
     Form: {
         defaultValidateMessages: {
             default: 'ערך השדה שגוי ${label}',
@@ -59,6 +62,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/hr_HR.tsx
+++ b/src/components/Locale/hr_HR.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/hr_HR';
 import Table from '../Table/Locale/hr_HR';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/hr_HR';
 
 const typeTemplate = '${label} nije valjan ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Molimo označite',
     },
+    DatePicker,
     Form: {
         optional: '(neobavezno)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/ht_HT.tsx
+++ b/src/components/Locale/ht_HT.tsx
@@ -1,12 +1,15 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/ht_HT';
 import Table from '../Table/Locale/ht_HT';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/ht_HT';
 
 const typeTemplate =
     "La valeur du champ ${label} n'est pas valide pour le type ${type}";
 
 const localeValues: Locale = {
     locale: 'fr',
+    DatePicker,
     Form: {
         optional: '(optionnel)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/hu_HU.tsx
+++ b/src/components/Locale/hu_HU.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/hu_HU';
 import Table from '../Table/Locale/hu_HU';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/hu_HU';
 
 const localeValues: Locale = {
     locale: 'hu',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/it_IT.tsx
+++ b/src/components/Locale/it_IT.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/it_IT';
 import Table from '../Table/Locale/it_IT';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/it_IT';
 
 const localeValues: Locale = {
     locale: 'it',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/ja_JP.tsx
+++ b/src/components/Locale/ja_JP.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/ja_JP';
 import Table from '../Table/Locale/ja_JP';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/ja_JP';
 
 const typeTemplate = '${label}は有効な${type}ではありません';
 
 const localeValues: Locale = {
     locale: 'ja',
+    DatePicker,
     Form: {
         defaultValidateMessages: {
             default: '${label}のフィールド検証エラー',
@@ -56,6 +59,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/ko_KR.tsx
+++ b/src/components/Locale/ko_KR.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/ko_KR';
 import Table from '../Table/Locale/ko_KR';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/ko_KR';
 
 const typeTemplate = '${label} 유효하지 않은 ${type}';
 
 const localeValues: Locale = {
     locale: 'ko',
+    DatePicker,
     Form: {
         defaultValidateMessages: {
             default: '필드 유효성 검사 오류 ${label}',
@@ -56,6 +59,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/ms_MY.tsx
+++ b/src/components/Locale/ms_MY.tsx
@@ -1,12 +1,16 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/ms_MY';
 import Table from '../Table/Locale/ms_MY';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/ms_MY';
 
 const localeValues: Locale = {
     locale: 'ms-my',
     global: {
         placeholder: 'Sila pilih',
     },
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/nb_NO.tsx
+++ b/src/components/Locale/nb_NO.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/nb_NO';
 import Table from '../Table/Locale/nb_NO';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/nb_NO';
 
 const typeTemplate = '${label} er ikke et gyldig ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Vennligst velg',
     },
+    DatePicker,
     Form: {
         defaultValidateMessages: {
             default: 'Feltvalideringsfeil ${label}',
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/nl_BE.tsx
+++ b/src/components/Locale/nl_BE.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_BE';
 import Table from '../Table/Locale/nl_BE';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_BE';
 
 const typeTemplate = '${label} is geen geldige ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Maak een selectie',
     },
+    DatePicker,
     Form: {
         optional: '(optioneel)',
         defaultValidateMessages: {
@@ -61,6 +64,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/nl_NL.tsx
+++ b/src/components/Locale/nl_NL.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_NL';
 import Table from '../Table/Locale/nl_NL';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_NL';
 
 const typeTemplate = '${label} is geen geldige ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Maak een selectie',
     },
+    DatePicker,
     Form: {
         optional: '(optioneel)',
         defaultValidateMessages: {
@@ -61,6 +64,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/pl_PL.tsx
+++ b/src/components/Locale/pl_PL.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/pl_PL';
 import Table from '../Table/Locale/pl_PL';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/pl_PL';
 
 const typeTemplate = '${label} nie posiada poprawnej wartości dla typu ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Wybierz',
     },
+    DatePicker,
     Form: {
         optional: '(opcjonalne)',
         defaultValidateMessages: {
@@ -61,6 +64,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/pt_BR.tsx
+++ b/src/components/Locale/pt_BR.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_BR';
 import Table from '../Table/Locale/pt_BR';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_BR';
 
 const typeTemplate = '${label} não é um ${type} válido';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Por favor escolha',
     },
+    DatePicker,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/pt_PT.tsx
+++ b/src/components/Locale/pt_PT.tsx
@@ -1,9 +1,13 @@
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_PT';
 import Table from '../Table/Locale/pt_PT';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_PT';
 
 const localeValues: Locale = {
     locale: 'pt',
+    DatePicker,
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/ru_RU.tsx
+++ b/src/components/Locale/ru_RU.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/ru_RU';
 import Table from '../Table/Locale/ru_RU';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/ru_RU';
 
 const typeTemplate: string = '${label} не является типом ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Пожалуйста выберите',
     },
+    DatePicker,
     Form: {
         defaultValidateMessages: {
             default: 'Ошибка проверки поля ${label}',
@@ -58,6 +61,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/sv_SE.tsx
+++ b/src/components/Locale/sv_SE.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/sv_SE';
 import Table from '../Table/Locale/sv_SE';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/sv_SE';
 
 const typeTemplate = '${label} är inte en giltig ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Vänligen välj',
     },
+    DatePicker,
     Form: {
         optional: '(valfritt)',
         defaultValidateMessages: {
@@ -61,6 +64,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/th_TH.tsx
+++ b/src/components/Locale/th_TH.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/th_TH';
 import Table from '../Table/Locale/th_TH';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/th_TH';
 
 const typeTemplate = '${label} ไม่ใช่ ${type} ที่ถูกต้อง';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'กรุณาเลือก',
     },
+    DatePicker,
     Form: {
         optional: '(ไม่จำเป็น)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/tr_TR.tsx
+++ b/src/components/Locale/tr_TR.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/tr_TR';
 import Table from '../Table/Locale/tr_TR';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/tr_TR';
 
 const typeTemplate = '${label} geçerli bir ${type} değil';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Lütfen seçiniz',
     },
+    DatePicker,
     Form: {
         optional: '(opsiyonel)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/uk_UA.tsx
+++ b/src/components/Locale/uk_UA.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/uk_UA';
 import Table from '../Table/Locale/uk_UA';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/uk_UA';
 
 const typeTemplate = '${label} не є типом ${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: 'Будь ласка, оберіть',
     },
+    DatePicker,
     Form: {
         optional: '(опціонально)',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/zh_CN.tsx
+++ b/src/components/Locale/zh_CN.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_CN';
 import Table from '../Table/Locale/zh_CN';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_CN';
 
 const typeTemplate = '${label}不是一个有效的${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: '请选择',
     },
+    DatePicker,
     Form: {
         optional: '（可选）',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/Locale/zh_TW.tsx
+++ b/src/components/Locale/zh_TW.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_TW';
 import Table from '../Table/Locale/zh_TW';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_TW';
 
 const typeTemplate = '${label}不是一個有效的${type}';
 
@@ -9,6 +11,7 @@ const localeValues: Locale = {
     global: {
         placeholder: '請選擇',
     },
+    DatePicker,
     Form: {
         optional: '（可選）',
         defaultValidateMessages: {
@@ -60,6 +63,7 @@ const localeValues: Locale = {
         },
     },
     Table,
+    TimePicker,
 };
 
 export default localeValues;

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -7,14 +7,14 @@ import LocaleContext from './Context';
 
 export interface Locale {
     locale: string;
-    DatePicker?: DatePickerLocale;
-    TimePicker?: Record<string, any>;
     global?: Record<string, any>;
+    DatePicker?: DatePickerLocale;
     Form?: {
         optional?: string;
         defaultValidateMessages: ValidateMessages;
     };
     Table?: TableLocale;
+    TimePicker?: Record<string, any>;
 }
 
 export interface LocaleProviderProps {


### PR DESCRIPTION
## SUMMARY:
Adds loc to picker components
Updates pickers to get loc from config provider when needed
Fixes pickers so a default locale is not required to render the component

## JIRA TASK (Eightfold Employees Only):
ENG-30913

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [X] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and do `yarn`, then `yarn storybook`, verify the Picker stories behave as expected.

Set the Pagination locale to another language and test the go to text as follows (pseudo-code):

```
import { zhCN } from "@eightfold.ai/octuple/";
<DatePicker locale={zhCN} okText={'foo'} />
```

The ok button text in the popup should read 'foo' and the others should use the loc defaults