### PR TITLE
feat(tabs): add underlined option to tabs

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -99,6 +99,8 @@ const Default_Story: ComponentStory<typeof Tabs> = (args) => {
 
 export const Default = Default_Story.bind({});
 
+export const DefaultUnderlined = Default_Story.bind({});
+
 const Default_Loading_Story: ComponentStory<typeof Tabs> = (args) => {
     const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
     return (
@@ -252,12 +254,18 @@ export const Pill_Icon_Label = Pill_Icon_Label_Story.bind({});
 const tabsArgs: Object = {
     scrollable: false,
     variant: TabVariant.default,
+    underlined: false,
     children: tabs.map((tab) => <Tab key={tab.value} {...tab} />),
     style: {},
 };
 
 Default.args = {
     ...tabsArgs,
+};
+
+DefaultUnderlined.args = {
+    ...tabsArgs,
+    underlined: true,
 };
 
 DefaultLoader.args = {

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -95,6 +95,12 @@ export interface TabsProps extends Omit<OcBaseProps<HTMLElement>, 'onChange'> {
      */
     scrollable?: boolean;
     /**
+     * If the tabs should have an underline/penline beneath them.
+     * NOTE: won't be applied if pill variant is used.
+     * @default false
+     */
+    underlined?: boolean;
+    /**
      * The default tab to select.
      */
     value?: TabValue;

--- a/src/components/Tabs/Tabs/AnimatedTabs.tsx
+++ b/src/components/Tabs/Tabs/AnimatedTabs.tsx
@@ -14,6 +14,7 @@ export const AnimatedTabs: FC<TabsProps> = React.forwardRef(
             style,
             variant = TabVariant.default,
             scrollable,
+            underlined = false,
             onChange,
             ...rest
         },
@@ -22,6 +23,7 @@ export const AnimatedTabs: FC<TabsProps> = React.forwardRef(
         const { currentActiveTab } = useTabs();
         const tabClassName: string = mergeClasses([
             styles.tabWrap,
+            { [styles.underlined]: underlined && variant !== TabVariant.pill },
             { [styles.small]: variant === TabVariant.small },
             { [styles.pill]: variant === TabVariant.pill },
             { [styles.scrollable]: scrollable },

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -6,6 +6,10 @@
         @include no-scrollbars;
     }
 
+    &.underlined {
+        border-bottom: 1px solid var(--tab-underline);
+    }
+
     .tab {
         align-items: center;
         border: none;

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -195,6 +195,7 @@
     --tab-pill-active-background: var(--accent-color-20);
     --tab-pill-hover-label: var(--primary-color);
     --tab-pill-background: var(--grey-color-10);
+    --tab-underline: var(--border-color);
     /* ------ Tabs theme ------ */
 
     /* ------ Navbar theme ------ */


### PR DESCRIPTION
## SUMMARY:
Many mocks include an edge-to-edge underline beneath tabs. Adding opt-in support for that line.

https://user-images.githubusercontent.com/106610186/193306451-564d6096-2392-447e-a235-70fd40d8ec7b.mov

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
NA

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [X] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change
-   [x] I have not added unittests for this change

## TEST PLAN:
Open any Tabs story (other than pill variant) and enable "underlined" control. Observe the presence of an underline