### PR TITLE
feat: panel: add localization support to Panel, InfoBar

### DIFF
--- a/src/components/Dialog/BaseDialog/BaseDialog.types.ts
+++ b/src/components/Dialog/BaseDialog/BaseDialog.types.ts
@@ -121,7 +121,7 @@ export interface BaseDialogProps
      */
     height?: number;
     /**
-     * The Pagination locale.
+     * The Dialog locale.
      * @default 'enUS'
      */
     locale?: DialogLocale;

--- a/src/components/InfoBar/InfoBar.stories.tsx
+++ b/src/components/InfoBar/InfoBar.stories.tsx
@@ -71,7 +71,6 @@ const infoBarArgs: Object = {
     style: {},
     classNames: 'my-info-bar-class',
     closeButtonProps: {
-        ariaLabel: 'Close',
         classNames: 'my-close-btn-class',
         'data-test-id': 'my-close-btn-test-id',
         id: 'myCloseButton',

--- a/src/components/InfoBar/InfoBar.types.ts
+++ b/src/components/InfoBar/InfoBar.types.ts
@@ -11,15 +11,35 @@ export enum InfoBarType {
     disruptive = 'disruptive',
 }
 
+type Locale = {
+    /**
+     * The InfoBar locale.
+     */
+    locale: string;
+    /**
+     * The InfoBar `Close` Button aria label string.
+     */
+    closeButtonAriaLabelText?: string;
+};
+
+export type InfoBarLocale = {
+    lang: Locale;
+};
+
 export interface InfoBarsProps extends OcBaseProps<HTMLDivElement> {
     /**
      * Props for the action button
      */
     actionButtonProps?: ButtonProps;
     /**
-     * If the infoBar is closable or not
+     * If the InfoBar is closable or not
      */
     closable?: boolean;
+    /**
+     * The Panel `Close` Button aria label string.
+     * @default 'Close'
+     */
+    closeButtonAriaLabelText?: string;
     /**
      * Custom props for the close button
      */
@@ -30,24 +50,29 @@ export interface InfoBarsProps extends OcBaseProps<HTMLDivElement> {
      */
     closeIcon?: IconName;
     /**
-     * Content of the info bar
+     * Content of the InfoBar
      */
     content: string;
     /**
-     * Custom icon for the infoBar
+     * Custom icon for the InfoBar
      * @default IconName.mdiInformation | IconName.mdiCheckCircle | IconName.mdiAlert
      */
     icon?: IconName;
     /**
-     * Callback fired on close of the infoBar
+     * The InfoBar locale.
+     * @default 'enUS'
+     */
+    locale?: InfoBarLocale;
+    /**
+     * Callback fired on close of the InfoBar
      */
     onClose?: () => void;
     /**
-     * Role of the info bar
+     * Role of the InfoBar
      */
     role?: string;
     /**
-     * Type of the infoBar
+     * Type of the InfoBar
      * @default InfoBarType.neutral
      */
     type?: InfoBarType;

--- a/src/components/InfoBar/Locale/cs_CZ.tsx
+++ b/src/components/InfoBar/Locale/cs_CZ.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'cs_CZ',
+        closeButtonAriaLabelText: 'Zavřít',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/da_DK.tsx
+++ b/src/components/InfoBar/Locale/da_DK.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'da_DK',
+        closeButtonAriaLabelText: 'Lukke',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/de_DE.tsx
+++ b/src/components/InfoBar/Locale/de_DE.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'de_DE',
+        closeButtonAriaLabelText: 'Schließen',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/el_GR.tsx
+++ b/src/components/InfoBar/Locale/el_GR.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'el_GR',
+        closeButtonAriaLabelText: 'Κλείνω',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/en_GB.tsx
+++ b/src/components/InfoBar/Locale/en_GB.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'en_GB',
+        closeButtonAriaLabelText: 'Close',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/en_US.tsx
+++ b/src/components/InfoBar/Locale/en_US.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'en_US',
+        closeButtonAriaLabelText: 'Close',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/es_DO.tsx
+++ b/src/components/InfoBar/Locale/es_DO.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'es_DO',
+        closeButtonAriaLabelText: 'Cerrar',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/es_ES.tsx
+++ b/src/components/InfoBar/Locale/es_ES.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'es_ES',
+        closeButtonAriaLabelText: 'Cerrar',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/es_MX.tsx
+++ b/src/components/InfoBar/Locale/es_MX.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'es_MX',
+        closeButtonAriaLabelText: 'Cerrar',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/fi_FI.tsx
+++ b/src/components/InfoBar/Locale/fi_FI.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'fi_FI',
+        closeButtonAriaLabelText: 'Sulkea',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/fr_BE.tsx
+++ b/src/components/InfoBar/Locale/fr_BE.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'fr_BE',
+        closeButtonAriaLabelText: 'Fermer',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/fr_CA.tsx
+++ b/src/components/InfoBar/Locale/fr_CA.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'fr_CA',
+        closeButtonAriaLabelText: 'Fermer',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/fr_FR.tsx
+++ b/src/components/InfoBar/Locale/fr_FR.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'fr_FR',
+        closeButtonAriaLabelText: 'Fermer',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/he_IL.tsx
+++ b/src/components/InfoBar/Locale/he_IL.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'he_IL',
+        closeButtonAriaLabelText: 'קרוב',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/hr_HR.tsx
+++ b/src/components/InfoBar/Locale/hr_HR.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'hr_HR',
+        closeButtonAriaLabelText: 'Blizak',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/ht_HT.tsx
+++ b/src/components/InfoBar/Locale/ht_HT.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'ht_HT',
+        closeButtonAriaLabelText: 'Fèmen',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/hu_HU.tsx
+++ b/src/components/InfoBar/Locale/hu_HU.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'hu_HU',
+        closeButtonAriaLabelText: 'Bezár',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/it_IT.tsx
+++ b/src/components/InfoBar/Locale/it_IT.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'it_IT',
+        closeButtonAriaLabelText: 'Chiudere',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/ja_JP.tsx
+++ b/src/components/InfoBar/Locale/ja_JP.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'ja_JP',
+        closeButtonAriaLabelText: '閉める',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/ko_KR.tsx
+++ b/src/components/InfoBar/Locale/ko_KR.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'ko_KR',
+        closeButtonAriaLabelText: '닫다',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/ms_MY.tsx
+++ b/src/components/InfoBar/Locale/ms_MY.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'ms_MY',
+        closeButtonAriaLabelText: 'Tutup',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/nb_NO.tsx
+++ b/src/components/InfoBar/Locale/nb_NO.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'nb_NO',
+        closeButtonAriaLabelText: 'Lukke',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/nl_BE.tsx
+++ b/src/components/InfoBar/Locale/nl_BE.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'nl_BE',
+        closeButtonAriaLabelText: 'Sluiten',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/nl_NL.tsx
+++ b/src/components/InfoBar/Locale/nl_NL.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'nl_NL',
+        closeButtonAriaLabelText: 'Sluiten',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/pl_PL.tsx
+++ b/src/components/InfoBar/Locale/pl_PL.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'pl_PL',
+        closeButtonAriaLabelText: 'Zamykać',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/pt_BR.tsx
+++ b/src/components/InfoBar/Locale/pt_BR.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'pt_BR',
+        closeButtonAriaLabelText: 'Fechar',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/pt_PT.tsx
+++ b/src/components/InfoBar/Locale/pt_PT.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'pt_PT',
+        closeButtonAriaLabelText: 'Fechar',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/ru_RU.tsx
+++ b/src/components/InfoBar/Locale/ru_RU.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'ru_RU',
+        closeButtonAriaLabelText: 'Закрывать',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/sv_SE.tsx
+++ b/src/components/InfoBar/Locale/sv_SE.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'sv_SE',
+        closeButtonAriaLabelText: 'Stänga',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/th_TH.tsx
+++ b/src/components/InfoBar/Locale/th_TH.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'th_TH',
+        closeButtonAriaLabelText: 'ปิด',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/tr_TR.tsx
+++ b/src/components/InfoBar/Locale/tr_TR.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'tr_TR',
+        closeButtonAriaLabelText: 'Kapatmak',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/uk_UA.tsx
+++ b/src/components/InfoBar/Locale/uk_UA.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'uk_UA',
+        closeButtonAriaLabelText: 'Закрити',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/zh_CN.tsx
+++ b/src/components/InfoBar/Locale/zh_CN.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'zh_CN',
+        closeButtonAriaLabelText: '关闭',
+    },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/zh_TW.tsx
+++ b/src/components/InfoBar/Locale/zh_TW.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+    lang: {
+        locale: 'zh_TW',
+        closeButtonAriaLabelText: '關閉',
+    },
+};
+
+export default locale;

--- a/src/components/Locale/Default.tsx
+++ b/src/components/Locale/Default.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/en_US';
 import Dialog from '../Dialog/BaseDialog/Locale/en_US';
+import InfoBar from '../InfoBar/Locale/en_US';
 import Pagination from '../Pagination/Locale/en_US';
+import Panel from '../Panel/Locale/en_US';
 import Table from '../Table/Locale/en_US';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_US';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/cs_CZ.tsx
+++ b/src/components/Locale/cs_CZ.tsx
@@ -2,6 +2,8 @@ import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/cs_CZ';
 import Dialog from '../Dialog/BaseDialog/Locale/cs_CZ';
 import Pagination from '../Pagination/Locale/cs_CZ';
+import Panel from '../Panel/Locale/cs_CZ';
+import InfoBar from '../InfoBar/Locale/cs_CZ';
 import Table from '../Table/Locale/cs_CZ';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/cs_CZ';
 
@@ -12,7 +14,9 @@ const localeValues: Locale = {
     },
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/da_DK.tsx
+++ b/src/components/Locale/da_DK.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/da_DK';
 import Dialog from '../Dialog/BaseDialog/Locale/da_DK';
+import InfoBar from '../InfoBar/Locale/da_DK';
 import Pagination from '../Pagination/Locale/da_DK';
+import Panel from '../Panel/Locale/da_DK';
 import Table from '../Table/Locale/da_DK';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/da_DK';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'da',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/de_DE.tsx
+++ b/src/components/Locale/de_DE.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/de_DE';
 import Dialog from '../Dialog/BaseDialog/Locale/de_DE';
+import InfoBar from '../InfoBar/Locale/de_DE';
 import Pagination from '../Pagination/Locale/de_DE';
+import Panel from '../Panel/Locale/de_DE';
 import Table from '../Table/Locale/de_DE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/de_DE';
 
@@ -64,7 +66,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/el_GR.tsx
+++ b/src/components/Locale/el_GR.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/el_GR';
 import Dialog from '../Dialog/BaseDialog/Locale/el_GR';
+import InfoBar from '../InfoBar/Locale/el_GR';
 import Pagination from '../Pagination/Locale/el_GR';
+import Panel from '../Panel/Locale/el_GR';
 import Table from '../Table/Locale/el_GR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/el_GR';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'el',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/en_GB.tsx
+++ b/src/components/Locale/en_GB.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/en_GB';
 import Dialog from '../Dialog/BaseDialog/Locale/en_GB';
+import InfoBar from '../InfoBar/Locale/en_GB';
 import Pagination from '../Pagination/Locale/en_GB';
+import Panel from '../Panel/Locale/en_GB';
 import Table from '../Table/Locale/en_GB';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_GB';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/es_DO.tsx
+++ b/src/components/Locale/es_DO.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_DO';
 import Dialog from '../Dialog/BaseDialog/Locale/es_DO';
+import InfoBar from '../InfoBar/Locale/es_DO';
 import Pagination from '../Pagination/Locale/es_DO';
+import Panel from '../Panel/Locale/es_DO';
 import Table from '../Table/Locale/es_DO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_DO';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/es_ES.tsx
+++ b/src/components/Locale/es_ES.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_ES';
 import Dialog from '../Dialog/BaseDialog/Locale/es_ES';
+import InfoBar from '../InfoBar/Locale/es_ES';
 import Pagination from '../Pagination/Locale/es_ES';
+import Panel from '../Panel/Locale/es_ES';
 import Table from '../Table/Locale/es_ES';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_ES';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/es_MX.tsx
+++ b/src/components/Locale/es_MX.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_MX';
 import Dialog from '../Dialog/BaseDialog/Locale/es_MX';
+import InfoBar from '../InfoBar/Locale/es_MX';
 import Pagination from '../Pagination/Locale/es_MX';
+import Panel from '../Panel/Locale/es_MX';
 import Table from '../Table/Locale/es_MX';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_MX';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/fi_FI.tsx
+++ b/src/components/Locale/fi_FI.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fi_FI';
 import Dialog from '../Dialog/BaseDialog/Locale/fi_FI';
+import InfoBar from '../InfoBar/Locale/fi_FI';
 import Pagination from '../Pagination/Locale/fi_FI';
+import Panel from '../Panel/Locale/fi_FI';
 import Table from '../Table/Locale/fi_FI';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fi_FI';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'fi',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/fr_BE.tsx
+++ b/src/components/Locale/fr_BE.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_BE';
 import Dialog from '../Dialog/BaseDialog/Locale/fr_BE';
+import InfoBar from '../InfoBar/Locale/fr_BE';
 import Pagination from '../Pagination/Locale/fr_BE';
+import Panel from '../Panel/Locale/fr_BE';
 import Table from '../Table/Locale/fr_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_BE';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'fr',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/fr_CA.tsx
+++ b/src/components/Locale/fr_CA.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_CA';
 import Dialog from '../Dialog/BaseDialog/Locale/fr_CA';
+import InfoBar from '../InfoBar/Locale/fr_CA';
 import Pagination from '../Pagination/Locale/fr_CA';
+import Panel from '../Panel/Locale/fr_CA';
 import Table from '../Table/Locale/fr_CA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_CA';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'fr',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/fr_FR.tsx
+++ b/src/components/Locale/fr_FR.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_FR';
 import Dialog from '../Dialog/BaseDialog/Locale/fr_FR';
+import InfoBar from '../InfoBar/Locale/fr_FR';
 import Pagination from '../Pagination/Locale/fr_FR';
+import Panel from '../Panel/Locale/fr_FR';
 import Table from '../Table/Locale/fr_FR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_FR';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/he_IL.tsx
+++ b/src/components/Locale/he_IL.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/he_IL';
 import Dialog from '../Dialog/BaseDialog/Locale/he_IL';
+import InfoBar from '../InfoBar/Locale/he_IL';
 import Pagination from '../Pagination/Locale/he_IL';
+import Panel from '../Panel/Locale/he_IL';
 import Table from '../Table/Locale/he_IL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/he_IL';
 
@@ -64,7 +66,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/hr_HR.tsx
+++ b/src/components/Locale/hr_HR.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/hr_HR';
 import Dialog from '../Dialog/BaseDialog/Locale/hr_HR';
+import InfoBar from '../InfoBar/Locale/hr_HR';
 import Pagination from '../Pagination/Locale/hr_HR';
+import Panel from '../Panel/Locale/hr_HR';
 import Table from '../Table/Locale/hr_HR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hr_HR';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/ht_HT.tsx
+++ b/src/components/Locale/ht_HT.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ht_HT';
 import Dialog from '../Dialog/BaseDialog/Locale/ht_HT';
+import InfoBar from '../InfoBar/Locale/ht_HT';
 import Pagination from '../Pagination/Locale/ht_HT';
+import Panel from '../Panel/Locale/ht_HT';
 import Table from '../Table/Locale/ht_HT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ht_HT';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/hu_HU.tsx
+++ b/src/components/Locale/hu_HU.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/hu_HU';
 import Dialog from '../Dialog/BaseDialog/Locale/hu_HU';
+import InfoBar from '../InfoBar/Locale/hu_HU';
 import Pagination from '../Pagination/Locale/hu_HU';
+import Panel from '../Panel/Locale/hu_HU';
 import Table from '../Table/Locale/hu_HU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hu_HU';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'hu',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/it_IT.tsx
+++ b/src/components/Locale/it_IT.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/it_IT';
 import Dialog from '../Dialog/BaseDialog/Locale/it_IT';
+import InfoBar from '../InfoBar/Locale/it_IT';
 import Pagination from '../Pagination/Locale/it_IT';
+import Panel from '../Panel/Locale/it_IT';
 import Table from '../Table/Locale/it_IT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/it_IT';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'it',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/ja_JP.tsx
+++ b/src/components/Locale/ja_JP.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ja_JP';
 import Dialog from '../Dialog/BaseDialog/Locale/ja_JP';
+import InfoBar from '../InfoBar/Locale/ja_JP';
 import Pagination from '../Pagination/Locale/ja_JP';
+import Panel from '../Panel/Locale/ja_JP';
 import Table from '../Table/Locale/ja_JP';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ja_JP';
 
@@ -61,7 +63,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/ko_KR.tsx
+++ b/src/components/Locale/ko_KR.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ko_KR';
 import Dialog from '../Dialog/BaseDialog/Locale/ko_KR';
+import InfoBar from '../InfoBar/Locale/ko_KR';
 import Pagination from '../Pagination/Locale/ko_KR';
+import Panel from '../Panel/Locale/ko_KR';
 import Table from '../Table/Locale/ko_KR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ko_KR';
 
@@ -61,7 +63,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/ms_MY.tsx
+++ b/src/components/Locale/ms_MY.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ms_MY';
 import Dialog from '../Dialog/BaseDialog/Locale/ms_MY';
+import InfoBar from '../InfoBar/Locale/ms_MY';
 import Pagination from '../Pagination/Locale/ms_MY';
+import Panel from '../Panel/Locale/ms_MY';
 import Table from '../Table/Locale/ms_MY';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ms_MY';
 
@@ -12,7 +14,9 @@ const localeValues: Locale = {
     },
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/nb_NO.tsx
+++ b/src/components/Locale/nb_NO.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nb_NO';
 import Dialog from '../Dialog/BaseDialog/Locale/nb_NO';
+import InfoBar from '../InfoBar/Locale/nb_NO';
 import Pagination from '../Pagination/Locale/nb_NO';
+import Panel from '../Panel/Locale/nb_NO';
 import Table from '../Table/Locale/nb_NO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nb_NO';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/nl_BE.tsx
+++ b/src/components/Locale/nl_BE.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_BE';
 import Dialog from '../Dialog/BaseDialog/Locale/nl_BE';
+import InfoBar from '../InfoBar/Locale/nl_BE';
 import Pagination from '../Pagination/Locale/nl_BE';
+import Panel from '../Panel/Locale/nl_BE';
 import Table from '../Table/Locale/nl_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_BE';
 
@@ -66,7 +68,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/nl_NL.tsx
+++ b/src/components/Locale/nl_NL.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_NL';
 import Dialog from '../Dialog/BaseDialog/Locale/nl_NL';
+import InfoBar from '../InfoBar/Locale/nl_NL';
 import Pagination from '../Pagination/Locale/nl_NL';
+import Panel from '../Panel/Locale/nl_NL';
 import Table from '../Table/Locale/nl_NL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_NL';
 
@@ -66,7 +68,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/pl_PL.tsx
+++ b/src/components/Locale/pl_PL.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pl_PL';
 import Dialog from '../Dialog/BaseDialog/Locale/pl_PL';
+import InfoBar from '../InfoBar/Locale/pl_PL';
 import Pagination from '../Pagination/Locale/pl_PL';
+import Panel from '../Panel/Locale/pl_PL';
 import Table from '../Table/Locale/pl_PL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pl_PL';
 
@@ -66,7 +68,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/pt_BR.tsx
+++ b/src/components/Locale/pt_BR.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_BR';
 import Dialog from '../Dialog/BaseDialog/Locale/pt_BR';
+import InfoBar from '../InfoBar/Locale/pt_BR';
 import Pagination from '../Pagination/Locale/pt_BR';
+import Panel from '../Panel/Locale/pt_BR';
 import Table from '../Table/Locale/pt_BR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_BR';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/pt_PT.tsx
+++ b/src/components/Locale/pt_PT.tsx
@@ -1,7 +1,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_PT';
 import Dialog from '../Dialog/BaseDialog/Locale/pt_PT';
+import InfoBar from '../InfoBar/Locale/pt_PT';
 import Pagination from '../Pagination/Locale/pt_PT';
+import Panel from '../Panel/Locale/pt_PT';
 import Table from '../Table/Locale/pt_PT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_PT';
 
@@ -9,7 +11,9 @@ const localeValues: Locale = {
     locale: 'pt',
     DatePicker,
     Dialog,
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/ru_RU.tsx
+++ b/src/components/Locale/ru_RU.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ru_RU';
 import Dialog from '../Dialog/BaseDialog/Locale/ru_RU';
+import InfoBar from '../InfoBar/Locale/ru_RU';
 import Pagination from '../Pagination/Locale/ru_RU';
+import Panel from '../Panel/Locale/ru_RU';
 import Table from '../Table/Locale/ru_RU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ru_RU';
 
@@ -63,7 +65,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/sv_SE.tsx
+++ b/src/components/Locale/sv_SE.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/sv_SE';
 import Dialog from '../Dialog/BaseDialog/Locale/sv_SE';
+import InfoBar from '../InfoBar/Locale/sv_SE';
 import Pagination from '../Pagination/Locale/sv_SE';
+import Panel from '../Panel/Locale/sv_SE';
 import Table from '../Table/Locale/sv_SE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/sv_SE';
 
@@ -66,7 +68,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/th_TH.tsx
+++ b/src/components/Locale/th_TH.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/th_TH';
 import Dialog from '../Dialog/BaseDialog/Locale/th_TH';
+import InfoBar from '../InfoBar/Locale/th_TH';
 import Pagination from '../Pagination/Locale/th_TH';
+import Panel from '../Panel/Locale/th_TH';
 import Table from '../Table/Locale/th_TH';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/th_TH';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/tr_TR.tsx
+++ b/src/components/Locale/tr_TR.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/tr_TR';
 import Dialog from '../Dialog/BaseDialog/Locale/tr_TR';
+import InfoBar from '../InfoBar/Locale/tr_TR';
 import Pagination from '../Pagination/Locale/tr_TR';
+import Panel from '../Panel/Locale/tr_TR';
 import Table from '../Table/Locale/tr_TR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/tr_TR';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/uk_UA.tsx
+++ b/src/components/Locale/uk_UA.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/uk_UA';
 import Dialog from '../Dialog/BaseDialog/Locale/uk_UA';
+import InfoBar from '../InfoBar/Locale/uk_UA';
 import Pagination from '../Pagination/Locale/uk_UA';
+import Panel from '../Panel/Locale/uk_UA';
 import Table from '../Table/Locale/uk_UA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/uk_UA';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/zh_CN.tsx
+++ b/src/components/Locale/zh_CN.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_CN';
 import Dialog from '../Dialog/BaseDialog/Locale/zh_CN';
+import InfoBar from '../InfoBar/Locale/zh_CN';
 import Pagination from '../Pagination/Locale/zh_CN';
+import Panel from '../Panel/Locale/zh_CN';
 import Table from '../Table/Locale/zh_CN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_CN';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/Locale/zh_TW.tsx
+++ b/src/components/Locale/zh_TW.tsx
@@ -2,7 +2,9 @@
 import type { Locale } from '../LocaleProvider';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_TW';
 import Dialog from '../Dialog/BaseDialog/Locale/zh_TW';
+import InfoBar from '../InfoBar/Locale/zh_TW';
 import Pagination from '../Pagination/Locale/zh_TW';
+import Panel from '../Panel/Locale/zh_TW';
 import Table from '../Table/Locale/zh_TW';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_TW';
 
@@ -65,7 +67,9 @@ const localeValues: Locale = {
             },
         },
     },
+    InfoBar,
     Pagination,
+    Panel,
     Table,
     TimePicker,
 };

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import memoizeOne from 'memoize-one';
 import type { DialogLocale } from '../Dialog/BaseDialog/BaseDialog.types';
 import type { PaginationLocale } from '../Pagination';
