### PR TITLE
fix: slider: slider track width when isrange and showmarkers false and values intersect

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -439,7 +439,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     ? `${lowerThumbOffset}px`
                     : `${thumbRadius}px`;
             }
-            trackRef.current.style.width = `${rangeWidth - thumbRadius}px`;
+            trackRef.current.style.width = `${rangeWidth}px`;
         };
 
         const [formatValue] = useOffset(
@@ -449,7 +449,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
             markers
         );
 
-        const rawValues = React.useMemo(() => {
+        const rawValues = useMemo(() => {
             const valueList =
                 value === null || value === undefined
                     ? []
@@ -486,7 +486,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
         }, [value, isRange, mergedMin, formatValue]);
 
         const rawValuesRef: React.MutableRefObject<number[]> =
-            React.useRef(rawValues);
+            useRef(rawValues);
         rawValuesRef.current = rawValues;
 
         const markList: SliderMarker[] = useMemo<SliderMarker[]>(() => {


### PR DESCRIPTION
## SUMMARY:
When `Slider` `isRange` is `true`, and `showMarkers` is `false` the track width was incorrect when the lower and upper thumb intersect. This change reverts the calc to be what it was prior to its last change. 

## JIRA TASK (Eightfold Employees Only):
ENG-36842

## CHANGE TYPE:

-   [X] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [X] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Slider` `Range Slider` story behaves as expected when `showMarkers` is both `true` and `false`. Sanity test other stories.