### PR TITLE
fix(dropdown): modify flip behavior for filterable Select

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -58,6 +58,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         onClickOutside,
         width,
         height,
+        inputRef,
     }) => {
         const [mergedVisible, setVisible] = useMergedState<boolean>(false, {
             value: visible,
@@ -71,7 +72,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
             useFloating({
                 placement,
                 strategy: positionStrategy,
-                middleware: [flip(), fOffset(offset), shift()],
+                middleware: [fOffset(offset), flip(), shift()],
             });
 
         const toggle: Function =
@@ -151,6 +152,15 @@ export const Dropdown: FC<DropdownProps> = React.memo(
             height: height ?? '',
         };
 
+        const dropdownStylesFlipped: React.CSSProperties = {
+            ...dropdownStyle,
+            position: strategy,
+            bottom: offset + inputRef?.current?.clientHeight,
+            left: x ?? '',
+            width: width ?? '',
+            height: height ?? '',
+        };
+
         const getReference = (): JSX.Element => {
             const child = React.Children.only(
                 children
@@ -184,7 +194,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
             mergedVisible && (
                 <div
                     ref={floating}
-                    style={dropdownStyles}
+                    style={y > 0 ? dropdownStyles : dropdownStylesFlipped}
                     className={dropdownClasses}
                     tabIndex={0}
                     onClick={

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MutableRefObject } from 'react';
 import { Placement, Strategy } from '@floating-ui/react-dom';
 
 export interface DropdownProps {
@@ -90,4 +90,8 @@ export interface DropdownProps {
      * Manually control the width of the dropdown
      */
     width?: number;
+    /**
+     * Include dropdown textbox ref if using Select component
+     */
+    inputRef?: MutableRefObject<HTMLInputElement>;
 }

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -33,6 +33,10 @@ export interface DropdownProps {
      */
     height?: number;
     /**
+     * Include dropdown textbox ref if using Select component
+     */
+    inputRef?: MutableRefObject<HTMLInputElement>;
+    /**
      * The offset from the reference element
      * @default 0
      */
@@ -90,8 +94,4 @@ export interface DropdownProps {
      * Manually control the width of the dropdown
      */
     width?: number;
-    /**
-     * Include dropdown textbox ref if using Select component
-     */
-    inputRef?: MutableRefObject<HTMLInputElement>;
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -559,6 +559,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                         }
                         showDropdown={showDropdown}
                         visible={dropdownVisible}
+                        inputRef={inputRef}
                     >
                         <TextInput
                             ref={inputRef}


### PR DESCRIPTION
## SUMMARY:
Fixing flip behavior for filterable Select. 
When dropdown is opened upwards, the filtered dropdown would condense upwards instead of downwards. Example:
<img width="518" alt="image" src="https://user-images.githubusercontent.com/106630167/195415797-3e847444-64c9-4e59-8731-cd131cacf443.png">

With this fix, the filtered dropdown will condense in the correct direction. 
<img width="460" alt="image" src="https://user-images.githubusercontent.com/106630167/195415909-c5fe35b5-4a97-4984-85e9-52b9acdf0a66.png">
<img width="444" alt="image" src="https://user-images.githubusercontent.com/106630167/195415955-92c4eaa3-2ea4-46ef-8aae-c8fdff6cb7e4.png">


## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-31392
https://eightfoldai.atlassian.net/browse/ENG-31991 (clone)

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
WIP