### PR TITLE
feat: dialog: add localization support to dialog

### DIFF
--- a/src/components/Dialog/BaseDialog/BaseDialog.tsx
+++ b/src/components/Dialog/BaseDialog/BaseDialog.tsx
@@ -27,6 +27,7 @@ export const BaseDialog: FC<BaseDialogProps> = React.forwardRef(
             bodyClassNames,
             bodyPadding = true,
             closable = true,
+            closeButtonAriaLabelText,
             closeButtonProps,
             closeIcon = IconName.mdiClose,
             dialogClassNames,
@@ -169,7 +170,7 @@ export const BaseDialog: FC<BaseDialogProps> = React.forwardRef(
                                 )}
                                 {closable && (
                                     <NeutralButton
-                                        ariaLabel={'Close'}
+                                        ariaLabel={closeButtonAriaLabelText}
                                         iconProps={{ path: closeIcon }}
                                         shape={ButtonShape.Round}
                                         onClick={onClose}

--- a/src/components/Dialog/BaseDialog/BaseDialog.types.ts
+++ b/src/components/Dialog/BaseDialog/BaseDialog.types.ts
@@ -19,7 +19,7 @@ type Locale = {
     /**
      * The Dialog `Cancel` button string.
      */
-    cancelButtonText?: string;
+    cancelText?: string;
     /**
      * The Dialog `Close` Button aria label string.
      */
@@ -27,7 +27,7 @@ type Locale = {
     /**
      * The Dialog `OK` button string.
      */
-    okButtonText?: string;
+    okText?: string;
 };
 
 export type DialogLocale = {
@@ -73,7 +73,7 @@ export interface BaseDialogProps
      * The dialog cancel button string.
      * @default 'Cancel'
      */
-    cancelButtonText?: string;
+    cancelText?: string;
     /**
      * Show close button on top right
      * @default true
@@ -134,7 +134,7 @@ export interface BaseDialogProps
      * The dialog ok button string.
      * @default 'OK'
      */
-    okButtonText?: string;
+    okText?: string;
     /**
      * Callback fired on close on the modal
      * @param e {EventType}

--- a/src/components/Dialog/BaseDialog/BaseDialog.types.ts
+++ b/src/components/Dialog/BaseDialog/BaseDialog.types.ts
@@ -11,6 +11,29 @@ type EventType =
 
 type Strategy = 'absolute' | 'fixed';
 
+type Locale = {
+    /**
+     * The Dialog locale.
+     */
+    locale: string;
+    /**
+     * The Dialog `Cancel` button string.
+     */
+    cancelButtonText?: string;
+    /**
+     * The Dialog `Close` Button aria label string.
+     */
+    closeButtonAriaLabelText?: string;
+    /**
+     * The Dialog `OK` button string.
+     */
+    okButtonText?: string;
+};
+
+export type DialogLocale = {
+    lang: Locale;
+};
+
 export interface BaseDialogProps
     extends Omit<OcBaseProps<HTMLDivElement>, 'classNames'> {
     /**
@@ -47,10 +70,20 @@ export interface BaseDialogProps
      */
     bodyPadding?: boolean;
     /**
+     * The dialog cancel button string.
+     * @default 'Cancel'
+     */
+    cancelButtonText?: string;
+    /**
      * Show close button on top right
      * @default true
      */
     closable?: boolean;
+    /**
+     * The dialog close button aria label string.
+     * @default 'Close'
+     */
+    closeButtonAriaLabelText?: string;
     /**
      * Close button extra props
      */
@@ -88,10 +121,20 @@ export interface BaseDialogProps
      */
     height?: number;
     /**
+     * The Pagination locale.
+     * @default 'enUS'
+     */
+    locale?: DialogLocale;
+    /**
      * Clicking on mask should close modal or not
      * @default true
      */
     maskClosable?: boolean;
+    /**
+     * The dialog ok button string.
+     * @default 'OK'
+     */
+    okButtonText?: string;
     /**
      * Callback fired on close on the modal
      * @param e {EventType}

--- a/src/components/Dialog/BaseDialog/Locale/cs_CZ.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/cs_CZ.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'cs_CZ',
-        cancelButtonText: 'Zrušit',
+        cancelText: 'Zrušit',
         closeButtonAriaLabelText: 'Zavřít',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/cs_CZ.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/cs_CZ.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'cs_CZ',
+        cancelButtonText: 'Zrušit',
+        closeButtonAriaLabelText: 'Zavřít',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/da_DK.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/da_DK.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'da_DK',
-        cancelButtonText: 'Aflyse',
+        cancelText: 'Aflyse',
         closeButtonAriaLabelText: 'Lukke',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/da_DK.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/da_DK.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'da_DK',
+        cancelButtonText: 'Aflyse',
+        closeButtonAriaLabelText: 'Lukke',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/de_DE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/de_DE.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'de_DE',
+        cancelButtonText: 'Abbrechen',
+        closeButtonAriaLabelText: 'Schließen',
+        okButtonText: 'Okay',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/de_DE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/de_DE.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'de_DE',
-        cancelButtonText: 'Abbrechen',
+        cancelText: 'Abbrechen',
         closeButtonAriaLabelText: 'Schließen',
-        okButtonText: 'Okay',
+        okText: 'Okay',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/el_GR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/el_GR.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'el_GR',
+        cancelButtonText: 'Ακυρώνω',
+        closeButtonAriaLabelText: 'Κλείνω',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/el_GR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/el_GR.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'el_GR',
-        cancelButtonText: 'Ακυρώνω',
+        cancelText: 'Ακυρώνω',
         closeButtonAriaLabelText: 'Κλείνω',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/en_GB.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/en_GB.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'en_GB',
-        cancelButtonText: 'Cancel',
+        cancelText: 'Cancel',
         closeButtonAriaLabelText: 'Close',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/en_GB.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/en_GB.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'en_GB',
+        cancelButtonText: 'Cancel',
+        closeButtonAriaLabelText: 'Close',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/en_US.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/en_US.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'en_US',
-        cancelButtonText: 'Cancel',
+        cancelText: 'Cancel',
         closeButtonAriaLabelText: 'Close',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/en_US.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/en_US.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'en_US',
+        cancelButtonText: 'Cancel',
+        closeButtonAriaLabelText: 'Close',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/es_DO.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/es_DO.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'es_DO',
-        cancelButtonText: 'Cancelar',
+        cancelText: 'Cancelar',
         closeButtonAriaLabelText: 'Cerrar',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/es_DO.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/es_DO.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'es_DO',
+        cancelButtonText: 'Cancelar',
+        closeButtonAriaLabelText: 'Cerrar',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/es_ES.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/es_ES.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'es_ES',
-        cancelButtonText: 'Cancelar',
+        cancelText: 'Cancelar',
         closeButtonAriaLabelText: 'Cerrar',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/es_ES.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/es_ES.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'es_ES',
+        cancelButtonText: 'Cancelar',
+        closeButtonAriaLabelText: 'Cerrar',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/es_MX.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/es_MX.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'es_MX',
-        cancelButtonText: 'Cancelar',
+        cancelText: 'Cancelar',
         closeButtonAriaLabelText: 'Cerrar',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/es_MX.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/es_MX.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'es_MX',
+        cancelButtonText: 'Cancelar',
+        closeButtonAriaLabelText: 'Cerrar',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/fi_FI.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fi_FI.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'fi_FI',
+        cancelButtonText: 'Perua',
+        closeButtonAriaLabelText: 'Sulkea',
+        okButtonText: 'Okei',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/fi_FI.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fi_FI.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'fi_FI',
-        cancelButtonText: 'Perua',
+        cancelText: 'Perua',
         closeButtonAriaLabelText: 'Sulkea',
-        okButtonText: 'Okei',
+        okText: 'Okei',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/fr_BE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fr_BE.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'fr_BE',
+        cancelButtonText: 'Annuler',
+        closeButtonAriaLabelText: 'Fermer',
+        okButtonText: 'D’accord',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/fr_BE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fr_BE.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'fr_BE',
-        cancelButtonText: 'Annuler',
+        cancelText: 'Annuler',
         closeButtonAriaLabelText: 'Fermer',
-        okButtonText: 'D’accord',
+        okText: 'D’accord',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/fr_CA.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fr_CA.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'fr_CA',
-        cancelButtonText: 'Annuler',
+        cancelText: 'Annuler',
         closeButtonAriaLabelText: 'Fermer',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/fr_CA.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fr_CA.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'fr_CA',
+        cancelButtonText: 'Annuler',
+        closeButtonAriaLabelText: 'Fermer',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/fr_FR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fr_FR.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'fr_FR',
+        cancelButtonText: 'Annuler',
+        closeButtonAriaLabelText: 'Fermer',
+        okButtonText: 'D’accord',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/fr_FR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/fr_FR.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'fr_FR',
-        cancelButtonText: 'Annuler',
+        cancelText: 'Annuler',
         closeButtonAriaLabelText: 'Fermer',
-        okButtonText: 'D’accord',
+        okText: 'D’accord',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/he_IL.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/he_IL.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'he_IL',
-        cancelButtonText: 'ביטל',
+        cancelText: 'ביטל',
         closeButtonAriaLabelText: 'קרוב',
-        okButtonText: 'אוקיי',
+        okText: 'אוקיי',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/he_IL.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/he_IL.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'he_IL',
+        cancelButtonText: 'ביטל',
+        closeButtonAriaLabelText: 'קרוב',
+        okButtonText: 'אוקיי',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/hr_HR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/hr_HR.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'hr_HR',
+        cancelButtonText: 'Otkazati',
+        closeButtonAriaLabelText: 'Blizak',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/hr_HR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/hr_HR.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'hr_HR',
-        cancelButtonText: 'Otkazati',
+        cancelText: 'Otkazati',
         closeButtonAriaLabelText: 'Blizak',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/ht_HT.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ht_HT.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'ht_HT',
-        cancelButtonText: 'Anile',
+        cancelText: 'Anile',
         closeButtonAriaLabelText: 'Fèmen',
-        okButtonText: 'Oke',
+        okText: 'Oke',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/ht_HT.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ht_HT.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'ht_HT',
+        cancelButtonText: 'Anile',
+        closeButtonAriaLabelText: 'Fèmen',
+        okButtonText: 'Oke',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/hu_HU.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/hu_HU.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'hu_HU',
+        cancelButtonText: 'Érvénytelenít',
+        closeButtonAriaLabelText: 'Bezár',
+        okButtonText: 'Oké',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/hu_HU.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/hu_HU.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'hu_HU',
-        cancelButtonText: 'Érvénytelenít',
+        cancelText: 'Érvénytelenít',
         closeButtonAriaLabelText: 'Bezár',
-        okButtonText: 'Oké',
+        okText: 'Oké',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/it_IT.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/it_IT.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'it_IT',
+        cancelButtonText: 'Annulla',
+        closeButtonAriaLabelText: 'Chiudere',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/it_IT.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/it_IT.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'it_IT',
-        cancelButtonText: 'Annulla',
+        cancelText: 'Annulla',
         closeButtonAriaLabelText: 'Chiudere',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/ja_JP.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ja_JP.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'ja_JP',
+        cancelButtonText: 'キャンセル',
+        closeButtonAriaLabelText: '閉める',
+        okButtonText: 'わかりました',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/ja_JP.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ja_JP.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'ja_JP',
-        cancelButtonText: 'キャンセル',
+        cancelText: 'キャンセル',
         closeButtonAriaLabelText: '閉める',
-        okButtonText: 'わかりました',
+        okText: 'わかりました',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/ko_KR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ko_KR.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'ko_KR',
-        cancelButtonText: '취소',
+        cancelText: '취소',
         closeButtonAriaLabelText: '닫다',
-        okButtonText: '닫다',
+        okText: '닫다',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/ko_KR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ko_KR.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'ko_KR',
+        cancelButtonText: '취소',
+        closeButtonAriaLabelText: '닫다',
+        okButtonText: '닫다',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/ms_MY.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ms_MY.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'ms_MY',
-        cancelButtonText: 'Membatalkan',
+        cancelText: 'Membatalkan',
         closeButtonAriaLabelText: 'Tutup',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/ms_MY.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ms_MY.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'ms_MY',
+        cancelButtonText: 'Membatalkan',
+        closeButtonAriaLabelText: 'Tutup',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/nb_NO.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/nb_NO.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'nb_NO',
-        cancelButtonText: 'Annullere',
+        cancelText: 'Annullere',
         closeButtonAriaLabelText: 'Lukke',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/nb_NO.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/nb_NO.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'nb_NO',
+        cancelButtonText: 'Annullere',
+        closeButtonAriaLabelText: 'Lukke',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/nl_BE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/nl_BE.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'nl_BE',
+        cancelButtonText: 'Annuleren',
+        closeButtonAriaLabelText: 'Sluiten',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/nl_BE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/nl_BE.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'nl_BE',
-        cancelButtonText: 'Annuleren',
+        cancelText: 'Annuleren',
         closeButtonAriaLabelText: 'Sluiten',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/nl_NL.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/nl_NL.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'nl_NL',
-        cancelButtonText: 'Annuleren',
+        cancelText: 'Annuleren',
         closeButtonAriaLabelText: 'Sluiten',
-        okButtonText: 'OK',
+        okText: 'OK',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/nl_NL.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/nl_NL.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'nl_NL',
+        cancelButtonText: 'Annuleren',
+        closeButtonAriaLabelText: 'Sluiten',
+        okButtonText: 'OK',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/pl_PL.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/pl_PL.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'pl_PL',
-        cancelButtonText: 'Anuluj',
+        cancelText: 'Anuluj',
         closeButtonAriaLabelText: 'Zamykać',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/pl_PL.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/pl_PL.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'pl_PL',
+        cancelButtonText: 'Anuluj',
+        closeButtonAriaLabelText: 'Zamykać',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/pt_BR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/pt_BR.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'pt_BR',
+        cancelButtonText: 'Cancelar',
+        closeButtonAriaLabelText: 'Fechar',
+        okButtonText: 'Okey',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/pt_BR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/pt_BR.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'pt_BR',
-        cancelButtonText: 'Cancelar',
+        cancelText: 'Cancelar',
         closeButtonAriaLabelText: 'Fechar',
-        okButtonText: 'Okey',
+        okText: 'Okey',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/pt_PT.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/pt_PT.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'pt_PT',
-        cancelButtonText: 'Cancelar',
+        cancelText: 'Cancelar',
         closeButtonAriaLabelText: 'Fechar',
-        okButtonText: 'Ok',
+        okText: 'Ok',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/pt_PT.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/pt_PT.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'pt_PT',
+        cancelButtonText: 'Cancelar',
+        closeButtonAriaLabelText: 'Fechar',
+        okButtonText: 'Ok',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/ru_RU.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ru_RU.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'ru_RU',
-        cancelButtonText: 'Отмена',
+        cancelText: 'Отмена',
         closeButtonAriaLabelText: 'Закрывать',
-        okButtonText: 'Хорошо',
+        okText: 'Хорошо',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/ru_RU.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ru_RU.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'ru_RU',
+        cancelButtonText: 'Отмена',
+        closeButtonAriaLabelText: 'Закрывать',
+        okButtonText: 'Хорошо',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/sv_SE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/sv_SE.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'sv_SE',
+        cancelButtonText: 'Annullera',
+        closeButtonAriaLabelText: 'Stänga',
+        okButtonText: 'Okej',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/sv_SE.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/sv_SE.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'sv_SE',
-        cancelButtonText: 'Annullera',
+        cancelText: 'Annullera',
         closeButtonAriaLabelText: 'Stänga',
-        okButtonText: 'Okej',
+        okText: 'Okej',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/th_TH.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/th_TH.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'th_TH',
+        cancelButtonText: 'ยกเลิก',
+        closeButtonAriaLabelText: 'ปิด',
+        okButtonText: 'ตกลง, ได้',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/th_TH.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/th_TH.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'th_TH',
-        cancelButtonText: 'ยกเลิก',
+        cancelText: 'ยกเลิก',
         closeButtonAriaLabelText: 'ปิด',
-        okButtonText: 'ตกลง, ได้',
+        okText: 'ตกลง, ได้',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/tr_TR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/tr_TR.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'tr_TR',
-        cancelButtonText: 'İptal',
+        cancelText: 'İptal',
         closeButtonAriaLabelText: 'Kapatmak',
-        okButtonText: 'Tamam',
+        okText: 'Tamam',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/tr_TR.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/tr_TR.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'tr_TR',
+        cancelButtonText: 'İptal',
+        closeButtonAriaLabelText: 'Kapatmak',
+        okButtonText: 'Tamam',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/uk_UA.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/uk_UA.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'uk_UA',
-        cancelButtonText: 'Скасувати',
+        cancelText: 'Скасувати',
         closeButtonAriaLabelText: 'Закрити',
-        okButtonText: 'Гаразд',
+        okText: 'Гаразд',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/uk_UA.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/uk_UA.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'uk_UA',
+        cancelButtonText: 'Скасувати',
+        closeButtonAriaLabelText: 'Закрити',
+        okButtonText: 'Гаразд',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/zh_CN.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/zh_CN.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'zh_CN',
-        cancelButtonText: '取消',
+        cancelText: '取消',
         closeButtonAriaLabelText: '关闭',
-        okButtonText: '还行',
+        okText: '还行',
     },
 };
 

--- a/src/components/Dialog/BaseDialog/Locale/zh_CN.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/zh_CN.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'zh_CN',
+        cancelButtonText: '取消',
+        closeButtonAriaLabelText: '关闭',
+        okButtonText: '还行',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/zh_TW.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/zh_TW.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+    lang: {
+        locale: 'zh_TW',
+        cancelButtonText: '取消',
+        closeButtonAriaLabelText: '關閉',
+        okButtonText: '還行',
+    },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/zh_TW.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/zh_TW.tsx
@@ -3,9 +3,9 @@ import type { DialogLocale } from '../BaseDialog.types';
 const locale: DialogLocale = {
     lang: {
         locale: 'zh_TW',
-        cancelButtonText: '取消',
+        cancelText: '取消',
         closeButtonAriaLabelText: '關閉',
-        okButtonText: '還行',
+        okText: '還行',
     },
 };
 

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -218,7 +218,6 @@ const dialogArgs: Object = {
         'data-test-id': 'my-cancel-btn-test-id',
         iconProps: null,
         id: 'myCancelButton',
-        text: 'Cancel',
     },
     'data-test-id': 'my-dialog-test-id',
     dialogClassNames: 'my-dialog-class',
@@ -233,7 +232,6 @@ const dialogArgs: Object = {
         'data-test-id': 'my-ok-btn-test-id',
         iconProps: null,
         id: 'myOkButton',
-        text: 'OK',
     },
     parent: document.body,
     zIndex: 1000,
@@ -254,7 +252,6 @@ Small.args = {
         disruptive: true,
         iconProps: null,
         id: 'myCancelButton',
-        text: 'Cancel',
     },
     okButtonProps: {
         ariaLabel: 'Accept',

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -21,7 +21,7 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
             bodyClassNames,
             bodyPadding = true,
             cancelButtonProps,
-            cancelButtonText: defaultCancelButtonText,
+            cancelText: defaultCancelButtonText,
             closeButtonAriaLabelText: defaultCloseButtonAriaLabelText,
             closeButtonProps,
             closeIcon,
@@ -32,7 +32,7 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
             height,
             locale = enUS,
             okButtonProps,
-            okButtonText: defaultOkButtonText,
+            okText: defaultOkButtonText,
             onOk,
             onCancel,
             overlay,
@@ -52,21 +52,20 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
             mergedLocale = dialogLocale || props.locale;
         }
 
-        const [cancelButtonText, setCancelButtonText] = useState<string>(
+        const [cancelText, setCancelButtonText] = useState<string>(
             defaultCancelButtonText
         );
         const [closeButtonAriaLabelText, setCloseButtonAriaLabelText] =
             useState<string>(defaultCloseButtonAriaLabelText);
-        const [okButtonText, setOkButtonText] =
-            useState<string>(defaultOkButtonText);
+        const [okText, setOkButtonText] = useState<string>(defaultOkButtonText);
 
         // Locs: if the prop isn't provided use the loc defaults.
         // If the mergedLocale is changed, update.
         useEffect(() => {
             setCancelButtonText(
-                props.cancelButtonText
-                    ? props.cancelButtonText
-                    : mergedLocale.lang!.cancelButtonText
+                props.cancelText
+                    ? props.cancelText
+                    : mergedLocale.lang!.cancelText
             );
             setCloseButtonAriaLabelText(
                 props.closeButtonAriaLabelText
@@ -74,9 +73,7 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
                     : mergedLocale.lang!.closeButtonAriaLabelText
             );
             setOkButtonText(
-                props.okButtonText
-                    ? props.okButtonText
-                    : mergedLocale.lang!.okButtonText
+                props.okText ? props.okText : mergedLocale.lang!.okText
             );
         }, [mergedLocale]);
 
@@ -116,14 +113,14 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
                                 <>
                                     {cancelButtonProps && (
                                         <NeutralButton
-                                            text={cancelButtonText}
+                                            text={cancelText}
                                             {...cancelButtonProps}
                                             onClick={onCancel}
                                         />
                                     )}
                                     {okButtonProps && (
                                         <PrimaryButton
-                                            text={okButtonText}
+                                            text={okText}
                                             {...okButtonProps}
                                             onClick={onOk}
                                         />
@@ -142,7 +139,7 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
                             headerIcon={headerIcon}
                             height={height}
                             locale={locale}
-                            okButtonText={okButtonText}
+                            okText={okText}
                             overlay={overlay}
                             width={width}
                         />

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,14 +1,19 @@
-import React, { FC, Ref } from 'react';
+import React, { FC, Ref, useEffect, useState } from 'react';
 import { DialogProps, DialogSize } from './Dialog.types';
 import { mergeClasses } from '../../shared/utilities';
 import { NeutralButton, PrimaryButton } from '../Button';
 import { BaseDialog } from './BaseDialog/BaseDialog';
+import { DialogLocale } from './BaseDialog/BaseDialog.types';
+import LocaleReceiver, {
+    useLocaleReceiver,
+} from '../LocaleProvider/LocaleReceiver';
+import enUS from './BaseDialog/Locale/en_US';
 
 import styles from './dialog.module.scss';
 
 export const Dialog: FC<DialogProps> = React.forwardRef(
-    (
-        {
+    (props: DialogProps, ref: Ref<HTMLDivElement>) => {
+        const {
             actionButtonOneProps,
             actionButtonTwoProps,
             actionButtonThreeProps,
@@ -16,6 +21,8 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
             bodyClassNames,
             bodyPadding = true,
             cancelButtonProps,
+            cancelButtonText: defaultCancelButtonText,
+            closeButtonAriaLabelText: defaultCloseButtonAriaLabelText,
             closeButtonProps,
             closeIcon,
             dialogClassNames,
@@ -23,7 +30,9 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
             headerClassNames,
             headerIcon,
             height,
+            locale = enUS,
             okButtonProps,
+            okButtonText: defaultOkButtonText,
             onOk,
             onCancel,
             overlay,
@@ -31,9 +40,46 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
             size = DialogSize.medium,
             width,
             ...rest
-        },
-        ref: Ref<HTMLDivElement>
-    ) => {
+        } = props;
+
+        // ============================ Strings ===========================
+        const [dialogLocale] = useLocaleReceiver('Dialog');
+        let mergedLocale: DialogLocale;
+
+        if (props.locale) {
+            mergedLocale = props.locale;
+        } else {
+            mergedLocale = dialogLocale || props.locale;
+        }
+
+        const [cancelButtonText, setCancelButtonText] = useState<string>(
+            defaultCancelButtonText
+        );
+        const [closeButtonAriaLabelText, setCloseButtonAriaLabelText] =
+            useState<string>(defaultCloseButtonAriaLabelText);
+        const [okButtonText, setOkButtonText] =
+            useState<string>(defaultOkButtonText);
+
+        // Locs: if the prop isn't provided use the loc defaults.
+        // If the mergedLocale is changed, update.
+        useEffect(() => {
+            setCancelButtonText(
+                props.cancelButtonText
+                    ? props.cancelButtonText
+                    : mergedLocale.lang!.cancelButtonText
+            );
+            setCloseButtonAriaLabelText(
+                props.closeButtonAriaLabelText
+                    ? props.closeButtonAriaLabelText
+                    : mergedLocale.lang!.closeButtonAriaLabelText
+            );
+            setOkButtonText(
+                props.okButtonText
+                    ? props.okButtonText
+                    : mergedLocale.lang!.okButtonText
+            );
+        }, [mergedLocale]);
+
         const dialogClasses: string = mergeClasses([
             styles.dialog,
             { [styles.noBodyPadding]: bodyPadding === false },
@@ -55,38 +101,54 @@ export const Dialog: FC<DialogProps> = React.forwardRef(
         ]);
 
         return (
-            <BaseDialog
-                {...rest}
-                ref={ref}
-                actionButtonOneProps={actionButtonOneProps}
-                actionButtonTwoProps={actionButtonTwoProps}
-                actionButtonThreeProps={actionButtonThreeProps}
-                actions={
-                    <>
-                        {cancelButtonProps && (
-                            <NeutralButton
-                                {...cancelButtonProps}
-                                onClick={onCancel}
-                            />
-                        )}
-                        {okButtonProps && (
-                            <PrimaryButton {...okButtonProps} onClick={onOk} />
-                        )}
-                    </>
-                }
-                actionsClassNames={actionClasses}
-                bodyClassNames={bodyClasses}
-                bodyPadding={bodyPadding}
-                closeButtonProps={closeButtonProps}
-                closeIcon={closeIcon}
-                dialogClassNames={dialogClasses}
-                headerButtonProps={headerButtonProps}
-                headerClassNames={headerClasses}
-                headerIcon={headerIcon}
-                height={height}
-                overlay={overlay}
-                width={width}
-            />
+            <LocaleReceiver componentName={'Dialog'} defaultLocale={enUS}>
+                {(contextLocale: DialogLocale) => {
+                    const locale = { ...contextLocale, ...mergedLocale };
+
+                    return (
+                        <BaseDialog
+                            {...rest}
+                            ref={ref}
+                            actionButtonOneProps={actionButtonOneProps}
+                            actionButtonTwoProps={actionButtonTwoProps}
+                            actionButtonThreeProps={actionButtonThreeProps}
+                            actions={
+                                <>
+                                    {cancelButtonProps && (
+                                        <NeutralButton
+                                            text={cancelButtonText}
+                                            {...cancelButtonProps}
+                                            onClick={onCancel}
+                                        />
+                                    )}
+                                    {okButtonProps && (
+                                        <PrimaryButton
+                                            text={okButtonText}
+                                            {...okButtonProps}
+                                            onClick={onOk}
+                                        />
+                                    )}
+                                </>
+                            }
+                            actionsClassNames={actionClasses}
+                            bodyClassNames={bodyClasses}
+                            bodyPadding={bodyPadding}
+                            closeButtonAriaLabelText={closeButtonAriaLabelText}
+                            closeButtonProps={closeButtonProps}
+                            closeIcon={closeIcon}
+                            dialogClassNames={dialogClasses}
+                            headerButtonProps={headerButtonProps}
+                            headerClassNames={headerClasses}
+                            headerIcon={headerIcon}
+                            height={height}
+                            locale={locale}
+                            okButtonText={okButtonText}
+                            overlay={overlay}
+                            width={width}
+                        />
+                    );
+                }}
+            </LocaleReceiver>
         );
     }
 );

--- a/src/components/Locale/Default.tsx
+++ b/src/components/Locale/Default.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/en_US';
+import Dialog from '../Dialog/BaseDialog/Locale/en_US';
 import Pagination from '../Pagination/Locale/en_US';
 import Table from '../Table/Locale/en_US';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_US';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Select',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(optional)',
         defaultValidateMessages: {

--- a/src/components/Locale/cs_CZ.tsx
+++ b/src/components/Locale/cs_CZ.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/cs_CZ';
+import Dialog from '../Dialog/BaseDialog/Locale/cs_CZ';
 import Pagination from '../Pagination/Locale/cs_CZ';
 import Table from '../Table/Locale/cs_CZ';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/cs_CZ';
@@ -10,6 +11,7 @@ const localeValues: Locale = {
         placeholder: 'Prosím vyber',
     },
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/da_DK.tsx
+++ b/src/components/Locale/da_DK.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/da_DK';
+import Dialog from '../Dialog/BaseDialog/Locale/da_DK';
 import Pagination from '../Pagination/Locale/da_DK';
 import Table from '../Table/Locale/da_DK';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/da_DK';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/da_DK';
 const localeValues: Locale = {
     locale: 'da',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/de_DE.tsx
+++ b/src/components/Locale/de_DE.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/de_DE';
+import Dialog from '../Dialog/BaseDialog/Locale/de_DE';
 import Pagination from '../Pagination/Locale/de_DE';
 import Table from '../Table/Locale/de_DE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/de_DE';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Bitte auswählen',
     },
     DatePicker,
+    Dialog,
     Form: {
         defaultValidateMessages: {
             default: 'Feld-Validierungsfehler: ${label}',

--- a/src/components/Locale/el_GR.tsx
+++ b/src/components/Locale/el_GR.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/el_GR';
+import Dialog from '../Dialog/BaseDialog/Locale/el_GR';
 import Pagination from '../Pagination/Locale/el_GR';
 import Table from '../Table/Locale/el_GR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/el_GR';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/el_GR';
 const localeValues: Locale = {
     locale: 'el',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/en_GB.tsx
+++ b/src/components/Locale/en_GB.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/en_GB';
+import Dialog from '../Dialog/BaseDialog/Locale/en_GB';
 import Pagination from '../Pagination/Locale/en_GB';
 import Table from '../Table/Locale/en_GB';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_GB';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Select',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(optional)',
         defaultValidateMessages: {

--- a/src/components/Locale/es_DO.tsx
+++ b/src/components/Locale/es_DO.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_DO';
+import Dialog from '../Dialog/BaseDialog/Locale/es_DO';
 import Pagination from '../Pagination/Locale/es_DO';
 import Table from '../Table/Locale/es_DO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_DO';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Seleccione',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {

--- a/src/components/Locale/es_ES.tsx
+++ b/src/components/Locale/es_ES.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_ES';
+import Dialog from '../Dialog/BaseDialog/Locale/es_ES';
 import Pagination from '../Pagination/Locale/es_ES';
 import Table from '../Table/Locale/es_ES';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_ES';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Seleccione',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {

--- a/src/components/Locale/es_MX.tsx
+++ b/src/components/Locale/es_MX.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_MX';
+import Dialog from '../Dialog/BaseDialog/Locale/es_MX';
 import Pagination from '../Pagination/Locale/es_MX';
 import Table from '../Table/Locale/es_MX';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_MX';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Seleccione',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {

--- a/src/components/Locale/fi_FI.tsx
+++ b/src/components/Locale/fi_FI.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fi_FI';
+import Dialog from '../Dialog/BaseDialog/Locale/fi_FI';
 import Pagination from '../Pagination/Locale/fi_FI';
 import Table from '../Table/Locale/fi_FI';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fi_FI';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/fi_FI';
 const localeValues: Locale = {
     locale: 'fi',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/fr_BE.tsx
+++ b/src/components/Locale/fr_BE.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_BE';
+import Dialog from '../Dialog/BaseDialog/Locale/fr_BE';
 import Pagination from '../Pagination/Locale/fr_BE';
 import Table from '../Table/Locale/fr_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_BE';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_BE';
 const localeValues: Locale = {
     locale: 'fr',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/fr_CA.tsx
+++ b/src/components/Locale/fr_CA.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_CA';
+import Dialog from '../Dialog/BaseDialog/Locale/fr_CA';
 import Pagination from '../Pagination/Locale/fr_CA';
 import Table from '../Table/Locale/fr_CA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_CA';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_CA';
 const localeValues: Locale = {
     locale: 'fr',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/fr_FR.tsx
+++ b/src/components/Locale/fr_FR.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_FR';
+import Dialog from '../Dialog/BaseDialog/Locale/fr_FR';
 import Pagination from '../Pagination/Locale/fr_FR';
 import Table from '../Table/Locale/fr_FR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_FR';
@@ -11,6 +12,7 @@ const typeTemplate =
 const localeValues: Locale = {
     locale: 'fr',
     DatePicker,
+    Dialog,
     Form: {
         optional: '(optionnel)',
         defaultValidateMessages: {

--- a/src/components/Locale/he_IL.tsx
+++ b/src/components/Locale/he_IL.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/he_IL';
+import Dialog from '../Dialog/BaseDialog/Locale/he_IL';
 import Pagination from '../Pagination/Locale/he_IL';
 import Table from '../Table/Locale/he_IL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/he_IL';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'אנא בחר',
     },
     DatePicker,
+    Dialog,
     Form: {
         defaultValidateMessages: {
             default: 'ערך השדה שגוי ${label}',

--- a/src/components/Locale/hr_HR.tsx
+++ b/src/components/Locale/hr_HR.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/hr_HR';
+import Dialog from '../Dialog/BaseDialog/Locale/hr_HR';
 import Pagination from '../Pagination/Locale/hr_HR';
 import Table from '../Table/Locale/hr_HR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hr_HR';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Molimo označite',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(neobavezno)',
         defaultValidateMessages: {

--- a/src/components/Locale/ht_HT.tsx
+++ b/src/components/Locale/ht_HT.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ht_HT';
+import Dialog from '../Dialog/BaseDialog/Locale/ht_HT';
 import Pagination from '../Pagination/Locale/ht_HT';
 import Table from '../Table/Locale/ht_HT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ht_HT';
@@ -11,6 +12,7 @@ const typeTemplate =
 const localeValues: Locale = {
     locale: 'fr',
     DatePicker,
+    Dialog,
     Form: {
         optional: '(optionnel)',
         defaultValidateMessages: {

--- a/src/components/Locale/hu_HU.tsx
+++ b/src/components/Locale/hu_HU.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/hu_HU';
+import Dialog from '../Dialog/BaseDialog/Locale/hu_HU';
 import Pagination from '../Pagination/Locale/hu_HU';
 import Table from '../Table/Locale/hu_HU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hu_HU';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/hu_HU';
 const localeValues: Locale = {
     locale: 'hu',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/it_IT.tsx
+++ b/src/components/Locale/it_IT.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/it_IT';
+import Dialog from '../Dialog/BaseDialog/Locale/it_IT';
 import Pagination from '../Pagination/Locale/it_IT';
 import Table from '../Table/Locale/it_IT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/it_IT';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/it_IT';
 const localeValues: Locale = {
     locale: 'it',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/ja_JP.tsx
+++ b/src/components/Locale/ja_JP.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ja_JP';
+import Dialog from '../Dialog/BaseDialog/Locale/ja_JP';
 import Pagination from '../Pagination/Locale/ja_JP';
 import Table from '../Table/Locale/ja_JP';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ja_JP';
@@ -10,6 +11,7 @@ const typeTemplate = '${label}は有効な${type}ではありません';
 const localeValues: Locale = {
     locale: 'ja',
     DatePicker,
+    Dialog,
     Form: {
         defaultValidateMessages: {
             default: '${label}のフィールド検証エラー',

--- a/src/components/Locale/ko_KR.tsx
+++ b/src/components/Locale/ko_KR.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ko_KR';
+import Dialog from '../Dialog/BaseDialog/Locale/ko_KR';
 import Pagination from '../Pagination/Locale/ko_KR';
 import Table from '../Table/Locale/ko_KR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ko_KR';
@@ -10,6 +11,7 @@ const typeTemplate = '${label} 유효하지 않은 ${type}';
 const localeValues: Locale = {
     locale: 'ko',
     DatePicker,
+    Dialog,
     Form: {
         defaultValidateMessages: {
             default: '필드 유효성 검사 오류 ${label}',

--- a/src/components/Locale/ms_MY.tsx
+++ b/src/components/Locale/ms_MY.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ms_MY';
+import Dialog from '../Dialog/BaseDialog/Locale/ms_MY';
 import Pagination from '../Pagination/Locale/ms_MY';
 import Table from '../Table/Locale/ms_MY';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ms_MY';
@@ -10,6 +11,7 @@ const localeValues: Locale = {
         placeholder: 'Sila pilih',
     },
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/nb_NO.tsx
+++ b/src/components/Locale/nb_NO.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nb_NO';
+import Dialog from '../Dialog/BaseDialog/Locale/nb_NO';
 import Pagination from '../Pagination/Locale/nb_NO';
 import Table from '../Table/Locale/nb_NO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nb_NO';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Vennligst velg',
     },
     DatePicker,
+    Dialog,
     Form: {
         defaultValidateMessages: {
             default: 'Feltvalideringsfeil ${label}',

--- a/src/components/Locale/nl_BE.tsx
+++ b/src/components/Locale/nl_BE.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_BE';
+import Dialog from '../Dialog/BaseDialog/Locale/nl_BE';
 import Pagination from '../Pagination/Locale/nl_BE';
 import Table from '../Table/Locale/nl_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_BE';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Maak een selectie',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(optioneel)',
         defaultValidateMessages: {

--- a/src/components/Locale/nl_NL.tsx
+++ b/src/components/Locale/nl_NL.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_NL';
+import Dialog from '../Dialog/BaseDialog/Locale/nl_NL';
 import Pagination from '../Pagination/Locale/nl_NL';
 import Table from '../Table/Locale/nl_NL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_NL';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Maak een selectie',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(optioneel)',
         defaultValidateMessages: {

--- a/src/components/Locale/pl_PL.tsx
+++ b/src/components/Locale/pl_PL.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pl_PL';
+import Dialog from '../Dialog/BaseDialog/Locale/pl_PL';
 import Pagination from '../Pagination/Locale/pl_PL';
 import Table from '../Table/Locale/pl_PL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pl_PL';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Wybierz',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(opcjonalne)',
         defaultValidateMessages: {

--- a/src/components/Locale/pt_BR.tsx
+++ b/src/components/Locale/pt_BR.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_BR';
+import Dialog from '../Dialog/BaseDialog/Locale/pt_BR';
 import Pagination from '../Pagination/Locale/pt_BR';
 import Table from '../Table/Locale/pt_BR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_BR';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Por favor escolha',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(opcional)',
         defaultValidateMessages: {

--- a/src/components/Locale/pt_PT.tsx
+++ b/src/components/Locale/pt_PT.tsx
@@ -1,5 +1,6 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_PT';
+import Dialog from '../Dialog/BaseDialog/Locale/pt_PT';
 import Pagination from '../Pagination/Locale/pt_PT';
 import Table from '../Table/Locale/pt_PT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_PT';
@@ -7,6 +8,7 @@ import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_PT';
 const localeValues: Locale = {
     locale: 'pt',
     DatePicker,
+    Dialog,
     Pagination,
     Table,
     TimePicker,

--- a/src/components/Locale/ru_RU.tsx
+++ b/src/components/Locale/ru_RU.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ru_RU';
+import Dialog from '../Dialog/BaseDialog/Locale/ru_RU';
 import Pagination from '../Pagination/Locale/ru_RU';
 import Table from '../Table/Locale/ru_RU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ru_RU';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Пожалуйста выберите',
     },
     DatePicker,
+    Dialog,
     Form: {
         defaultValidateMessages: {
             default: 'Ошибка проверки поля ${label}',

--- a/src/components/Locale/sv_SE.tsx
+++ b/src/components/Locale/sv_SE.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/sv_SE';
+import Dialog from '../Dialog/BaseDialog/Locale/sv_SE';
 import Pagination from '../Pagination/Locale/sv_SE';
 import Table from '../Table/Locale/sv_SE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/sv_SE';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Vänligen välj',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(valfritt)',
         defaultValidateMessages: {

--- a/src/components/Locale/th_TH.tsx
+++ b/src/components/Locale/th_TH.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/th_TH';
+import Dialog from '../Dialog/BaseDialog/Locale/th_TH';
 import Pagination from '../Pagination/Locale/th_TH';
 import Table from '../Table/Locale/th_TH';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/th_TH';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'กรุณาเลือก',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(ไม่จำเป็น)',
         defaultValidateMessages: {

--- a/src/components/Locale/tr_TR.tsx
+++ b/src/components/Locale/tr_TR.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/tr_TR';
+import Dialog from '../Dialog/BaseDialog/Locale/tr_TR';
 import Pagination from '../Pagination/Locale/tr_TR';
 import Table from '../Table/Locale/tr_TR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/tr_TR';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Lütfen seçiniz',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(opsiyonel)',
         defaultValidateMessages: {

--- a/src/components/Locale/uk_UA.tsx
+++ b/src/components/Locale/uk_UA.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/uk_UA';
+import Dialog from '../Dialog/BaseDialog/Locale/uk_UA';
 import Pagination from '../Pagination/Locale/uk_UA';
 import Table from '../Table/Locale/uk_UA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/uk_UA';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: 'Будь ласка, оберіть',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '(опціонально)',
         defaultValidateMessages: {

--- a/src/components/Locale/zh_CN.tsx
+++ b/src/components/Locale/zh_CN.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_CN';
+import Dialog from '../Dialog/BaseDialog/Locale/zh_CN';
 import Pagination from '../Pagination/Locale/zh_CN';
 import Table from '../Table/Locale/zh_CN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_CN';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: '请选择',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '（可选）',
         defaultValidateMessages: {

--- a/src/components/Locale/zh_TW.tsx
+++ b/src/components/Locale/zh_TW.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_TW';
+import Dialog from '../Dialog/BaseDialog/Locale/zh_TW';
 import Pagination from '../Pagination/Locale/zh_TW';
 import Table from '../Table/Locale/zh_TW';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_TW';
@@ -13,6 +14,7 @@ const localeValues: Locale = {
         placeholder: '請選擇',
     },
     DatePicker,
+    Dialog,
     Form: {
         optional: '（可選）',
         defaultValidateMessages: {

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import memoizeOne from 'memoize-one';
+import type { DialogLocale } from '../Dialog/BaseDialog/BaseDialog.types';
 import type { PaginationLocale } from '../Pagination';
 import type { PickerLocale as DatePickerLocale } from '../DateTimePicker/DatePicker/Generate/Generate.types';
 import type { TableLocale } from '../Table/Table.types';
@@ -10,6 +11,7 @@ export interface Locale {
     locale: string;
     global?: Record<string, any>;
     DatePicker?: DatePickerLocale;
+    Dialog?: DialogLocale;
     Form?: {
         optional?: string;
         defaultValidateMessages: ValidateMessages;


### PR DESCRIPTION
## SUMMARY:
Adds localization support to `BaseDialog` and `Dialog`

## JIRA TASK (Eightfold Employees Only):
ENG-30997

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [X] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist (loc tests)
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and do `yarn`, then `yarn storybook`, verify the `Dialog` stories behave as expected.

Set the Dialog locale to another language and test the go to text as follows (pseudo-code):

```
import { zhCN } from "@eightfold.ai/octuple/";
<Dialog locale={zhCN} okText={'foo'} />
```

The ok button text in the `Dialog` should read 'foo' and the others should use the loc defaults.