### PR TITLE
fix: picker: fix flicker on resize, update buttons, and font weight to match latest design

### DIFF
--- a/src/components/DateTimePicker/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DateTimePicker/DatePicker/DatePicker.stories.tsx
@@ -509,6 +509,7 @@ export const Range_Status = Range_Status_Story.bind({});
 const pickerArgs: Object = {
     classNames: 'my-picker-class',
     id: 'myPickerInputId',
+    popupPlacement: 'bottomLeft',
     shape: DatePickerShape.Rectangle,
     size: DatePickerSize.Medium,
 };

--- a/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
+++ b/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
@@ -223,6 +223,7 @@ export default function generateRangePicker<DateType>(
                                 htmlDir as dir,
                                 popupPlacement
                             )}
+                            popupPlacement={popupPlacement}
                             nowText={nowText}
                             okText={okText}
                             todayText={todayText}
@@ -243,7 +244,6 @@ export default function generateRangePicker<DateType>(
                             superPrevIcon={IconName.mdiChevronDoubleLeft}
                             superNextIcon={IconName.mdiChevronDoubleRight}
                             allowClear
-                            transitionName={'picker-slide-up'}
                             {...rest}
                             {...additionalOverrideProps}
                             classNames={mergeClasses([

--- a/src/components/DateTimePicker/DatePicker/Generate/generateSinglePicker.tsx
+++ b/src/components/DateTimePicker/DatePicker/Generate/generateSinglePicker.tsx
@@ -265,6 +265,7 @@ export default function generatePicker<DateType>(
                                     htmlDir as dir,
                                     popupPlacement
                                 )}
+                                popupPlacement={popupPlacement}
                                 clearIcon={
                                     <Icon
                                         path={IconName.mdiCloseCircle}
@@ -281,7 +282,6 @@ export default function generatePicker<DateType>(
                                 superPrevIcon={IconName.mdiChevronDoubleLeft}
                                 superNextIcon={IconName.mdiChevronDoubleRight}
                                 allowClear
-                                transitionName={'picker-slide-up'}
                                 {...additionalProps}
                                 {...rest}
                                 {...additionalOverrideProps}

--- a/src/components/DateTimePicker/DatePicker/Styles/partial.scss
+++ b/src/components/DateTimePicker/DatePicker/Styles/partial.scss
@@ -247,7 +247,7 @@ $picker-time-partial-cell-height: 28px;
 
         &-view {
             flex: auto;
-            font-weight: 500;
+            font-weight: $text-font-weight-semibold;
             line-height: $picker-text-height;
         }
     }
@@ -261,7 +261,7 @@ $picker-time-partial-cell-height: 28px;
         td {
             position: relative;
             min-width: 24px;
-            font-weight: 400;
+            font-weight: $text-font-weight-regular;
         }
 
         th {

--- a/src/components/DateTimePicker/Internal/OcPickerPartial.tsx
+++ b/src/components/DateTimePicker/Internal/OcPickerPartial.tsx
@@ -28,7 +28,7 @@ import RangeContext from './RangeContext';
 import { getExtraFooter } from './Utils/getExtraFooter';
 import getRanges from './Utils/getRanges';
 import { getLowerBoundTime, setDateTime, setTime } from './Utils/timeUtil';
-import { ButtonSize, NeutralButton } from '../../Button';
+import { ButtonSize, SystemUIButton } from '../../Button';
 import { Breakpoints, useMatchMedia } from '../../../hooks/useMatchMedia';
 import { Size } from '../../ConfigProvider';
 import { DatePickerSize } from './OcPicker.types';
@@ -451,7 +451,7 @@ function OcPickerPartial<DateType>(props: OcPickerPartialProps<DateType>) {
         const now: DateType = generateConfig.getNow();
         const disabled: boolean = disabledDate && disabledDate(now);
         todayNode = (
-            <NeutralButton
+            <SystemUIButton
                 aria-disabled={disabled}
                 classNames={mergeClasses([
                     'picker-today-btn',

--- a/src/components/DateTimePicker/Internal/OcPickerTrigger.tsx
+++ b/src/components/DateTimePicker/Internal/OcPickerTrigger.tsx
@@ -3,7 +3,7 @@ import { mergeClasses } from '../../../shared/utilities';
 import Trigger from '../../Trigger/Trigger';
 import { OcPickerTriggerProps } from './OcPicker.types';
 
-import styles from './ocpicker.module.scss';
+import triggerStyles from '../../Trigger/trigger.module.scss';
 
 const BUILT_IN_PLACEMENTS = {
     bottomLeft: {
@@ -68,27 +68,27 @@ function OcPickerTrigger({
             popupAlign={dropdownAlign}
             popupClassNames={mergeClasses([
                 dropdownClassNames,
-                styles.triggerPopup,
-                { [styles.slideUpEnter]: visible },
-                { [styles.slideUpLeave]: !visible },
+                triggerStyles.triggerPopup,
+                { [triggerStyles.slideUpEnter]: visible },
+                { [triggerStyles.slideUpLeave]: !visible },
                 {
-                    [styles.triggerPopupPlacementBottomLeft]:
+                    [triggerStyles.triggerPopupPlacementBottomLeft]:
                         getPopupPlacement() === 'bottomLeft',
                 },
                 {
-                    [styles.triggerPopupPlacementBottomRight]:
+                    [triggerStyles.triggerPopupPlacementBottomRight]:
                         getPopupPlacement() === 'bottomRight',
                 },
                 {
-                    [styles.triggerPopupPlacementTopLeft]:
+                    [triggerStyles.triggerPopupPlacementTopLeft]:
                         getPopupPlacement() === 'topLeft',
                 },
                 {
-                    [styles.triggerPopupPlacementTopRight]:
+                    [triggerStyles.triggerPopupPlacementTopRight]:
                         getPopupPlacement() === 'topRight',
                 },
-                { [styles.pickerDropdownRange]: range },
-                { [styles.pickerDropdownRtl]: direction === 'rtl' },
+                { [triggerStyles.triggerPopupRange]: range },
+                { [triggerStyles.triggerPopupRtl]: direction === 'rtl' },
             ])}
             popupPlacement={getPopupPlacement()}
             popupStyle={popupStyle}

--- a/src/components/DateTimePicker/Internal/OcRangePicker.tsx
+++ b/src/components/DateTimePicker/Internal/OcRangePicker.tsx
@@ -54,6 +54,7 @@ import useHoverValue from './Hooks/useHoverValue';
 import { DatePickerShape, DatePickerSize } from './OcPicker.types';
 
 import styles from './ocpicker.module.scss';
+import triggerStyles from '../../Trigger/trigger.module.scss';
 
 function reorderValues<DateType>(
     values: RangeValue<DateType>,
@@ -906,14 +907,15 @@ function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
             startInputDivRef.current.offsetWidth +
             separatorRef.current.offsetWidth;
 
-        // If partialWidth - arrowWidth - arrowMarginLeft < arrowLeft, partial should move to right side.
+        // If partialWidth - arrowWidth + arrowMarginLeft < arrowLeft, partial should move to right side.
         // If offsetLeft > arrowLeft, arrow position is absolutely right, because arrowLeft is not calculated with arrow margin.
         if (
             partialDivRef.current.offsetWidth &&
             arrowRef.current.offsetWidth &&
             arrowLeft >
                 partialDivRef.current.offsetWidth -
-                    arrowRef.current.offsetWidth -
+                    (arrowRef.current.offsetWidth +
+                        parseInt(arrowRef.current.style.marginLeft, 10)) -
                     (direction === 'rtl' ||
                     arrowRef.current.offsetLeft > arrowLeft
                         ? 0
@@ -1048,7 +1050,7 @@ function InnerRangePicker<DateType>(props: OcRangePickerProps<DateType>) {
         >
             <div
                 ref={arrowRef}
-                className={styles.pickerRangeArrow}
+                className={triggerStyles.pickerRangeArrow}
                 style={arrowPositionStyle}
             />
             {renderPartials()}

--- a/src/components/DateTimePicker/Internal/Partials/DatePartial/DateHeader.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/DatePartial/DateHeader.tsx
@@ -3,7 +3,7 @@ import { DateHeaderProps } from './Date.types';
 import { Header } from '../Header';
 import PartialContext from '../../PartialContext';
 import { formatValue } from '../../Utils/dateUtil';
-import { ButtonSize, NeutralButton } from '../../../../Button';
+import { ButtonSize, SystemUIButton } from '../../../../Button';
 import { Size } from '../../../../ConfigProvider';
 import { DatePickerSize } from '../../OcPicker.types';
 
@@ -45,7 +45,7 @@ function DateHeader<DateType>(props: DateHeaderProps<DateType>) {
     ]);
 
     const yearNode: React.ReactNode = (
-        <NeutralButton
+        <SystemUIButton
             classNames={'picker-year-btn'}
             key="year"
             onClick={onYearClick}
@@ -58,7 +58,7 @@ function DateHeader<DateType>(props: DateHeaderProps<DateType>) {
         />
     );
     const monthNode: React.ReactNode = (
-        <NeutralButton
+        <SystemUIButton
             classNames={'picker-month-btn'}
             key="month"
             onClick={onMonthClick}

--- a/src/components/DateTimePicker/Internal/Partials/Header.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { HeaderProps } from './Partial.types';
 import PartialContext from '../PartialContext';
-import { ButtonSize, NeutralButton } from '../../../Button';
+import { ButtonSize, SystemUIButton } from '../../../Button';
 import { IconName } from '../../../Icon';
 import { Size } from '../../../ConfigProvider';
 import { DatePickerSize } from '../OcPicker.types';
@@ -42,7 +42,7 @@ export const Header = ({
     return (
         <div className={styles.pickerHeader}>
             {onSuperPrev && (
-                <NeutralButton
+                <SystemUIButton
                     classNames={'picker-header-super-prev-btn'}
                     iconProps={{
                         path: superPrevIcon,
@@ -54,7 +54,7 @@ export const Header = ({
                 />
             )}
             {onPrev && (
-                <NeutralButton
+                <SystemUIButton
                     classNames={'picker-header-prev-btn'}
                     iconProps={{
                         path: prevIcon,
@@ -67,7 +67,7 @@ export const Header = ({
             )}
             <div className={styles.pickerHeaderView}>{children}</div>
             {onNext && (
-                <NeutralButton
+                <SystemUIButton
                     classNames={'picker-header-next-btn'}
                     iconProps={{
                         path: nextIcon,
@@ -79,7 +79,7 @@ export const Header = ({
                 />
             )}
             {onSuperNext && (
-                <NeutralButton
+                <SystemUIButton
                     classNames={'picker-header-super-next-btn'}
                     iconProps={{
                         path: superNextIcon,

--- a/src/components/DateTimePicker/Internal/Partials/MonthPartial/MonthHeader.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/MonthPartial/MonthHeader.tsx
@@ -3,7 +3,7 @@ import { MonthHeaderProps } from './Month.types';
 import { Header } from '../Header';
 import PartialContext from '../../PartialContext';
 import { formatValue } from '../../Utils/dateUtil';
-import { ButtonSize, NeutralButton } from '../../../../Button';
+import { ButtonSize, SystemUIButton } from '../../../../Button';
 import { Size } from '../../../../ConfigProvider';
 import { DatePickerSize } from '../../OcPicker.types';
 
@@ -40,7 +40,7 @@ function MonthHeader<DateType>(props: MonthHeaderProps<DateType>) {
             onSuperNext={onNextYear}
             size={size}
         >
-            <NeutralButton
+            <SystemUIButton
                 classNames={'picker-year-btn'}
                 onClick={onYearClick}
                 size={datePickerSizeToButtonSizeMap.get(size)}

--- a/src/components/DateTimePicker/Internal/Partials/QuarterPartial/QuarterHeader.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/QuarterPartial/QuarterHeader.tsx
@@ -3,7 +3,7 @@ import { QuarterHeaderProps } from './Quarter.types';
 import { Header } from '../Header';
 import PartialContext from '../../PartialContext';
 import { formatValue } from '../../Utils/dateUtil';
-import { ButtonSize, NeutralButton } from '../../../../Button';
+import { ButtonSize, SystemUIButton } from '../../../../Button';
 import { Size } from '../../../../ConfigProvider';
 import { DatePickerSize } from '../../OcPicker.types';
 
@@ -35,7 +35,7 @@ function QuarterHeader<DateType>(props: QuarterHeaderProps<DateType>) {
 
     return (
         <Header {...props} onSuperPrev={onPrevYear} onSuperNext={onNextYear}>
-            <NeutralButton
+            <SystemUIButton
                 classNames={'picker-year-btn'}
                 onClick={onYearClick}
                 size={datePickerSizeToButtonSizeMap.get(size)}

--- a/src/components/DateTimePicker/Internal/Partials/YearPartial/YearHeader.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/YearPartial/YearHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Header } from '../Header';
 import { YEAR_DECADE_COUNT, YearHeaderProps } from './Year.types';
 import PartialContext from '../../PartialContext';
-import { ButtonSize, NeutralButton } from '../../../../Button';
+import { ButtonSize, SystemUIButton } from '../../../../Button';
 import { DatePickerSize } from '../../OcPicker.types';
 import { Size } from '../../../../ConfigProvider';
 
@@ -43,7 +43,7 @@ function YearHeader<DateType>(props: YearHeaderProps<DateType>) {
             onSuperNext={onNextDecade}
             size={size}
         >
-            <NeutralButton
+            <SystemUIButton
                 classNames={'picker-decade-btn'}
                 onClick={onDecadeClick}
                 size={datePickerSizeToButtonSizeMap.get(size)}

--- a/src/components/DateTimePicker/Internal/Tests/__snapshots__/partial.rtl.shot
+++ b/src/components/DateTimePicker/Internal/Tests/__snapshots__/partial.rtl.shot
@@ -21,7 +21,7 @@ LoadedCheerio {
               Node {
                 "attribs": Object {
                   "aria-disabled": "false",
-                  "class": "picker-header-super-prev-btn button button-neutral button-medium pill-shape icon-left",
+                  "class": "picker-header-super-prev-btn button button-system-ui button-medium pill-shape icon-left",
                 },
                 "children": Array [
                   Node {
@@ -106,7 +106,7 @@ LoadedCheerio {
                     Node {
                       "attribs": Object {
                         "aria-disabled": "false",
-                        "class": "picker-year-btn button button-neutral button-medium pill-shape",
+                        "class": "picker-year-btn button button-system-ui button-medium pill-shape",
                       },
                       "children": Array [
                         Node {
@@ -157,7 +157,7 @@ LoadedCheerio {
                   "next": Node {
                     "attribs": Object {
                       "aria-disabled": "false",
-                      "class": "picker-header-super-next-btn button button-neutral button-medium pill-shape icon-left",
+                      "class": "picker-header-super-next-btn button button-system-ui button-medium pill-shape icon-left",
                     },
                     "children": Array [
                       Node {
@@ -277,7 +277,7 @@ LoadedCheerio {
                   Node {
                     "attribs": Object {
                       "aria-disabled": "false",
-                      "class": "picker-year-btn button button-neutral button-medium pill-shape",
+                      "class": "picker-year-btn button button-system-ui button-medium pill-shape",
                     },
                     "children": Array [
                       Node {
@@ -328,7 +328,7 @@ LoadedCheerio {
                 "next": Node {
                   "attribs": Object {
                     "aria-disabled": "false",
-                    "class": "picker-header-super-next-btn button button-neutral button-medium pill-shape icon-left",
+                    "class": "picker-header-super-next-btn button button-system-ui button-medium pill-shape icon-left",
                   },
                   "children": Array [
                     Node {
@@ -422,7 +422,7 @@ LoadedCheerio {
                 "prev": Node {
                   "attribs": Object {
                     "aria-disabled": "false",
-                    "class": "picker-header-super-prev-btn button button-neutral button-medium pill-shape icon-left",
+                    "class": "picker-header-super-prev-btn button button-system-ui button-medium pill-shape icon-left",
                   },
                   "children": Array [
                     Node {
@@ -523,7 +523,7 @@ LoadedCheerio {
               Node {
                 "attribs": Object {
                   "aria-disabled": "false",
-                  "class": "picker-header-super-next-btn button button-neutral button-medium pill-shape icon-left",
+                  "class": "picker-header-super-next-btn button button-system-ui button-medium pill-shape icon-left",
                 },
                 "children": Array [
                   Node {
@@ -610,7 +610,7 @@ LoadedCheerio {
                     Node {
                       "attribs": Object {
                         "aria-disabled": "false",
-                        "class": "picker-year-btn button button-neutral button-medium pill-shape",
+                        "class": "picker-year-btn button button-system-ui button-medium pill-shape",
                       },
                       "children": Array [
                         Node {
@@ -663,7 +663,7 @@ LoadedCheerio {
                   "prev": Node {
                     "attribs": Object {
                       "aria-disabled": "false",
-                      "class": "picker-header-super-prev-btn button button-neutral button-medium pill-shape icon-left",
+                      "class": "picker-header-super-prev-btn button button-system-ui button-medium pill-shape icon-left",
                     },
                     "children": Array [
                       Node {
@@ -14909,7 +14909,7 @@ LoadedCheerio {
                 Node {
                   "attribs": Object {
                     "aria-disabled": "false",
-                    "class": "picker-header-super-prev-btn button button-neutral button-medium pill-shape icon-left",
+                    "class": "picker-header-super-prev-btn button button-system-ui button-medium pill-shape icon-left",
                   },
                   "children": Array [
                     Node {
@@ -14994,7 +14994,7 @@ LoadedCheerio {
                       Node {
                         "attribs": Object {
                           "aria-disabled": "false",
-                          "class": "picker-year-btn button button-neutral button-medium pill-shape",
+                          "class": "picker-year-btn button button-system-ui button-medium pill-shape",
                         },
                         "children": Array [
                           Node {
@@ -15045,7 +15045,7 @@ LoadedCheerio {
                     "next": Node {
                       "attribs": Object {
                         "aria-disabled": "false",
-                        "class": "picker-header-super-next-btn button button-neutral button-medium pill-shape icon-left",
+                        "class": "picker-header-super-next-btn button button-system-ui button-medium pill-shape icon-left",
                       },
                       "children": Array [
                         Node {
@@ -15165,7 +15165,7 @@ LoadedCheerio {
                     Node {
                       "attribs": Object {
                         "aria-disabled": "false",
-                        "class": "picker-year-btn button button-neutral button-medium pill-shape",
+                        "class": "picker-year-btn button button-system-ui button-medium pill-shape",
                       },
                       "children": Array [
                         Node {
@@ -15216,7 +15216,7 @@ LoadedCheerio {
                   "next": Node {
                     "attribs": Object {
                       "aria-disabled": "false",
-                      "class": "picker-header-super-next-btn button button-neutral button-medium pill-shape icon-left",
+                      "class": "picker-header-super-next-btn button button-system-ui button-medium pill-shape icon-left",
                     },
                     "children": Array [
                       Node {
@@ -15310,7 +15310,7 @@ LoadedCheerio {
                   "prev": Node {
                     "attribs": Object {
                       "aria-disabled": "false",
-                      "class": "picker-header-super-prev-btn button button-neutral button-medium pill-shape icon-left",
+                      "class": "picker-header-super-prev-btn button button-system-ui button-medium pill-shape icon-left",
                     },
                     "children": Array [
                       Node {
@@ -15411,7 +15411,7 @@ LoadedCheerio {
                 Node {
                   "attribs": Object {
                     "aria-disabled": "false",
-                    "class": "picker-header-super-next-btn button button-neutral button-medium pill-shape icon-left",
+                    "class": "picker-header-super-next-btn button button-system-ui button-medium pill-shape icon-left",
                   },
                   "children": Array [
                     Node {
@@ -15498,7 +15498,7 @@ LoadedCheerio {
                       Node {
                         "attribs": Object {
                           "aria-disabled": "false",
-                          "class": "picker-year-btn button button-neutral button-medium pill-shape",
+                          "class": "picker-year-btn button button-system-ui button-medium pill-shape",
                         },
                         "children": Array [
                           Node {
@@ -15551,7 +15551,7 @@ LoadedCheerio {
                     "prev": Node {
                       "attribs": Object {
                         "aria-disabled": "false",
-                        "class": "picker-header-super-prev-btn button button-neutral button-medium pill-shape icon-left",
+                        "class": "picker-header-super-prev-btn button button-system-ui button-medium pill-shape icon-left",
                       },
                       "children": Array [
                         Node {

--- a/src/components/DateTimePicker/Internal/Tests/__snapshots__/range.test.tsx.snap
+++ b/src/components/DateTimePicker/Internal/Tests/__snapshots__/range.test.tsx.snap
@@ -2683,7 +2683,7 @@ LoadedCheerio {
       "children": Array [
         Node {
           "attribs": Object {
-            "class": "trigger-popup trigger-popup slide-up-enter trigger-popup-placement-bottom-left picker-dropdown-range",
+            "class": "trigger-popup trigger-popup slide-up-enter trigger-popup-placement-bottom-left trigger-popup-range",
             "style": "opacity: 0;",
           },
           "children": Array [
@@ -2877,7 +2877,7 @@ LoadedCheerio {
           "children": Array [
             Node {
               "attribs": Object {
-                "class": "trigger-popup trigger-popup slide-up-enter trigger-popup-placement-bottom-left picker-dropdown-range",
+                "class": "trigger-popup trigger-popup slide-up-enter trigger-popup-placement-bottom-left trigger-popup-range",
                 "style": "opacity: 0;",
               },
               "children": Array [
@@ -3074,7 +3074,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "trigger-popup trigger-popup slide-up-enter trigger-popup-placement-bottom-left picker-dropdown-range",
+          "class": "trigger-popup trigger-popup slide-up-enter trigger-popup-placement-bottom-left trigger-popup-range",
           "style": "opacity: 0;",
         },
         "children": Array [

--- a/src/components/DateTimePicker/Internal/Tests/range.test.tsx
+++ b/src/components/DateTimePicker/Internal/Tests/range.test.tsx
@@ -878,14 +878,14 @@ describe('Picker.Range', () => {
             domMock.mockRestore();
         });
 
-        it('end date arrow should move partial left', () => {
+        it('end date arrow should not move partial left', () => {
             const wrapper = mount(<DayjsRangePicker />);
             wrapper.openPicker(1);
             wrapper.update();
             expect(
                 (wrapper.find('.picker-partial-container').props() as any).style
                     .marginLeft
-            ).toEqual(200);
+            ).toEqual(0);
         });
     });
 

--- a/src/components/DateTimePicker/Internal/Utils/getRanges.tsx
+++ b/src/components/DateTimePicker/Internal/Utils/getRanges.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Size } from '../../../ConfigProvider';
 import { Components, DatePickerSize, RangeList } from '../OcPicker.types';
-import { ButtonSize, DefaultButton, PrimaryButton } from '../../../Button';
+import { ButtonSize, SystemUIButton } from '../../../Button';
 
 import styles from '../ocpicker.module.scss';
 
@@ -69,7 +69,7 @@ export default function getRanges({
         if (onNow && !presetNode && showNow !== false) {
             presetNode = (
                 <li className={'picker-now'}>
-                    <DefaultButton
+                    <SystemUIButton
                         classNames={'picker-now-btn'}
                         onClick={onNow}
                         size={datePickerSizeToButtonSizeMap.get(size)}
@@ -81,7 +81,7 @@ export default function getRanges({
 
         okNode = needConfirmButton && (
             <li className={styles.pickerOk}>
-                <PrimaryButton
+                <SystemUIButton
                     disabled={okDisabled}
                     onClick={onOk as () => void}
                     size={datePickerSizeToButtonSizeMap.get(size)}

--- a/src/components/DateTimePicker/Internal/ocpicker.module.scss
+++ b/src/components/DateTimePicker/Internal/ocpicker.module.scss
@@ -33,6 +33,7 @@
             tr {
                 th {
                     color: $picker-header-cell-foreground-color;
+                    font-weight: $text-font-weight-semibold;
                 }
             }
         }
@@ -121,6 +122,7 @@
 
         &-view {
             flex: auto;
+            flex-shrink: 0;
             height: 28px;
             text-align: center;
 
@@ -166,7 +168,7 @@
             padding: 0;
             font-family: $octuple-font-family;
             font-size: $picker-font-size-m;
-            font-weight: $text-font-weight-semibold;
+            font-weight: $text-font-weight-regular;
             line-height: $picker-cell-height-m;
             border-radius: 50%;
             outline: none;
@@ -440,7 +442,7 @@
             &-view {
                 font-size: $picker-font-size-s;
                 height: $picker-header-height-s;
-                padding: 2px 14px;
+                padding: $space-xxxs 14px;
             }
         }
     }
@@ -559,7 +561,7 @@
 
         .picker-cell-week {
             color: $picker-foreground-color;
-            font-weight: $text-font-weight-bold;
+            font-weight: $text-font-weight-regular;
             font-size: $picker-font-size-m;
         }
 
@@ -739,7 +741,7 @@
             &-inner {
                 color: $picker-cell-foreground-color;
                 font-family: $octuple-font-family;
-                font-weight: $text-font-weight-semibold;
+                font-weight: $text-font-weight-regular;
                 height: $picker-cell-height-m;
                 line-height: $picker-cell-height-m;
                 margin: 0;
@@ -1067,71 +1069,6 @@
         }
     }
 
-    &-dropdown {
-        position: absolute;
-
-        &-range {
-            padding: 10px 0;
-        }
-
-        &-hidden {
-            display: none;
-        }
-
-        &-placement-topLeft,
-        &-placement-topRight {
-            .picker-range-arrow {
-                bottom: calc($picker-arrow-size / 2) + 1px;
-                transform: rotate(135deg);
-            }
-        }
-        &-placement-bottomLeft,
-        &-placement-bottomright {
-            .picker-range-arrow {
-                top: calc($picker-arrow-size / 2) + 1px;
-                transform: rotate(-45deg);
-            }
-        }
-
-        .picker-range-arrow {
-            position: absolute;
-            left: $picker-arrow-size;
-            z-index: 1;
-            width: $picker-arrow-size;
-            height: $picker-arrow-size;
-            margin-left: 10px;
-            transition: all 0.3s;
-
-            &:before,
-            &:after {
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                box-sizing: border-box;
-                transform: translate(-50%, -50%);
-                content: '';
-            }
-
-            &:before {
-                width: $picker-arrow-size;
-                height: $picker-arrow-size;
-                border: calc($picker-arrow-size / 2) solid
-                    $picker-border-color-active;
-                border-color: $picker-border-color-active
-                    $picker-border-color-active transparent transparent;
-            }
-
-            &:after {
-                width: $picker-arrow-size - 2px;
-                height: $picker-arrow-size - 2px;
-                border: calc(calc($picker-arrow-size - 2px) / 2) solid
-                    $picker-border-color-active;
-                border-color: $picker-background-color $picker-background-color
-                    transparent transparent;
-            }
-        }
-    }
-
     &-range {
         position: relative;
         display: inline-flex;
@@ -1152,10 +1089,10 @@
 
         .picker-active-bar {
             bottom: 0;
-            height: 2px;
+            height: $space-xxxs;
             background: $picker-input-active-bar-color;
             border: 1px solid transparent;
-            border-radius: 2px;
+            border-radius: $corner-radius-xs;
             opacity: 0;
             transition: all 0.3s;
             pointer-events: none;
@@ -1233,24 +1170,6 @@
             .picker-clear {
                 left: $picker-input-padding-horizontal-l;
                 right: unset;
-            }
-        }
-
-        .picker-dropdown {
-            &-rtl {
-                .picker-range-arrow {
-                    right: $picker-arrow-size;
-                    left: unset;
-                    margin-right: 10px;
-                    margin-left: 0;
-
-                    &:before,
-                    &:after {
-                        right: 50%;
-                        left: auto;
-                        transform: translate(50%, -50%);
-                    }
-                }
             }
         }
     }
@@ -1569,125 +1488,6 @@
                 }
             }
         }
-    }
-}
-
-.trigger-popup {
-    @include reset-component();
-
-    position: absolute;
-    top: -9999px;
-    left: -9999px;
-    z-index: $z-index-top;
-
-    &-placement-bottomLeft {
-        .picker-range-arrow {
-            top: calc($picker-arrow-size / 2) - calc($picker-arrow-size / 3) +
-                0.7px;
-            display: block;
-            transform: rotate(-135deg) translateY(1px);
-        }
-    }
-
-    &-placement-topLeft {
-        .picker-range-arrow {
-            bottom: calc($picker-arrow-size / 2) - calc($picker-arrow-size / 3) +
-                0.7px;
-            display: block;
-            transform: rotate(45deg);
-        }
-    }
-
-    &.slide-up-enter.trigger-popup-placement-topLeft,
-    &.slide-up-enter.trigger-popup-placement-topRight {
-        animation-name: slideDownIn;
-        animation-duration: $motion-duration-fast;
-        animation-fill-mode: forwards;
-    }
-
-    &.slide-up-enter.trigger-popup-placement-bottomLeft,
-    &.slide-up-enter.trigger-popup-placement-bottomRight {
-        animation-name: slideUpIn;
-        animation-duration: $motion-duration-fast;
-        animation-fill-mode: forwards;
-    }
-
-    &.slide-up-leave.trigger-popup-placement-topLeft,
-    &.slide-up-leave.trigger-popup-placement-topRight {
-        animation-name: slideDownOut;
-        animation-duration: $motion-duration-fast;
-        animation-fill-mode: forwards;
-    }
-
-    &.slide-up-leave.trigger-popup-placement-bottomLeft,
-    &.slide-up-leave.trigger-popup-placement-bottomRight {
-        animation-name: slideUpOut;
-        animation-duration: $motion-duration-fast;
-        animation-fill-mode: forwards;
-    }
-}
-
-@keyframes slideUpIn {
-    0% {
-        transform: scaleY(0.8);
-        transform-origin: 0% 0%;
-        opacity: 0;
-        pointer-events: none;
-    }
-
-    100% {
-        transform: scaleY(1);
-        transform-origin: 0% 0%;
-        opacity: 1;
-        pointer-events: all;
-    }
-}
-
-@keyframes slideUpOut {
-    0% {
-        transform: scaleY(1);
-        transform-origin: 0% 0%;
-        opacity: 1;
-        pointer-events: all;
-    }
-
-    100% {
-        transform: scaleY(0.8);
-        transform-origin: 0% 0%;
-        opacity: 0;
-        pointer-events: none;
-    }
-}
-
-@keyframes slideDownIn {
-    0% {
-        transform: scaleY(0.8);
-        transform-origin: 100% 100%;
-        opacity: 0;
-        pointer-events: none;
-    }
-
-    100% {
-        transform: scaleY(1);
-        transform-origin: 100% 100%;
-        opacity: 1;
-        pointer-events: all;
-    }
-}
-
-@keyframes slideDownOut {
-    0% {
-        transform: scaleY(1);
-        transform-origin: 100% 100%;
-        opacity: 1;
-        pointer-events: all;
-    }
-
-    100% {
-        transform: scaleY(0.8);
-        transform-origin: 100% 100%;
-        opacity: 0;
-        pointer-events: none;
     }
 }
 

--- a/src/components/Trigger/Utils/alignUtil.ts
+++ b/src/components/Trigger/Utils/alignUtil.ts
@@ -1,6 +1,8 @@
 import type { BuildInPlacements } from '../Trigger.types';
 import type { AlignType, AlignPoint } from '../../Align/Align.types';
 
+import styles from '../trigger.module.scss';
+
 function isPointsEq(
     a1: AlignPoint[],
     a2: AlignPoint[],
@@ -42,7 +44,7 @@ export function getAlignPopupClassName(
                 isAlignPoint
             )
         ) {
-            return `trigger-popup-placement-${placement}`;
+            return (styles as any)[`trigger-popup-placement-${placement}`];
         }
     }
 

--- a/src/components/Trigger/trigger.module.scss
+++ b/src/components/Trigger/trigger.module.scss
@@ -1,16 +1,124 @@
 .trigger-popup {
     position: absolute;
-    left: -9999px;
     top: -9999px;
-    z-index: 1050;
+    left: -9999px;
+    z-index: $z-index-top;
 
     &-hidden {
-        opacity: 0;
-        pointer-events: none;
+        display: none;
     }
 
+    // Picker styles
+    .picker-range-arrow {
+        position: absolute;
+        left: $picker-arrow-size;
+        z-index: 1;
+        width: $picker-arrow-size;
+        height: $picker-arrow-size;
+        margin-left: $space-xs;
+        transition: all 0.3s;
+
+        &:before,
+        &:after {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            box-sizing: border-box;
+            transform: translate(-50%, -50%);
+            content: '';
+        }
+
+        &:before {
+            width: $picker-arrow-size;
+            height: $picker-arrow-size;
+            border: calc($picker-arrow-size / 2) solid $picker-background-color;
+            border-color: $picker-background-color $picker-background-color
+                transparent transparent;
+        }
+
+        &:after {
+            width: $picker-arrow-size - $space-xxxs;
+            height: $picker-arrow-size - $space-xxxs;
+            border: calc(calc($picker-arrow-size - $space-xxxs) / 2) solid
+                $picker-background-color;
+            border-color: $picker-background-color $picker-background-color
+                transparent transparent;
+        }
+    }
+
+    &-placement-bottomLeft,
+    &-placement-bottomRight {
+        .picker-range-arrow {
+            bottom: unset;
+            top: 1px;
+            transform: rotate(-45deg);
+        }
+    }
+
+    &.slide-up-enter.trigger-popup-placement-bottomLeft,
+    &.slide-up-enter.trigger-popup-placement-bottomRight {
+        animation-name: slideUpIn;
+        animation-duration: $motion-duration-fast;
+        animation-timing-function: $motion-easing-easeout;
+    }
+
+    &.slide-up-leave.trigger-popup-placement-bottomLeft,
+    &.slide-up-leave.trigger-popup-placement-bottomRight {
+        animation-name: slideUpOut;
+        animation-duration: $motion-duration-fast;
+        animation-timing-function: $motion-easing-easein;
+    }
+
+    &-placement-topLeft,
+    &-placement-topRight {
+        .picker-range-arrow {
+            bottom: $space-xxxs;
+            top: unset;
+            transform: rotate(135deg);
+        }
+    }
+
+    &.slide-up-enter.trigger-popup-placement-topLeft,
+    &.slide-up-enter.trigger-popup-placement-topRight {
+        animation-name: slideDownIn;
+        animation-duration: $motion-duration-fast;
+        animation-timing-function: $motion-easing-easeout;
+    }
+
+    &.slide-up-leave.trigger-popup-placement-topLeft,
+    &.slide-up-leave.trigger-popup-placement-topRight {
+        animation-name: slideDownOut;
+        animation-duration: $motion-duration-fast;
+        animation-timing-function: $motion-easing-easein;
+    }
+
+    &-range {
+        padding: ($picker-arrow-size * 2 / 3) 0;
+
+        &-hidden {
+            display: none;
+        }
+    }
+
+    &-rtl {
+        .picker-range-arrow {
+            right: $picker-arrow-size;
+            left: unset;
+            margin-right: 10px;
+            margin-left: 0;
+
+            &:before,
+            &:after {
+                right: 50%;
+                left: auto;
+                transform: translate(50%, -50%);
+            }
+        }
+    }
+
+    // Assert styles
     @mixin effect() {
-        animation-duration: 0.3s;
+        animation-duration: $motion-duration-fast;
         animation-fill-mode: both;
     }
 
@@ -18,13 +126,13 @@
     &-zoom-appear {
         opacity: 0;
         @include effect();
-        animation-timing-function: cubic-bezier(0.18, 0.89, 0.32, 1.28);
+        animation-timing-function: $motion-easing-easeout;
         animation-play-state: paused;
     }
 
     &-zoom-leave {
         @include effect();
-        animation-timing-function: cubic-bezier(0.6, -0.3, 0.74, 0.05);
+        animation-timing-function: $motion-easing-easein;
         animation-play-state: paused;
     }
 
@@ -37,31 +145,6 @@
     &-zoom-leave &-zoom-leave-active {
         animation-name: triggerZoomOut;
         animation-play-state: running;
-    }
-
-    @keyframes triggerZoomIn {
-        0% {
-            opacity: 0;
-            transform-origin: 50% 50%;
-            transform: scale(0, 0);
-        }
-        100% {
-            opacity: 1;
-            transform-origin: 50% 50%;
-            transform: scale(1, 1);
-        }
-    }
-    @keyframes triggerZoomOut {
-        0% {
-            opacity: 1;
-            transform-origin: 50% 50%;
-            transform: scale(1, 1);
-        }
-        100% {
-            opacity: 0;
-            transform-origin: 50% 50%;
-            transform: scale(0, 0);
-        }
     }
 }
 

--- a/src/styles/base/_motion.scss
+++ b/src/styles/base/_motion.scss
@@ -1,3 +1,21 @@
+@keyframes fadeIn {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+@keyframes fadOut {
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
 @keyframes scaleIn {
     0% {
         transform: scale(0, 0);
@@ -7,6 +25,18 @@
     100% {
         transform: scale(1, 1);
         opacity: 1;
+    }
+}
+
+@keyframes scaleOut {
+    0% {
+        transform: scale(1, 1);
+        opacity: 1;
+    }
+
+    100% {
+        transform: scale(0, 0);
+        opacity: 0;
     }
 }
 
@@ -23,37 +53,78 @@
 
 @keyframes slideUpIn {
     0% {
-        transform: scaleY(0.8);
-        transform-origin: 0 0;
         opacity: 0;
+        transform: scaleY(0.8);
+        transform-origin: 0% 0%;
     }
-
     100% {
-        transform: scaleY(1);
-        transform-origin: 0 0;
         opacity: 1;
+        transform: scaleY(1);
+        transform-origin: 0% 0%;
     }
 }
 
 @keyframes slideUpOut {
     0% {
-        transform: scaleY(1);
-        transform-origin: 0 0;
         opacity: 1;
+        transform: scaleY(1);
+        transform-origin: 0% 0%;
     }
-
     100% {
-        transform: scaleY(0.8);
-        transform-origin: 0 0;
         opacity: 0;
+        transform: scaleY(0.8);
+        transform-origin: 0% 0%;
     }
 }
 
-@keyframes fadeIn {
+@keyframes slideDownIn {
     0% {
         opacity: 0;
+        transform: scaleY(0.8);
+        transform-origin: 100% 100%;
     }
     100% {
         opacity: 1;
+        transform: scaleY(1);
+        transform-origin: 100% 100%;
+    }
+}
+
+@keyframes slideDownOut {
+    0% {
+        opacity: 1;
+        transform: scaleY(1);
+        transform-origin: 100% 100%;
+    }
+    100% {
+        opacity: 0;
+        transform: scaleY(0.8);
+        transform-origin: 100% 100%;
+    }
+}
+
+@keyframes triggerZoomIn {
+    0% {
+        opacity: 0;
+        transform-origin: 50% 50%;
+        transform: scale(0, 0);
+    }
+    100% {
+        opacity: 1;
+        transform-origin: 50% 50%;
+        transform: scale(1, 1);
+    }
+}
+
+@keyframes triggerZoomOut {
+    0% {
+        opacity: 1;
+        transform-origin: 50% 50%;
+        transform: scale(1, 1);
+    }
+    100% {
+        opacity: 0;
+        transform-origin: 50% 50%;
+        transform: scale(0, 0);
     }
 }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -219,7 +219,7 @@
     --picker-cell-range-start-background-color-active: var(--accent-color-30);
     --picker-cell-range-end-background-color-hover: var(--accent-color-30);
     --picker-cell-range-end-background-color-active: var(--accent-color-30);
-    --picker-cell-foreground-color: var(--text-secondary-color);
+    --picker-cell-foreground-color: var(--text-tertiary-color);
     --picker-cell-foreground-color-active: var(--primary-color);
     --picker-cell-foreground-color-hover: var(--primary-color);
     --picker-column-background-color: var(--background-color);

--- a/src/styles/themes/_definitions.scss
+++ b/src/styles/themes/_definitions.scss
@@ -195,8 +195,7 @@ $picker-border-style: solid;
 $picker-border-width: 1px;
 $picker-border: $picker-border-width $picker-border-style $picker-border-color;
 
-$picker-box-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12),
-    0px 4px 16px rgba(15, 20, 31, 0.16);
+$picker-box-shadow: $shadow-object-m;
 $picker-cell-background-color: var(--picker-cell-background-color);
 $picker-cell-today-background-color: var(--picker-cell-today-background-color);
 $picker-cell-selected-background-color-active: var(


### PR DESCRIPTION
## SUMMARY:
Prior to this change the pickers used a visually hidden approach via `opacity`, this was problematic because the resize event would cause a noticeable flicker. This change updates the pickers to use `display: hidden`.


https://user-images.githubusercontent.com/99700808/193958529-d4992bbb-7430-4d75-99bd-824edea8675f.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-29871

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and run `yarn` and `yarn storybook` via terminal. Verify the Pickers behave as expected.