### PR TITLE
fix: select: update when options change

### DIFF
--- a/src/components/Form/Tests/index.test.js
+++ b/src/components/Form/Tests/index.test.js
@@ -904,7 +904,6 @@ describe('Form', () => {
                         <Form.Item name={itemName}>
                             <Select
                                 classNames={'form_item_parentNode'}
-                                defaultValue="lucy"
                                 showDropdown={open}
                                 options={[
                                     {
@@ -914,6 +913,7 @@ describe('Form', () => {
                                     {
                                         text: 'Lucy',
                                         value: 'lucy',
+                                        selected: true,
                                     },
                                     {
                                         text: 'Yiminghe',
@@ -1127,21 +1127,45 @@ describe('Form', () => {
         const Demo = () => (
             <Form>
                 <Form.Item validateStatus="error" noStyle>
-                    <Select classNames={'custom-select'} />
+                    <Select
+                        classNames={'custom-select'}
+                        options={{
+                            text: 'School',
+                            value: 'school',
+                        }}
+                    />
                 </Form.Item>
                 <Form.Item validateStatus="error">
                     <Form.Item noStyle>
-                        <Select classNames={'custom-select-b'} />
+                        <Select
+                            classNames={'custom-select-b'}
+                            options={{
+                                text: 'School',
+                                value: 'school',
+                            }}
+                        />
                     </Form.Item>
                 </Form.Item>
                 <Form.Item validateStatus="error">
                     <Form.Item noStyle validateStatus="warning">
-                        <Select classNames={'custom-select-c'} />
+                        <Select
+                            classNames={'custom-select-c'}
+                            options={{
+                                text: 'School',
+                                value: 'school',
+                            }}
+                        />
                     </Form.Item>
                 </Form.Item>
                 <Form.Item noStyle>
                     <Form.Item validateStatus="warning">
-                        <Select classNames={'custom-select-d'} />
+                        <Select
+                            classNames={'custom-select-d'}
+                            options={{
+                                text: 'School',
+                                value: 'school',
+                            }}
+                        />
                     </Form.Item>
                 </Form.Item>
             </Form>
@@ -1179,17 +1203,17 @@ describe('Form', () => {
                 <Form.Item labelCol={4} validateStatus="error">
                     <Modal
                         visible={true}
-                        body={<Select classNames={'modal-select'} />}
+                        body={<TextInput classNames={'modal-input'} />}
                     />
                 </Form.Item>
             </Form>
         );
         const { container } = render(<Demo />, { container: document.body });
         expect(
-            container.querySelector('.modal-select')?.className
+            container.querySelector('.modal-input')?.className
         ).not.toContain('in-form-item');
         expect(
-            container.querySelector('.modal-select')?.className
+            container.querySelector('.modal-input')?.className
         ).not.toContain('status-error');
     });
 

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -186,6 +186,10 @@ export interface InputProps<T>
      */
     autoFocus?: boolean;
     /**
+     * programmatically clear the input when true.
+     */
+    clear?: boolean;
+    /**
      * option to show the clear input button.
      * default is true for backward compatibility
      * @default true

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -187,6 +187,7 @@ export interface InputProps<T>
     autoFocus?: boolean;
     /**
      * programmatically clear the input when true.
+     * @default false
      */
     clear?: boolean;
     /**

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -35,7 +35,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             ariaLabel,
             autoFocus = false,
             classNames,
-            clear,
+            clear = false,
             clearable = true,
             clearButtonAriaLabel,
             configContextProps = {

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Ref, useContext, useEffect, useState } from 'react';
+import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import DisabledContext, {
     Disabled,
 } from '../../ConfigProvider/DisabledContext';
@@ -35,6 +35,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             ariaLabel,
             autoFocus = false,
             classNames,
+            clear,
             clearable = true,
             clearButtonAriaLabel,
             configContextProps = {
@@ -85,6 +86,9 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
         const [clearButtonShown, _setClearButtonShown] =
             useState<boolean>(false);
         const [inputId] = useState<string>(uniqueId(id || 'input-'));
+
+        const clearButtonRef: React.MutableRefObject<HTMLButtonElement> =
+            useRef<HTMLButtonElement>(null);
 
         const {
             status: contextStatus,
@@ -287,6 +291,12 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
                 : _setClearButtonShown(showClear);
         };
 
+        useEffect(() => {
+            if (clear) {
+                clearButtonRef.current?.click();
+            }
+        }, [clear]);
+
         const handleOnClear = (_event: React.MouseEvent) => {
             _event.preventDefault();
             _event.stopPropagation();
@@ -452,6 +462,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
                         !numbersOnly &&
                         htmlType !== 'number' && (
                             <DefaultButton
+                                ref={clearButtonRef}
                                 allowDisabledFocus={allowDisabledFocus}
                                 ariaLabel={clearButtonAriaLabel}
                                 classNames={clearIconButtonClassNames}

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -41,13 +41,14 @@ describe('Select', () => {
         await sleep();
     }
 
+    const defaultOptions: SelectOption[] = [
+        {
+            text: 'School',
+            value: 'school',
+        },
+    ];
+
     test('Select clearable', async () => {
-        let defaultOptions: SelectOption[] = [
-            {
-                text: 'School',
-                value: 'school',
-            },
-        ];
         const { container } = render(
             <Select
                 defaultValue="school"
@@ -99,12 +100,6 @@ describe('Select', () => {
 
             fireEvent.keyUp(element, sharedEventConfig);
         };
-        const defaultOptions: SelectOption[] = [
-            {
-                text: 'School',
-                value: 'school',
-            },
-        ];
         const { container } = render(<Select options={defaultOptions} />);
         await change(container, 'School');
         expect(
@@ -122,32 +117,44 @@ describe('Select', () => {
     });
 
     test('Select is large', () => {
-        const { container } = render(<Select size={SelectSize.Large} />);
+        const { container } = render(
+            <Select options={defaultOptions} size={SelectSize.Large} />
+        );
         expect(container.firstChild).toMatchSnapshot();
     });
 
     test('Select is medium', () => {
-        const { container } = render(<Select size={SelectSize.Medium} />);
+        const { container } = render(
+            <Select options={defaultOptions} size={SelectSize.Medium} />
+        );
         expect(container.firstChild).toMatchSnapshot();
     });
 
     test('Select is small', () => {
-        const { container } = render(<Select size={SelectSize.Small} />);
+        const { container } = render(
+            <Select options={defaultOptions} size={SelectSize.Small} />
+        );
         expect(container.firstChild).toMatchSnapshot();
     });
 
     test('Select is rectangle shaped', () => {
-        const { container } = render(<Select shape={SelectShape.Rectangle} />);
+        const { container } = render(
+            <Select options={defaultOptions} shape={SelectShape.Rectangle} />
+        );
         expect(container.firstChild).toMatchSnapshot();
     });
 
     test('Select is pill shaped', () => {
-        const { container } = render(<Select shape={SelectShape.Pill} />);
+        const { container } = render(
+            <Select options={defaultOptions} shape={SelectShape.Pill} />
+        );
         expect(container.firstChild).toMatchSnapshot();
     });
 
     test('Select is underline shaped', () => {
-        const { container } = render(<Select shape={SelectShape.Underline} />);
+        const { container } = render(
+            <Select options={defaultOptions} shape={SelectShape.Underline} />
+        );
         expect(container.firstChild).toMatchSnapshot();
     });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -156,7 +156,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                     ...option,
                 }))
             );
-        }, [isLoading]);
+        }, [_options, isLoading]);
 
         useEffect(() => {
             onOptionsChange?.(getSelectedOptions());


### PR DESCRIPTION
## SUMMARY:
Previously the `Select` was not aware its `options` have changed, adds `_options` to existing `useEffect`
also adds a `boolean` to programmatically `clear` TextInput if `needed`.


https://user-images.githubusercontent.com/99700808/193370706-0901a4f3-8eaa-4129-81bc-a7a6b6212738.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-31020

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and do `yarn`, then `yarn storybook`, verify the `Select` and `TextInput` stories behave as expected.