+import type { PanelLocale } from '../Panel';
+import type { InfoBarLocale } from '../InfoBar';
 import type { PickerLocale as DatePickerLocale } from '../DateTimePicker/DatePicker/Generate/Generate.types';
 import type { TableLocale } from '../Table/Table.types';
 import type { ValidateMessages } from '../Form/Internal/OcForm.types';
@@ -16,7 +18,9 @@ export interface Locale {
         optional?: string;
         defaultValidateMessages: ValidateMessages;
     };
+    InfoBar?: InfoBarLocale;
     Pagination?: PaginationLocale;
+    Panel?: PanelLocale;
     Table?: TableLocale;
     TimePicker?: Record<string, any>;
 }

--- a/src/components/Panel/Locale/cs_CZ.tsx
+++ b/src/components/Panel/Locale/cs_CZ.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'cs_CZ',
+        closeButtonAriaLabelText: 'Zavřít',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/da_DK.tsx
+++ b/src/components/Panel/Locale/da_DK.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'da_DK',
+        closeButtonAriaLabelText: 'Lukke',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/de_DE.tsx
+++ b/src/components/Panel/Locale/de_DE.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'de_DE',
+        closeButtonAriaLabelText: 'Schließen',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/el_GR.tsx
+++ b/src/components/Panel/Locale/el_GR.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'el_GR',
+        closeButtonAriaLabelText: 'Κλείνω',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/en_GB.tsx
+++ b/src/components/Panel/Locale/en_GB.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'en_GB',
+        closeButtonAriaLabelText: 'Close',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/en_US.tsx
+++ b/src/components/Panel/Locale/en_US.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'en_US',
+        closeButtonAriaLabelText: 'Close',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/es_DO.tsx
+++ b/src/components/Panel/Locale/es_DO.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'es_DO',
+        closeButtonAriaLabelText: 'Cerrar',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/es_ES.tsx
+++ b/src/components/Panel/Locale/es_ES.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'es_ES',
+        closeButtonAriaLabelText: 'Cerrar',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/es_MX.tsx
+++ b/src/components/Panel/Locale/es_MX.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'es_MX',
+        closeButtonAriaLabelText: 'Cerrar',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/fi_FI.tsx
+++ b/src/components/Panel/Locale/fi_FI.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'fi_FI',
+        closeButtonAriaLabelText: 'Sulkea',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/fr_BE.tsx
+++ b/src/components/Panel/Locale/fr_BE.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'fr_BE',
+        closeButtonAriaLabelText: 'Fermer',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/fr_CA.tsx
+++ b/src/components/Panel/Locale/fr_CA.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'fr_CA',
+        closeButtonAriaLabelText: 'Fermer',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/fr_FR.tsx
+++ b/src/components/Panel/Locale/fr_FR.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'fr_FR',
+        closeButtonAriaLabelText: 'Fermer',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/he_IL.tsx
+++ b/src/components/Panel/Locale/he_IL.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'he_IL',
+        closeButtonAriaLabelText: 'קרוב',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/hr_HR.tsx
+++ b/src/components/Panel/Locale/hr_HR.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'hr_HR',
+        closeButtonAriaLabelText: 'Blizak',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/ht_HT.tsx
+++ b/src/components/Panel/Locale/ht_HT.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'ht_HT',
+        closeButtonAriaLabelText: 'Fèmen',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/hu_HU.tsx
+++ b/src/components/Panel/Locale/hu_HU.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'hu_HU',
+        closeButtonAriaLabelText: 'Bezár',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/it_IT.tsx
+++ b/src/components/Panel/Locale/it_IT.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'it_IT',
+        closeButtonAriaLabelText: 'Chiudere',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/ja_JP.tsx
+++ b/src/components/Panel/Locale/ja_JP.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'ja_JP',
+        closeButtonAriaLabelText: '閉める',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/ko_KR.tsx
+++ b/src/components/Panel/Locale/ko_KR.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'ko_KR',
+        closeButtonAriaLabelText: '닫다',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/ms_MY.tsx
+++ b/src/components/Panel/Locale/ms_MY.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'ms_MY',
+        closeButtonAriaLabelText: 'Tutup',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/nb_NO.tsx
+++ b/src/components/Panel/Locale/nb_NO.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'nb_NO',
+        closeButtonAriaLabelText: 'Lukke',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/nl_BE.tsx
+++ b/src/components/Panel/Locale/nl_BE.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'nl_BE',
+        closeButtonAriaLabelText: 'Sluiten',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/nl_NL.tsx
+++ b/src/components/Panel/Locale/nl_NL.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'nl_NL',
+        closeButtonAriaLabelText: 'Sluiten',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/pl_PL.tsx
+++ b/src/components/Panel/Locale/pl_PL.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'pl_PL',
+        closeButtonAriaLabelText: 'Zamykać',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/pt_BR.tsx
+++ b/src/components/Panel/Locale/pt_BR.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'pt_BR',
+        closeButtonAriaLabelText: 'Fechar',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/pt_PT.tsx
+++ b/src/components/Panel/Locale/pt_PT.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'pt_PT',
+        closeButtonAriaLabelText: 'Fechar',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/ru_RU.tsx
+++ b/src/components/Panel/Locale/ru_RU.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'ru_RU',
+        closeButtonAriaLabelText: 'Закрывать',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/sv_SE.tsx
+++ b/src/components/Panel/Locale/sv_SE.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'sv_SE',
+        closeButtonAriaLabelText: 'Stänga',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/th_TH.tsx
+++ b/src/components/Panel/Locale/th_TH.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'th_TH',
+        closeButtonAriaLabelText: 'ปิด',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/tr_TR.tsx
+++ b/src/components/Panel/Locale/tr_TR.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'tr_TR',
+        closeButtonAriaLabelText: 'Kapatmak',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/uk_UA.tsx
+++ b/src/components/Panel/Locale/uk_UA.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'uk_UA',
+        closeButtonAriaLabelText: 'Закрити',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/zh_CN.tsx
+++ b/src/components/Panel/Locale/zh_CN.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'zh_CN',
+        closeButtonAriaLabelText: '关闭',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/zh_TW.tsx
+++ b/src/components/Panel/Locale/zh_TW.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+    lang: {
+        locale: 'zh_TW',
+        closeButtonAriaLabelText: '關閉',
+    },
+};
+
+export default locale;

