### PR TITLE
fix: slider: fixes collision detection in grid layouts

### DIFF
--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Stack } from '../Stack';
+import { Col, Row } from '../Grid';
 
 import { Slider, SliderSize } from './';
 
@@ -30,11 +31,15 @@ const Slider_Story: ComponentStory<typeof Slider> = (args) => {
 
     return (
         <Stack align="stretch" direction="vertical" fullWidth gap="xl">
-            <Slider
-                {...args}
-                value={transientSlidingValue}
-                onChange={handleChange}
-            />
+            <Row>
+                <Col span={6} push={3}>
+                    <Slider
+                        {...args}
+                        value={transientSlidingValue}
+                        onChange={handleChange}
+                    />
+                </Col>
+            </Row>
             <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
                 <div>{transientSlidingValue}</div>
             </Stack>

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -311,7 +311,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     showMaxLabel =
                         showLabels &&
                         lowerThumbOffset <
-                            minLabelRef.current.getBoundingClientRect().left -
+                            minLabelRef.current.offsetLeft -
                                 lowerLabelRef.current.offsetWidth / 2 -
                                 thumbRadius;
                     maxLabelRef.current.style.opacity = showMaxLabel
@@ -321,7 +321,8 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     showMinLabel =
                         showLabels &&
                         lowerThumbOffset >
-                            maxLabelRef.current.getBoundingClientRect().right +
+                            maxLabelRef.current.offsetLeft +
+                                maxLabelRef.current.offsetWidth +
                                 lowerLabelRef.current.offsetWidth / 2 -
                                 thumbRadius;
                     minLabelRef.current.style.opacity = showMinLabel
@@ -336,7 +337,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     showMaxLabel =
                         showLabels &&
                         lowerThumbOffset <
-                            maxLabelRef.current.getBoundingClientRect().left -
+                            maxLabelRef.current.offsetLeft -
                                 lowerLabelRef.current.offsetWidth / 2 -
                                 thumbRadius;
                     maxLabelRef.current.style.opacity = showMaxLabel
@@ -346,7 +347,8 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     showMinLabel =
                         showLabels &&
                         lowerThumbOffset >
-                            minLabelRef.current.getBoundingClientRect().right +
+                            minLabelRef.current.offsetLeft +
+                                minLabelRef.current.offsetWidth +
                                 lowerLabelRef.current.offsetWidth / 2 -
                                 thumbRadius;
                     minLabelRef.current.style.opacity = showMinLabel

--- a/src/components/Upload/Upload.stories.tsx
+++ b/src/components/Upload/Upload.stories.tsx
@@ -20,7 +20,19 @@ export default {
                     <article>
                         <section>
                             <h1>Upload</h1>
-                            <p>TBD</p>
+                            <p>
+                                Use the Upload component to publishing
+                                information (text, pictures, video, etc.) to a
+                                remote server via a web app. Use this component
+                                to do the following:
+                            </p>
+                            <ul>
+                                <li>To upload one or more files</li>
+                                <li>To show the process of uploading</li>
+                                <li>
+                                    To upload files by dragging and dropping
+                                </li>
+                            </ul>
                         </section>
                         <section>
                             <Stories includePrimary title="" />

--- a/src/components/Upload/Upload.types.tsx
+++ b/src/components/Upload/Upload.types.tsx
@@ -4,6 +4,7 @@ import type {
     OcFile as InternalOcFile,
     OcUploadProps,
     UploadRequestOption as OcCustomRequestOptions,
+    UploadRequestMethod,
 } from './Internal/OcUpload.types';
 import type { ProgressProps } from '../Progress';
 import { ConfigContextProps } from '../ConfigProvider';
@@ -148,7 +149,7 @@ export interface UploadFile<T = any> {
      */
     error?: any;
     /**
-     * The upload file name.
+     * The Upload file name.
      */
     fileName?: string;
     /**
@@ -180,7 +181,7 @@ export interface UploadFile<T = any> {
      */
     preview?: string;
     /**
-     * The Upload file resoponse
+     * The Upload file response.
      */
     response?: T;
     /**
@@ -310,7 +311,7 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
      */
     classNames?: string;
     /**
-     * Configure how contextual props are consumed
+     * Configure how contextual props are consumed.
      */
     configContextProps?: ConfigContextProps;
     /**
@@ -329,9 +330,12 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
         | ((
               file: UploadFile<T>
           ) => Record<string, unknown> | Promise<Record<string, unknown>>);
+    /**
+     * Default list of files that have been uploaded.
+     */
     defaultFileList?: Array<UploadFile<T>>;
     /**
-     * upload a directory.
+     * Upload a directory.
      * https://caniuse.com/input-file-directory
      * @default false
      */
@@ -353,7 +357,7 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
     dragAndDropFileText?: string;
     /**
      * The multiple drag and drop string.
-     * @default 'Drag & drop file'
+     * @default 'Drag & drop files'
      */
     dragAndDropMultipleFilesText?: string;
     /**
@@ -405,7 +409,7 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
      * The http method of the upload request.
      * @default 'post'
      */
-    method?: 'POST' | 'PUT' | 'PATCH' | 'post' | 'put' | 'patch';
+    method?: UploadRequestMethod;
     /**
      * Whether to support multiple file upload.
      * Enables select multiple files using CTRL button when true
@@ -415,7 +419,7 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
     multiple?: boolean;
     /**
      * The name of uploading file.
-     * @default file
+     * @default 'file'
      */
     name?: string;
     /**
@@ -515,7 +519,7 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
      */
     supportServerRender?: boolean;
     /**
-     * The Upload type
+     * The Upload type.
      * @default 'select'
      */
     type?: UploadType;


### PR DESCRIPTION
## SUMMARY:
`getBoundingClientRect()` was not returning the correct offset in flex layouts. This change updates the collision detection logic to use offset properties and their values.

- Also tidies up Upload types and storybook doc

## JIRA TASK (Eightfold Employees Only):


## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the Slider stories behave as expected.