### PR TITLE
fix: select: adds html type to chevron button

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -479,6 +479,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
             clearable: clearable,
             inputWidth: inputWidth,
             iconButtonProps: {
+                htmlType: 'button',
                 iconProps: {
                     path: dropdownVisible
                         ? IconName.mdiChevronUp

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`Select Select is large 1`] = `
         <button
           aria-disabled="false"
           class="icon-button right-icon button button-default button-large pill-shape icon-left"
+          type="button"
         >
           <span
             aria-hidden="false"
@@ -84,6 +85,7 @@ exports[`Select Select is medium 1`] = `
         <button
           aria-disabled="false"
           class="icon-button right-icon button button-default button-medium pill-shape icon-left"
+          type="button"
         >
           <span
             aria-hidden="false"
@@ -138,6 +140,7 @@ exports[`Select Select is pill shaped 1`] = `
         <button
           aria-disabled="false"
           class="icon-button right-icon button button-default button-medium pill-shape icon-left"
+          type="button"
         >
           <span
             aria-hidden="false"
@@ -192,6 +195,7 @@ exports[`Select Select is rectangle shaped 1`] = `
         <button
           aria-disabled="false"
           class="icon-button right-icon button button-default button-medium pill-shape icon-left"
+          type="button"
         >
           <span
             aria-hidden="false"
@@ -246,6 +250,7 @@ exports[`Select Select is small 1`] = `
         <button
           aria-disabled="false"
           class="icon-button right-icon button button-default button-small pill-shape icon-left"
+          type="button"
         >
           <span
             aria-hidden="false"
@@ -300,6 +305,7 @@ exports[`Select Select is underline shaped 1`] = `
         <button
           aria-disabled="false"
           class="icon-button right-icon button button-default button-medium pill-shape icon-left"
+          type="button"
         >
           <span
             aria-hidden="false"


### PR DESCRIPTION
## SUMMARY:
Missing button type caused form submit action, this change fixes the bug.

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