--- a/src/components/Panel/Panel.types.ts
+++ b/src/components/Panel/Panel.types.ts
@@ -22,6 +22,21 @@ export type EventType =
 
 export type CloseButtonProps = Omit<ButtonProps, 'onClick' | 'iconProps'>;
 
+type Locale = {
+    /**
+     * The Panel locale.
+     */
+    locale: string;
+    /**
+     * The Panel `Close` Button aria label string.
+     */
+    closeButtonAriaLabelText?: string;
+};
+
+export type PanelLocale = {
+    lang: Locale;
+};
+
 export interface PanelProps extends Omit<OcBaseProps<HTMLElement>, 'title'> {
     /**
      * Props for the first header action button
@@ -53,6 +68,11 @@ export interface PanelProps extends Omit<OcBaseProps<HTMLElement>, 'title'> {
      * Content of the body
      */
     children?: React.ReactNode;
+    /**
+     * The Panel `Close` Button aria label string.
+     * @default 'Close'
+     */
+    closeButtonAriaLabelText?: string;
     /**
      * Close button extra props
      */
@@ -95,6 +115,11 @@ export interface PanelProps extends Omit<OcBaseProps<HTMLElement>, 'title'> {
      * Custom height of the panel
      */
     height?: number;
+    /**
+     * The Panel locale.
+     * @default 'enUS'
+     */
+    locale?: PanelLocale;
     /**
      * Clicking on mask should close panel or not
      * @default true
@@ -175,7 +200,7 @@ export interface PanelProps extends Omit<OcBaseProps<HTMLElement>, 'title'> {
     scrollLock?: boolean;
 }
 
-export interface PanelHeaderProps {
+export interface PanelHeaderProps extends OcBaseProps<HTMLDivElement> {
     /**
      * Props for the first header action button
      */
@@ -189,10 +214,20 @@ export interface PanelHeaderProps {
      */
     actionDefaultButtonProps?: ButtonProps;
     /**
+     * The Panel `Close` Button aria label string.
+     * @default 'Close'
+     */
+    closeButtonAriaLabelText?: string;
+    /**
      * Close icon name
      * @default IconName.mdiClose
      */
     closeIcon?: IconName;
+    /**
+     * The PanelHeader locale.
+     * @default 'enUS'
+     */
+    locale?: PanelLocale;
     /**
      * Callback fired on close on the panel
      * @param e {EventType}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -1,47 +1,91 @@
-import React, { FC } from 'react';
-
-import { PanelHeaderProps } from './Panel.types';
-
+import React, { FC, Ref, useEffect, useState } from 'react';
+import { PanelHeaderProps, PanelLocale } from './Panel.types';
 import { SystemUIButton } from '../Button';
 import { IconName } from '../Icon';
+import LocaleReceiver, {
+    useLocaleReceiver,
+} from '../LocaleProvider/LocaleReceiver';
+import enUS from './Locale/en_US';
 
 import styles from './panel.module.scss';
 
-export const PanelHeader: FC<PanelHeaderProps> = ({
-    onClose,
-    closeIcon = IconName.mdiClose,
-    title,
-    actionDefaultButtonProps,
-    actionButtonOneProps,
-    actionButtonTwoProps,
-}) => {
-    return (
-        <div className={styles.logoGradientHeaderWrapper}>
-            <div className={styles.headerTitle}>
-                {actionDefaultButtonProps && (
-                    <SystemUIButton {...actionDefaultButtonProps} />
-                )}
-                {title}
-            </div>
-            <div className={styles.headerActionButtons}>
-                {actionButtonOneProps && (
-                    <SystemUIButton {...actionButtonOneProps} />
-                )}
-                {actionButtonTwoProps && (
-                    <SystemUIButton {...actionButtonTwoProps} />
-                )}
-                {onClose && (
-                    <SystemUIButton
-                        iconProps={{
-                            path: closeIcon,
-                            color: 'var(--white-color)',
-                        }}
-                        ariaLabel={'Close'}
-                        onClick={onClose}
-                        transparent
-                    />
-                )}
-            </div>
-        </div>
-    );
-};
+export const PanelHeader: FC<PanelHeaderProps> = React.forwardRef(
+    (props: PanelHeaderProps, ref: Ref<HTMLDivElement>) => {
+        const {
+            actionButtonOneProps,
+            actionButtonTwoProps,
+            actionDefaultButtonProps,
+            closeButtonAriaLabelText: defaultCloseButtonAriaLabelText,
+            closeIcon = IconName.mdiClose,
+            locale = enUS,
+            onClose,
+            title,
+            ...rest
+        } = props;
+
+        // ============================ Strings ===========================
+        const [panelLocale] = useLocaleReceiver('Panel');
+        let mergedLocale: PanelLocale;
+
+        if (props.locale) {
+            mergedLocale = props.locale;
+        } else {
+            mergedLocale = panelLocale || props.locale;
+        }
+
+        const [closeButtonAriaLabelText, setCloseButtonAriaLabelText] =
+            useState<string>(defaultCloseButtonAriaLabelText);
+
+        // Locs: if the prop isn't provided use the loc defaults.
+        // If the mergedLocale is changed, update.
+        useEffect(() => {
+            setCloseButtonAriaLabelText(
+                props.closeButtonAriaLabelText
+                    ? props.closeButtonAriaLabelText
+                    : mergedLocale.lang!.closeButtonAriaLabelText
+            );
+        }, [mergedLocale]);
+
+        return (
+            <LocaleReceiver componentName={'Panel'} defaultLocale={enUS}>
+                {(_contextLocale: PanelLocale) => {
+                    return (
+                        <div
+                            ref={ref}
+                            {...rest}
+                            className={styles.logoGradientHeaderWrapper}
+                        >
+                            <div className={styles.headerTitle}>
+                                {actionDefaultButtonProps && (
+                                    <SystemUIButton
+                                        {...actionDefaultButtonProps}
+                                    />
+                                )}
+                                {title}
+                            </div>
+                            <div className={styles.headerActionButtons}>
+                                {actionButtonOneProps && (
+                                    <SystemUIButton {...actionButtonOneProps} />
+                                )}
+                                {actionButtonTwoProps && (
+                                    <SystemUIButton {...actionButtonTwoProps} />
+                                )}
+                                {onClose && (
+                                    <SystemUIButton
+                                        iconProps={{
+                                            path: closeIcon,
+                                            color: 'var(--white-color)',
+                                        }}
+                                        ariaLabel={closeButtonAriaLabelText}
+                                        onClick={onClose}
+                                        transparent
+                                    />
+                                )}
+                            </div>
+                        </div>
+                    );
+                }}
+            </LocaleReceiver>
+        );
+    }
+);


### PR DESCRIPTION
## SUMMARY:
Adds loc support to `Panel` and `InfoBar`.

## JIRA TASK (Eightfold Employees Only):
ENG-31144

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [X] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist (loc tests)
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and do `yarn`, then `yarn storybook`, verify the Panel and InfoBar stories behave as expected.

Set the `Panel` or `InfoBar` locale to another language and test the close button aria label as follows (pseudo-code):

```
import { zhCN } from "@eightfold.ai/octuple/";
<Panel locale={zhCN} closeButtonAriaLabelText={'foo'} />
```

NOTE: The close button aria label text should read 'foo' when provided, else use the loc defaults.