### PR TITLE
fix: pagination: fixes pagination aria attributes

### DIFF
--- a/src/components/Pagination/Pager.tsx
+++ b/src/components/Pagination/Pager.tsx
@@ -135,7 +135,7 @@ export const Pager: FC<PagerProps> = React.forwardRef(
                     <li>
                         {!simplified ? (
                             <NeutralButton
-                                checked={currentPage === 1}
+                                aria-current={currentPage === 1}
                                 classNames={mergeClasses([
                                     styles.paginationButton,
                                     { [styles.active]: currentPage === 1 },
@@ -144,7 +144,6 @@ export const Pager: FC<PagerProps> = React.forwardRef(
                                 onClick={() => onCurrentChange(1)}
                                 size={ButtonSize.Medium}
                                 text={'1'.toLocaleString()}
-                                toggle
                             />
                         ) : (
                             <span>{`${currentPage.toLocaleString()} ${
@@ -192,8 +191,7 @@ export const Pager: FC<PagerProps> = React.forwardRef(
                         return (
                             <li key={idx}>
                                 <NeutralButton
-                                    checked={currentPage === pager}
-                                    shape={ButtonShape.Rectangle}
+                                    aria-current={currentPage === pager}
                                     classNames={mergeClasses([
                                         styles.paginationButton,
                                         {
@@ -202,9 +200,9 @@ export const Pager: FC<PagerProps> = React.forwardRef(
                                         },
                                     ])}
                                     onClick={() => onCurrentChange(pager)}
+                                    shape={ButtonShape.Rectangle}
                                     size={ButtonSize.Medium}
                                     text={pager.toLocaleString()}
-                                    toggle
                                 />
                             </li>
                         );
@@ -243,8 +241,7 @@ export const Pager: FC<PagerProps> = React.forwardRef(
                     <li>
                         {!simplified ? (
                             <NeutralButton
-                                shape={ButtonShape.Rectangle}
-                                checked={currentPage === pageCount}
+                                aria-current={currentPage === pageCount}
                                 classNames={mergeClasses([
                                     styles.paginationButton,
                                     {
@@ -253,9 +250,9 @@ export const Pager: FC<PagerProps> = React.forwardRef(
                                     },
                                 ])}
                                 onClick={() => onCurrentChange(pageCount)}
+                                shape={ButtonShape.Rectangle}
                                 size={ButtonSize.Medium}
                                 text={pageCount.toLocaleString()}
-                                toggle
                             />
                         ) : (
                             <span>{pageCount.toLocaleString()}</span>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -281,6 +281,7 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
                             {...rest}
                             ref={ref}
                             className={paginationWrapperClassNames}
+                            role="navigation"
                             data-test-id={dataTestId}
                         >
                             {_total > 0 && (

--- a/src/components/Table/Tests/__snapshots__/Table.expand.test.tsx.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.expand.test.tsx.snap
@@ -1878,6 +1878,7 @@ LoadedCheerio {
         "next": Node {
           "attribs": Object {
             "class": "table-pagination table-pagination-right pagination",
+            "role": "navigation",
           },
           "children": Array [
             Node {
@@ -1895,9 +1896,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1935,15 +1935,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -1987,9 +1985,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -2027,15 +2024,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -2083,9 +2078,11 @@ LoadedCheerio {
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
+            "role": undefined,
           },
           "x-attribsPrefix": Object {
             "class": undefined,
+            "role": undefined,
           },
         },
         "parent": [Circular],
@@ -2101,6 +2098,7 @@ LoadedCheerio {
       Node {
         "attribs": Object {
           "class": "table-pagination table-pagination-right pagination",
+          "role": "navigation",
         },
         "children": Array [
           Node {
@@ -2118,9 +2116,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -2158,15 +2155,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -2210,9 +2205,8 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "aria-checked": "true",
+                      "aria-current": "true",
                       "aria-disabled": "false",
-                      "aria-pressed": "true",
                       "class": "pagination-button active button button-neutral button-medium",
                     },
                     "children": Array [
@@ -2250,15 +2244,13 @@ LoadedCheerio {
                     "prev": null,
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                   },
@@ -4184,9 +4176,11 @@ LoadedCheerio {
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
+          "role": undefined,
         },
         "x-attribsPrefix": Object {
           "class": undefined,
+          "role": undefined,
         },
       },
     ],

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.accepttrue.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.accepttrue.shot
@@ -906,6 +906,7 @@ LoadedCheerio {
         "next": Node {
           "attribs": Object {
             "class": "table-pagination table-pagination-right pagination",
+            "role": "navigation",
           },
           "children": Array [
             Node {
@@ -1005,9 +1006,8 @@ LoadedCheerio {
                       "children": Array [
                         Node {
                           "attribs": Object {
-                            "aria-checked": "true",
+                            "aria-current": "true",
                             "aria-disabled": "false",
-                            "aria-pressed": "true",
                             "class": "pagination-button active button button-neutral button-medium",
                           },
                           "children": Array [
@@ -1045,15 +1045,13 @@ LoadedCheerio {
                           "prev": null,
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                         },
@@ -1293,9 +1291,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1333,15 +1330,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -1504,9 +1499,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -1544,15 +1538,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -1881,9 +1873,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1921,15 +1912,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2089,9 +2078,11 @@ LoadedCheerio {
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
+            "role": undefined,
           },
           "x-attribsPrefix": Object {
             "class": undefined,
+            "role": undefined,
           },
         },
         "parent": [Circular],
@@ -2107,6 +2098,7 @@ LoadedCheerio {
       Node {
         "attribs": Object {
           "class": "table-pagination table-pagination-right pagination",
+          "role": "navigation",
         },
         "children": Array [
           Node {
@@ -2206,9 +2198,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -2246,15 +2237,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2494,9 +2483,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -2534,15 +2522,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -2705,9 +2691,8 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "aria-checked": "true",
+                      "aria-current": "true",
                       "aria-disabled": "false",
-                      "aria-pressed": "true",
                       "class": "pagination-button active button button-neutral button-medium",
                     },
                     "children": Array [
@@ -2745,15 +2730,13 @@ LoadedCheerio {
                     "prev": null,
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                   },
@@ -3082,9 +3065,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -3122,15 +3104,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -4196,9 +4176,11 @@ LoadedCheerio {
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
+          "role": undefined,
         },
         "x-attribsPrefix": Object {
           "class": undefined,
+          "role": undefined,
         },
       },
     ],

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.nocrashonchange.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.nocrashonchange.shot
@@ -906,6 +906,7 @@ LoadedCheerio {
         "next": Node {
           "attribs": Object {
             "class": "table-pagination table-pagination-right pagination",
+            "role": "navigation",
           },
           "children": Array [
             Node {
@@ -1005,9 +1006,8 @@ LoadedCheerio {
                       "children": Array [
                         Node {
                           "attribs": Object {
-                            "aria-checked": "true",
+                            "aria-current": "true",
                             "aria-disabled": "false",
-                            "aria-pressed": "true",
                             "class": "pagination-button active button button-neutral button-medium",
                           },
                           "children": Array [
@@ -1045,15 +1045,13 @@ LoadedCheerio {
                           "prev": null,
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                         },
@@ -1293,9 +1291,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1333,15 +1330,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -1504,9 +1499,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -1544,15 +1538,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -1881,9 +1873,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1921,15 +1912,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2089,9 +2078,11 @@ LoadedCheerio {
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
+            "role": undefined,
           },
           "x-attribsPrefix": Object {
             "class": undefined,
+            "role": undefined,
           },
         },
         "parent": [Circular],
@@ -2107,6 +2098,7 @@ LoadedCheerio {
       Node {
         "attribs": Object {
           "class": "table-pagination table-pagination-right pagination",
+          "role": "navigation",
         },
         "children": Array [
           Node {
@@ -2206,9 +2198,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -2246,15 +2237,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2494,9 +2483,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -2534,15 +2522,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -2705,9 +2691,8 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "aria-checked": "true",
+                      "aria-current": "true",
                       "aria-disabled": "false",
-                      "aria-pressed": "true",
                       "class": "pagination-button active button button-neutral button-medium",
                     },
                     "children": Array [
@@ -2745,15 +2730,13 @@ LoadedCheerio {
                     "prev": null,
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                   },
@@ -3082,9 +3065,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -3122,15 +3104,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -4196,9 +4176,11 @@ LoadedCheerio {
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
+          "role": undefined,
         },
         "x-attribsPrefix": Object {
           "class": undefined,
+          "role": undefined,
         },
       },
     ],

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.position.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.position.shot
@@ -906,6 +906,7 @@ LoadedCheerio {
         "next": Node {
           "attribs": Object {
             "class": "table-pagination table-pagination-right pagination",
+            "role": "navigation",
           },
           "children": Array [
             Node {
@@ -1005,9 +1006,8 @@ LoadedCheerio {
                       "children": Array [
                         Node {
                           "attribs": Object {
-                            "aria-checked": "true",
+                            "aria-current": "true",
                             "aria-disabled": "false",
-                            "aria-pressed": "true",
                             "class": "pagination-button active button button-neutral button-medium",
                           },
                           "children": Array [
@@ -1045,15 +1045,13 @@ LoadedCheerio {
                           "prev": null,
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                         },
@@ -1293,9 +1291,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1333,15 +1330,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -1504,9 +1499,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -1544,15 +1538,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -1881,9 +1873,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1921,15 +1912,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2089,9 +2078,11 @@ LoadedCheerio {
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
+            "role": undefined,
           },
           "x-attribsPrefix": Object {
             "class": undefined,
+            "role": undefined,
           },
         },
         "parent": [Circular],
@@ -2107,6 +2098,7 @@ LoadedCheerio {
       Node {
         "attribs": Object {
           "class": "table-pagination table-pagination-right pagination",
+          "role": "navigation",
         },
         "children": Array [
           Node {
@@ -2206,9 +2198,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -2246,15 +2237,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2494,9 +2483,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -2534,15 +2522,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -2705,9 +2691,8 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "aria-checked": "true",
+                      "aria-current": "true",
                       "aria-disabled": "false",
-                      "aria-pressed": "true",
                       "class": "pagination-button active button button-neutral button-medium",
                     },
                     "children": Array [
@@ -2745,15 +2730,13 @@ LoadedCheerio {
                     "prev": null,
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                   },
@@ -3082,9 +3065,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -3122,15 +3104,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -4196,9 +4176,11 @@ LoadedCheerio {
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
+          "role": undefined,
         },
         "x-attribsPrefix": Object {
           "class": undefined,
+          "role": undefined,
         },
       },
     ],

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.renders.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.renders.shot
@@ -906,6 +906,7 @@ LoadedCheerio {
         "next": Node {
           "attribs": Object {
             "class": "table-pagination table-pagination-right my-page pagination",
+            "role": "navigation",
           },
           "children": Array [
             Node {
@@ -1005,9 +1006,8 @@ LoadedCheerio {
                       "children": Array [
                         Node {
                           "attribs": Object {
-                            "aria-checked": "true",
+                            "aria-current": "true",
                             "aria-disabled": "false",
-                            "aria-pressed": "true",
                             "class": "pagination-button active button button-neutral button-medium",
                           },
                           "children": Array [
@@ -1045,15 +1045,13 @@ LoadedCheerio {
                           "prev": null,
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-checked": undefined,
+                            "aria-current": undefined,
                             "aria-disabled": undefined,
-                            "aria-pressed": undefined,
                             "class": undefined,
                           },
                         },
@@ -1293,9 +1291,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1333,15 +1330,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -1504,9 +1499,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -1544,15 +1538,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -1881,9 +1873,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -1921,15 +1912,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2089,9 +2078,11 @@ LoadedCheerio {
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
+            "role": undefined,
           },
           "x-attribsPrefix": Object {
             "class": undefined,
+            "role": undefined,
           },
         },
         "parent": [Circular],
@@ -2107,6 +2098,7 @@ LoadedCheerio {
       Node {
         "attribs": Object {
           "class": "table-pagination table-pagination-right my-page pagination",
+          "role": "navigation",
         },
         "children": Array [
           Node {
@@ -2206,9 +2198,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -2246,15 +2237,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -2494,9 +2483,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -2534,15 +2522,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -2705,9 +2691,8 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "aria-checked": "true",
+                      "aria-current": "true",
                       "aria-disabled": "false",
-                      "aria-pressed": "true",
                       "class": "pagination-button active button button-neutral button-medium",
                     },
                     "children": Array [
@@ -2745,15 +2730,13 @@ LoadedCheerio {
                     "prev": null,
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                   },
@@ -3082,9 +3065,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -3122,15 +3104,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -4196,9 +4176,11 @@ LoadedCheerio {
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
+          "role": undefined,
         },
         "x-attribsPrefix": Object {
           "class": undefined,
+          "role": undefined,
         },
       },
     ],

--- a/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
@@ -11113,6 +11113,7 @@ LoadedCheerio {
         "next": Node {
           "attribs": Object {
             "class": "table-pagination table-pagination-right pagination",
+            "role": "navigation",
           },
           "children": Array [
             Node {
@@ -11130,9 +11131,8 @@ LoadedCheerio {
                     "children": Array [
                       Node {
                         "attribs": Object {
-                          "aria-checked": "true",
+                          "aria-current": "true",
                           "aria-disabled": "false",
-                          "aria-pressed": "true",
                           "class": "pagination-button active button button-neutral button-medium",
                         },
                         "children": Array [
@@ -11170,15 +11170,13 @@ LoadedCheerio {
                         "prev": null,
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-checked": undefined,
+                          "aria-current": undefined,
                           "aria-disabled": undefined,
-                          "aria-pressed": undefined,
                           "class": undefined,
                         },
                       },
@@ -11222,9 +11220,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -11262,15 +11259,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -11318,9 +11313,11 @@ LoadedCheerio {
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
+            "role": undefined,
           },
           "x-attribsPrefix": Object {
             "class": undefined,
+            "role": undefined,
           },
         },
         "parent": [Circular],
@@ -11336,6 +11333,7 @@ LoadedCheerio {
       Node {
         "attribs": Object {
           "class": "table-pagination table-pagination-right pagination",
+          "role": "navigation",
         },
         "children": Array [
           Node {
@@ -11353,9 +11351,8 @@ LoadedCheerio {
                   "children": Array [
                     Node {
                       "attribs": Object {
-                        "aria-checked": "true",
+                        "aria-current": "true",
                         "aria-disabled": "false",
-                        "aria-pressed": "true",
                         "class": "pagination-button active button button-neutral button-medium",
                       },
                       "children": Array [
@@ -11393,15 +11390,13 @@ LoadedCheerio {
                       "prev": null,
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-checked": undefined,
+                        "aria-current": undefined,
                         "aria-disabled": undefined,
-                        "aria-pressed": undefined,
                         "class": undefined,
                       },
                     },
@@ -11445,9 +11440,8 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "aria-checked": "true",
+                      "aria-current": "true",
                       "aria-disabled": "false",
-                      "aria-pressed": "true",
                       "class": "pagination-button active button button-neutral button-medium",
                     },
                     "children": Array [
@@ -11485,15 +11479,13 @@ LoadedCheerio {
                     "prev": null,
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-checked": undefined,
+                      "aria-current": undefined,
                       "aria-disabled": undefined,
-                      "aria-pressed": undefined,
                       "class": undefined,
                     },
                   },
@@ -14211,9 +14203,11 @@ LoadedCheerio {
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
+          "role": undefined,
         },
         "x-attribsPrefix": Object {
           "class": undefined,
+          "role": undefined,
         },
       },
     ],


### PR DESCRIPTION
## SUMMARY:
Updates `Pagination` to use the correct aria attributes to announce current page.

## JIRA TASK (Eightfold Employees Only):
ENG-34426

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn`, and `yarn storybook`. Verify `Pagination` stories behave as expected. Turn on VoiceOver via System Preferences. Pagination should now appropriately announce the current item.