### PR TITLE
fix: added position left on expandable search

### DIFF
--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -1465,6 +1465,7 @@
 
         .expandable-thumb {
             position: absolute;
+            left: 0;
         }
 
         .overlay {


### PR DESCRIPTION
## SUMMARY:
Search expandable thumb position fix
 
## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-36644

## CHANGE TYPE:

-   [x] Bugfix Pull Request
-   [ ] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
N/A