### PR TITLE
fix: table: updates use selection hook selectors to have ids by row key

### DIFF
--- a/src/components/Table/Hooks/useSelection.tsx
+++ b/src/components/Table/Hooks/useSelection.tsx
@@ -440,8 +440,9 @@ export default function useSelection<RecordType>(
 
                 const allDisabledData = flattedData
                     .map((record, index) => {
-                        const key = getRowKey(record, index);
-                        const checkboxProps = checkboxPropsMap.get(key) || {};
+                        const key: React.Key = getRowKey(record, index);
+                        const checkboxProps: Partial<CheckboxProps> =
+                            checkboxPropsMap.get(key) || {};
                         return { checked: keySet.has(key), ...checkboxProps };
                     })
                     .filter(({ disabled }) => disabled);
@@ -453,9 +454,6 @@ export default function useSelection<RecordType>(
                 const allDisabledAndChecked =
                     allDisabled &&
                     allDisabledData.every(({ checked }) => checked);
-                const allDisabledSomeChecked =
-                    allDisabled &&
-                    allDisabledData.some(({ checked }) => checked);
 
                 title = !hideSelectAll && (
                     <div className={styles.tableSelectionColumn}>
@@ -466,7 +464,7 @@ export default function useSelection<RecordType>(
                                     : allDisabledAndChecked
                             }
                             classNames={styles.selectionCheckbox}
-                            id={'selectCheckBox'}
+                            id={'selectAllCheckBox'}
                             onChange={onSelectAllChange}
                             disabled={flattedData.length === 0 || allDisabled}
                         />
@@ -483,8 +481,8 @@ export default function useSelection<RecordType>(
             ) => { node: React.ReactNode; checked: boolean };
             if (selectionType === 'radio') {
                 renderCell = (_, record, index) => {
-                    const key = getRowKey(record, index);
-                    const checked = keySet.has(key);
+                    const key: React.Key = getRowKey(record, index);
+                    const checked: boolean = keySet.has(key);
 
                     return {
                         node: (
@@ -493,7 +491,7 @@ export default function useSelection<RecordType>(
                                 checked={checked}
                                 name={'oc-table-radio-group'}
                                 classNames={styles.selectionRadiobutton}
-                                id={'selectRadioButton'}
+                                id={`selectRadioButton-${key}`}
                                 onClick={(e) => e.stopPropagation()}
                                 onChange={(event) => {
                                     if (!keySet.has(key)) {
@@ -512,9 +510,10 @@ export default function useSelection<RecordType>(
                 };
             } else {
                 renderCell = (_, record, index) => {
-                    const key = getRowKey(record, index);
-                    const checked = keySet.has(key);
-                    const checkboxProps = checkboxPropsMap.get(key);
+                    const key: React.Key = getRowKey(record, index);
+                    const checked: boolean = keySet.has(key);
+                    const checkboxProps: Partial<CheckboxProps> =
+                        checkboxPropsMap.get(key);
 
                     // Record checked
                     return {
@@ -523,7 +522,7 @@ export default function useSelection<RecordType>(
                                 {...checkboxProps}
                                 checked={checked}
                                 classNames={styles.selectionCheckbox}
-                                id={'selectCheckBox'}
+                                id={`selectCheckBox-${key}`}
                                 onClick={(e) => e.stopPropagation()}
                                 onChange={(nativeEvent: any) => {
                                     const { shiftKey } = nativeEvent;

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionexpandonleft.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionexpandonleft.shot
@@ -79,7 +79,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -90,7 +90,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -200,7 +200,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -281,7 +281,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -423,7 +423,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -434,7 +434,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -544,7 +544,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -625,7 +625,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -940,7 +940,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -951,7 +951,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1061,7 +1061,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -1142,7 +1142,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1265,7 +1265,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1276,7 +1276,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-0",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -1386,7 +1386,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1467,7 +1467,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-0",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1565,7 +1565,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1576,7 +1576,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -1686,7 +1686,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1767,7 +1767,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1890,7 +1890,7 @@ LoadedCheerio {
                                                 Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1901,7 +1901,7 @@ LoadedCheerio {
                                                   "next": Node {
                                                     "attribs": Object {
                                                       "class": "",
-                                                      "for": "selectCheckBox",
+                                                      "for": "selectCheckBox-1",
                                                     },
                                                     "children": Array [
                                                       Node {
@@ -2011,7 +2011,7 @@ LoadedCheerio {
                                                 Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -2092,7 +2092,7 @@ LoadedCheerio {
                                                   "prev": Node {
                                                     "attribs": Object {
                                                       "aria-disabled": "false",
-                                                      "id": "selectCheckBox",
+                                                      "id": "selectCheckBox-1",
                                                       "readonly": "",
                                                       "type": "checkbox",
                                                       "value": "",
@@ -2229,7 +2229,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -2240,7 +2240,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2350,7 +2350,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -2431,7 +2431,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2554,7 +2554,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2565,7 +2565,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2675,7 +2675,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2756,7 +2756,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -2854,7 +2854,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2865,7 +2865,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2975,7 +2975,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3056,7 +3056,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -3179,7 +3179,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -3190,7 +3190,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -3300,7 +3300,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -3381,7 +3381,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -3706,7 +3706,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -3717,7 +3717,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3827,7 +3827,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -3908,7 +3908,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4031,7 +4031,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4042,7 +4042,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4152,7 +4152,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4233,7 +4233,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4333,7 +4333,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4344,7 +4344,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4454,7 +4454,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4535,7 +4535,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4658,7 +4658,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4669,7 +4669,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-0",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -4779,7 +4779,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4860,7 +4860,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-0",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -5220,7 +5220,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectAllCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -5231,7 +5231,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5341,7 +5341,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectAllCheckBox",
                                             },
                                             "children": Array [
                                               Node {
@@ -5422,7 +5422,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -5564,7 +5564,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -5575,7 +5575,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -5685,7 +5685,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5766,7 +5766,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -6081,7 +6081,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -6092,7 +6092,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6202,7 +6202,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -6283,7 +6283,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6406,7 +6406,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6417,7 +6417,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -6527,7 +6527,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6608,7 +6608,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -6706,7 +6706,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6717,7 +6717,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -6827,7 +6827,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6908,7 +6908,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -7031,7 +7031,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -7042,7 +7042,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -7152,7 +7152,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -7233,7 +7233,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -7370,7 +7370,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -7381,7 +7381,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -7491,7 +7491,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -7572,7 +7572,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7695,7 +7695,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7706,7 +7706,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -7816,7 +7816,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -7897,7 +7897,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -7995,7 +7995,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -8006,7 +8006,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -8116,7 +8116,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -8197,7 +8197,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -8320,7 +8320,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -8331,7 +8331,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -8441,7 +8441,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -8522,7 +8522,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -8847,7 +8847,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -8858,7 +8858,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -8968,7 +8968,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -9049,7 +9049,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9172,7 +9172,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9183,7 +9183,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -9293,7 +9293,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -9374,7 +9374,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9474,7 +9474,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9485,7 +9485,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -9595,7 +9595,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -9676,7 +9676,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9799,7 +9799,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9810,7 +9810,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -9920,7 +9920,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -10001,7 +10001,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -10571,7 +10571,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -10582,7 +10582,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -10692,7 +10692,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -10773,7 +10773,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -10896,7 +10896,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -10907,7 +10907,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11017,7 +11017,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -11098,7 +11098,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11196,7 +11196,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -11207,7 +11207,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11317,7 +11317,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -11398,7 +11398,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11521,7 +11521,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11532,7 +11532,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -11642,7 +11642,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11723,7 +11723,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -11860,7 +11860,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-0",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -11871,7 +11871,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -11981,7 +11981,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-0",
                                         },
                                         "children": Array [
                                           Node {
@@ -12062,7 +12062,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12185,7 +12185,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12196,7 +12196,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -12306,7 +12306,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -12387,7 +12387,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12485,7 +12485,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12496,7 +12496,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -12606,7 +12606,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -12687,7 +12687,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12810,7 +12810,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12821,7 +12821,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -12931,7 +12931,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -13012,7 +13012,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -13337,7 +13337,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-1",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -13348,7 +13348,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -13458,7 +13458,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-1",
                                         },
                                         "children": Array [
                                           Node {
@@ -13539,7 +13539,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13662,7 +13662,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13673,7 +13673,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -13783,7 +13783,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -13864,7 +13864,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -13964,7 +13964,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13975,7 +13975,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -14085,7 +14085,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -14166,7 +14166,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -14289,7 +14289,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -14300,7 +14300,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -14410,7 +14410,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -14491,7 +14491,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -14826,7 +14826,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -14837,7 +14837,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -14947,7 +14947,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -15028,7 +15028,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -15170,7 +15170,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -15181,7 +15181,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -15291,7 +15291,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -15372,7 +15372,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionleft.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionleft.shot
@@ -79,7 +79,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -90,7 +90,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -200,7 +200,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -281,7 +281,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -423,7 +423,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -434,7 +434,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -544,7 +544,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -625,7 +625,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -940,7 +940,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -951,7 +951,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1061,7 +1061,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -1142,7 +1142,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1265,7 +1265,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1276,7 +1276,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-0",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -1386,7 +1386,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1467,7 +1467,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-0",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1565,7 +1565,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1576,7 +1576,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -1686,7 +1686,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1767,7 +1767,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1890,7 +1890,7 @@ LoadedCheerio {
                                                 Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1901,7 +1901,7 @@ LoadedCheerio {
                                                   "next": Node {
                                                     "attribs": Object {
                                                       "class": "",
-                                                      "for": "selectCheckBox",
+                                                      "for": "selectCheckBox-1",
                                                     },
                                                     "children": Array [
                                                       Node {
@@ -2011,7 +2011,7 @@ LoadedCheerio {
                                                 Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -2092,7 +2092,7 @@ LoadedCheerio {
                                                   "prev": Node {
                                                     "attribs": Object {
                                                       "aria-disabled": "false",
-                                                      "id": "selectCheckBox",
+                                                      "id": "selectCheckBox-1",
                                                       "readonly": "",
                                                       "type": "checkbox",
                                                       "value": "",
@@ -2229,7 +2229,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -2240,7 +2240,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2350,7 +2350,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -2431,7 +2431,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2554,7 +2554,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2565,7 +2565,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2675,7 +2675,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2756,7 +2756,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -2854,7 +2854,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2865,7 +2865,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2975,7 +2975,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3056,7 +3056,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -3179,7 +3179,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -3190,7 +3190,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -3300,7 +3300,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -3381,7 +3381,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -3706,7 +3706,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -3717,7 +3717,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3827,7 +3827,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -3908,7 +3908,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4031,7 +4031,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4042,7 +4042,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4152,7 +4152,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4233,7 +4233,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4333,7 +4333,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4344,7 +4344,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4454,7 +4454,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4535,7 +4535,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4658,7 +4658,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4669,7 +4669,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-0",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -4779,7 +4779,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4860,7 +4860,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-0",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -5220,7 +5220,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectAllCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -5231,7 +5231,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5341,7 +5341,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectAllCheckBox",
                                             },
                                             "children": Array [
                                               Node {
@@ -5422,7 +5422,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -5564,7 +5564,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -5575,7 +5575,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -5685,7 +5685,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5766,7 +5766,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -6081,7 +6081,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -6092,7 +6092,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6202,7 +6202,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -6283,7 +6283,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6406,7 +6406,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6417,7 +6417,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -6527,7 +6527,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6608,7 +6608,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -6706,7 +6706,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6717,7 +6717,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -6827,7 +6827,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6908,7 +6908,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -7031,7 +7031,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -7042,7 +7042,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -7152,7 +7152,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -7233,7 +7233,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -7370,7 +7370,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -7381,7 +7381,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -7491,7 +7491,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -7572,7 +7572,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7695,7 +7695,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7706,7 +7706,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -7816,7 +7816,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -7897,7 +7897,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -7995,7 +7995,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -8006,7 +8006,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -8116,7 +8116,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -8197,7 +8197,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -8320,7 +8320,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -8331,7 +8331,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -8441,7 +8441,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -8522,7 +8522,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -8847,7 +8847,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -8858,7 +8858,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -8968,7 +8968,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -9049,7 +9049,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9172,7 +9172,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9183,7 +9183,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -9293,7 +9293,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -9374,7 +9374,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9474,7 +9474,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9485,7 +9485,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -9595,7 +9595,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -9676,7 +9676,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9799,7 +9799,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9810,7 +9810,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -9920,7 +9920,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -10001,7 +10001,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -10571,7 +10571,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -10582,7 +10582,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -10692,7 +10692,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -10773,7 +10773,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -10896,7 +10896,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -10907,7 +10907,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11017,7 +11017,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -11098,7 +11098,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11196,7 +11196,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -11207,7 +11207,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11317,7 +11317,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -11398,7 +11398,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11521,7 +11521,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11532,7 +11532,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -11642,7 +11642,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11723,7 +11723,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -11860,7 +11860,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-0",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -11871,7 +11871,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -11981,7 +11981,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-0",
                                         },
                                         "children": Array [
                                           Node {
@@ -12062,7 +12062,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12185,7 +12185,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12196,7 +12196,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -12306,7 +12306,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -12387,7 +12387,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12485,7 +12485,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12496,7 +12496,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -12606,7 +12606,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -12687,7 +12687,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12810,7 +12810,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12821,7 +12821,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -12931,7 +12931,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -13012,7 +13012,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -13337,7 +13337,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-1",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -13348,7 +13348,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -13458,7 +13458,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-1",
                                         },
                                         "children": Array [
                                           Node {
@@ -13539,7 +13539,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13662,7 +13662,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13673,7 +13673,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -13783,7 +13783,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -13864,7 +13864,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -13964,7 +13964,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13975,7 +13975,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -14085,7 +14085,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -14166,7 +14166,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -14289,7 +14289,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -14300,7 +14300,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -14410,7 +14410,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -14491,7 +14491,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -14826,7 +14826,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -14837,7 +14837,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -14947,7 +14947,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -15028,7 +15028,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -15170,7 +15170,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -15181,7 +15181,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -15291,7 +15291,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -15372,7 +15372,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionwithcols.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionwithcols.shot
@@ -79,7 +79,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -90,7 +90,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -200,7 +200,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -281,7 +281,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -427,7 +427,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -438,7 +438,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -548,7 +548,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -629,7 +629,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -946,7 +946,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -957,7 +957,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1067,7 +1067,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -1148,7 +1148,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1275,7 +1275,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1286,7 +1286,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-0",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -1396,7 +1396,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1477,7 +1477,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-0",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1577,7 +1577,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1588,7 +1588,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -1698,7 +1698,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1779,7 +1779,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1906,7 +1906,7 @@ LoadedCheerio {
                                                 Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -1917,7 +1917,7 @@ LoadedCheerio {
                                                   "next": Node {
                                                     "attribs": Object {
                                                       "class": "",
-                                                      "for": "selectCheckBox",
+                                                      "for": "selectCheckBox-1",
                                                     },
                                                     "children": Array [
                                                       Node {
@@ -2027,7 +2027,7 @@ LoadedCheerio {
                                                 Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -2108,7 +2108,7 @@ LoadedCheerio {
                                                   "prev": Node {
                                                     "attribs": Object {
                                                       "aria-disabled": "false",
-                                                      "id": "selectCheckBox",
+                                                      "id": "selectCheckBox-1",
                                                       "readonly": "",
                                                       "type": "checkbox",
                                                       "value": "",
@@ -2247,7 +2247,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -2258,7 +2258,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2368,7 +2368,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -2449,7 +2449,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2576,7 +2576,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2587,7 +2587,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2697,7 +2697,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2778,7 +2778,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -2878,7 +2878,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2889,7 +2889,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2999,7 +2999,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3080,7 +3080,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -3207,7 +3207,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -3218,7 +3218,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -3328,7 +3328,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -3409,7 +3409,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -3736,7 +3736,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -3747,7 +3747,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3857,7 +3857,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -3938,7 +3938,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4065,7 +4065,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4076,7 +4076,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4186,7 +4186,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4267,7 +4267,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4369,7 +4369,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4380,7 +4380,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4490,7 +4490,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4571,7 +4571,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4698,7 +4698,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -4709,7 +4709,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-0",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -4819,7 +4819,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -4900,7 +4900,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-0",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -5262,7 +5262,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectAllCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -5273,7 +5273,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5383,7 +5383,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectAllCheckBox",
                                             },
                                             "children": Array [
                                               Node {
@@ -5464,7 +5464,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -5610,7 +5610,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -5621,7 +5621,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -5731,7 +5731,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5812,7 +5812,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -6129,7 +6129,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -6140,7 +6140,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6250,7 +6250,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -6331,7 +6331,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6458,7 +6458,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6469,7 +6469,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -6579,7 +6579,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6660,7 +6660,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -6760,7 +6760,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6771,7 +6771,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -6881,7 +6881,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6962,7 +6962,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -7089,7 +7089,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -7100,7 +7100,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -7210,7 +7210,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -7291,7 +7291,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -7430,7 +7430,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -7441,7 +7441,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -7551,7 +7551,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -7632,7 +7632,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7759,7 +7759,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7770,7 +7770,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -7880,7 +7880,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -7961,7 +7961,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -8061,7 +8061,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -8072,7 +8072,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -8182,7 +8182,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -8263,7 +8263,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -8390,7 +8390,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -8401,7 +8401,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -8511,7 +8511,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -8592,7 +8592,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -8919,7 +8919,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -8930,7 +8930,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -9040,7 +9040,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -9121,7 +9121,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9248,7 +9248,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9259,7 +9259,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -9369,7 +9369,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -9450,7 +9450,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9552,7 +9552,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -9563,7 +9563,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -9673,7 +9673,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -9754,7 +9754,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9881,7 +9881,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9892,7 +9892,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -10002,7 +10002,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -10083,7 +10083,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -10655,7 +10655,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -10666,7 +10666,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -10776,7 +10776,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -10857,7 +10857,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -10984,7 +10984,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -10995,7 +10995,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11105,7 +11105,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -11186,7 +11186,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11286,7 +11286,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -11297,7 +11297,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11407,7 +11407,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -11488,7 +11488,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11615,7 +11615,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -11626,7 +11626,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -11736,7 +11736,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -11817,7 +11817,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -11956,7 +11956,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-0",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -11967,7 +11967,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -12077,7 +12077,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-0",
                                         },
                                         "children": Array [
                                           Node {
@@ -12158,7 +12158,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12285,7 +12285,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12296,7 +12296,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -12406,7 +12406,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -12487,7 +12487,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12587,7 +12587,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -12598,7 +12598,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -12708,7 +12708,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -12789,7 +12789,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12916,7 +12916,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -12927,7 +12927,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -13037,7 +13037,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -13118,7 +13118,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -13445,7 +13445,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-1",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -13456,7 +13456,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -13566,7 +13566,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-1",
                                         },
                                         "children": Array [
                                           Node {
@@ -13647,7 +13647,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13774,7 +13774,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -13785,7 +13785,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -13895,7 +13895,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -13976,7 +13976,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -14078,7 +14078,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -14089,7 +14089,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -14199,7 +14199,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -14280,7 +14280,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -14407,7 +14407,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -14418,7 +14418,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -14528,7 +14528,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -14609,7 +14609,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -14946,7 +14946,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -14957,7 +14957,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -15067,7 +15067,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -15148,7 +15148,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -15294,7 +15294,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -15305,7 +15305,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -15415,7 +15415,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -15496,7 +15496,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",

--- a/src/components/Table/Tests/__snapshots__/Table.usecolselectionwithkey.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.usecolselectionwithkey.shot
@@ -77,7 +77,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -88,7 +88,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -198,7 +198,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -279,7 +279,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -418,7 +418,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -429,7 +429,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -539,7 +539,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -620,7 +620,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -744,7 +744,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -755,7 +755,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -865,7 +865,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -946,7 +946,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -1066,7 +1066,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -1077,7 +1077,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1187,7 +1187,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -1268,7 +1268,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1363,7 +1363,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -1374,7 +1374,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1484,7 +1484,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -1565,7 +1565,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1685,7 +1685,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -1696,7 +1696,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-1",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -1806,7 +1806,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -1887,7 +1887,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-1",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -2007,7 +2007,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -2018,7 +2018,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2128,7 +2128,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -2209,7 +2209,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2329,7 +2329,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2340,7 +2340,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2450,7 +2450,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2531,7 +2531,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -2628,7 +2628,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -2639,7 +2639,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -2749,7 +2749,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -2830,7 +2830,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -2950,7 +2950,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -2961,7 +2961,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectCheckBox-0",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -3071,7 +3071,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -3152,7 +3152,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectCheckBox-0",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",
@@ -3307,7 +3307,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectAllCheckBox",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -3318,7 +3318,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3428,7 +3428,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectAllCheckBox",
                                             },
                                             "children": Array [
                                               Node {
@@ -3509,7 +3509,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -3648,7 +3648,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -3659,7 +3659,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -3769,7 +3769,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -3850,7 +3850,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -3974,7 +3974,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -3985,7 +3985,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -4095,7 +4095,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -4176,7 +4176,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -4296,7 +4296,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -4307,7 +4307,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4417,7 +4417,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -4498,7 +4498,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4593,7 +4593,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -4604,7 +4604,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -4714,7 +4714,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -4795,7 +4795,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4915,7 +4915,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -4926,7 +4926,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-1",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -5036,7 +5036,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5117,7 +5117,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-1",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -5237,7 +5237,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -5248,7 +5248,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -5358,7 +5358,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -5439,7 +5439,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -5559,7 +5559,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -5570,7 +5570,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5680,7 +5680,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -5761,7 +5761,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -5858,7 +5858,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -5869,7 +5869,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -5979,7 +5979,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -6060,7 +6060,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6180,7 +6180,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -6191,7 +6191,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectCheckBox-0",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -6301,7 +6301,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -6382,7 +6382,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectCheckBox-0",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -6559,7 +6559,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-0",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -6570,7 +6570,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -6680,7 +6680,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-0",
                                         },
                                         "children": Array [
                                           Node {
@@ -6761,7 +6761,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -6881,7 +6881,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -6892,7 +6892,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -7002,7 +7002,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -7083,7 +7083,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7178,7 +7178,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -7189,7 +7189,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -7299,7 +7299,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -7380,7 +7380,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7500,7 +7500,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -7511,7 +7511,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-1",
                                               },
                                               "children": Array [
                                                 Node {
@@ -7621,7 +7621,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -7702,7 +7702,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-1",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -7822,7 +7822,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-disabled": "false",
-                                          "id": "selectCheckBox",
+                                          "id": "selectCheckBox-1",
                                           "readonly": "",
                                           "type": "checkbox",
                                           "value": "",
@@ -7833,7 +7833,7 @@ LoadedCheerio {
                                         "next": Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -7943,7 +7943,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "",
-                                          "for": "selectCheckBox",
+                                          "for": "selectCheckBox-1",
                                         },
                                         "children": Array [
                                           Node {
@@ -8024,7 +8024,7 @@ LoadedCheerio {
                                         "prev": Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -8144,7 +8144,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-1",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -8155,7 +8155,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-1",
                                             },
                                             "children": Array [
                                               Node {
@@ -8265,7 +8265,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-1",
                                           },
                                           "children": Array [
                                             Node {
@@ -8346,7 +8346,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-1",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -8443,7 +8443,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-disabled": "false",
-                                            "id": "selectCheckBox",
+                                            "id": "selectCheckBox-0",
                                             "readonly": "",
                                             "type": "checkbox",
                                             "value": "",
@@ -8454,7 +8454,7 @@ LoadedCheerio {
                                           "next": Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -8564,7 +8564,7 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "class": "",
-                                            "for": "selectCheckBox",
+                                            "for": "selectCheckBox-0",
                                           },
                                           "children": Array [
                                             Node {
@@ -8645,7 +8645,7 @@ LoadedCheerio {
                                           "prev": Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -8765,7 +8765,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-disabled": "false",
-                                              "id": "selectCheckBox",
+                                              "id": "selectCheckBox-0",
                                               "readonly": "",
                                               "type": "checkbox",
                                               "value": "",
@@ -8776,7 +8776,7 @@ LoadedCheerio {
                                             "next": Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectCheckBox-0",
                                               },
                                               "children": Array [
                                                 Node {
@@ -8886,7 +8886,7 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "class": "",
-                                              "for": "selectCheckBox",
+                                              "for": "selectCheckBox-0",
                                             },
                                             "children": Array [
                                               Node {
@@ -8967,7 +8967,7 @@ LoadedCheerio {
                                             "prev": Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectCheckBox-0",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9097,7 +9097,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "aria-disabled": "false",
-                                                "id": "selectCheckBox",
+                                                "id": "selectAllCheckBox",
                                                 "readonly": "",
                                                 "type": "checkbox",
                                                 "value": "",
@@ -9108,7 +9108,7 @@ LoadedCheerio {
                                               "next": Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -9218,7 +9218,7 @@ LoadedCheerio {
                                             Node {
                                               "attribs": Object {
                                                 "class": "",
-                                                "for": "selectCheckBox",
+                                                "for": "selectAllCheckBox",
                                               },
                                               "children": Array [
                                                 Node {
@@ -9299,7 +9299,7 @@ LoadedCheerio {
                                               "prev": Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -9438,7 +9438,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "aria-disabled": "false",
-                                                  "id": "selectCheckBox",
+                                                  "id": "selectAllCheckBox",
                                                   "readonly": "",
                                                   "type": "checkbox",
                                                   "value": "",
@@ -9449,7 +9449,7 @@ LoadedCheerio {
                                                 "next": Node {
                                                   "attribs": Object {
                                                     "class": "",
-                                                    "for": "selectCheckBox",
+                                                    "for": "selectAllCheckBox",
                                                   },
                                                   "children": Array [
                                                     Node {
@@ -9559,7 +9559,7 @@ LoadedCheerio {
                                               Node {
                                                 "attribs": Object {
                                                   "class": "",
-                                                  "for": "selectCheckBox",
+                                                  "for": "selectAllCheckBox",
                                                 },
                                                 "children": Array [
                                                   Node {
@@ -9640,7 +9640,7 @@ LoadedCheerio {
                                                 "prev": Node {
                                                   "attribs": Object {
                                                     "aria-disabled": "false",
-                                                    "id": "selectCheckBox",
+                                                    "id": "selectAllCheckBox",
                                                     "readonly": "",
                                                     "type": "checkbox",
                                                     "value": "",


### PR DESCRIPTION
## SUMMARY:
Previously, all selectors shared the same id, this change uses the row id to make them more unique to each row, preventing inadvertent select all.

- also removes an unused variable, adds some typings

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/434

## JIRA TASK (Eightfold Employees Only):
ENG-35001

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist (updated snaps)
-   [ ] I have added unittests for this change

## TEST PLAN:
pull the pr branch and run `yarn` and `yarn storybook`. Verify the `Table` `Selection` story behaves as expected.