### PR TITLE
feat: add support for autocomplete attribute to TextInput and SearchBox

### DIFF
--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -181,6 +181,11 @@ export interface InputProps<T>
      */
     ariaLabel?: string;
     /**
+     * Indicates the autocomplete attribute value for the input field.
+     * @default undefined
+     */
+    autocomplete?: string;
+    /**
      * The input autoFocus attribute.
      * @default false
      */

--- a/src/components/Inputs/SearchBox/SearchBox.stories.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.stories.tsx
@@ -111,6 +111,9 @@ export default {
         },
     },
     argTypes: {
+        autocomplete: {
+            control: { type: 'text' },
+        },
         inline: {
             options: [true, false],
             control: { type: 'inline-radio' },
@@ -155,6 +158,7 @@ export const Search_Box = Search_Box_Story.bind({});
 Search_Box.args = {
     allowDisabledFocus: false,
     ariaLabel: 'Search',
+    autocomplete: undefined,
     autoFocus: true,
     classNames: 'my-searchbox-class',
     clearButtonAriaLabel: 'Clear',

--- a/src/components/Inputs/SearchBox/SearchBox.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.tsx
@@ -21,6 +21,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
             alignIcon = TextInputIconAlign.Left,
             allowDisabledFocus = false,
             ariaLabel,
+            autocomplete,
             autoFocus = false,
             classNames,
             clearable = true,
@@ -90,6 +91,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
                     clearable={clearable}
                     allowDisabledFocus={allowDisabledFocus}
                     ariaLabel={ariaLabel}
+                    autocomplete={autocomplete}
                     autoFocus={autoFocus}
                     classNames={classNames}
                     clearButtonAriaLabel={clearButtonAriaLabel}

--- a/src/components/Inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/Inputs/TextInput/TextInput.stories.tsx
@@ -101,6 +101,9 @@ export default {
         },
     },
     argTypes: {
+        autocomplete: {
+            control: { type: 'text' },
+        },
         inline: {
             options: [true, false],
             control: { type: 'inline-radio' },
@@ -148,6 +151,7 @@ export const Text_Input = Text_Input_Story.bind({});
 Text_Input.args = {
     allowDisabledFocus: false,
     ariaLabel: 'Sample text',
+    autocomplete: undefined,
     autoFocus: true,
     classNames: 'my-textinput-class',
     clearButtonAriaLabel: 'Clear',

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -34,6 +34,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             alignIcon = TextInputIconAlign.Left,
             allowDisabledFocus = false,
             ariaLabel,
+            autocomplete,
             autoFocus = false,
             classNames,
             clear = false,
@@ -422,6 +423,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
                             ref={ref}
                             aria-disabled={mergedDisabled}
                             aria-label={ariaLabel}
+                            autoComplete={autocomplete}
                             autoFocus={autoFocus}
                             className={textInputClassNames}
                             disabled={!allowDisabledFocus && mergedDisabled}


### PR DESCRIPTION
## SUMMARY:
Add missing support for autocomplete attribute so we can disable this in search circumstances where the autocomplete interferes with custom autocomplete implementations

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

-   [ ] Bugfix Pull Request
-   [x] Feature Pull Request

## TEST COVERAGE:

-   [ ] Tests for this change already exist
-   [ ] I have added unittests for this change

## TEST PLAN:
In Storybook, inspect element in devtools to confirm there is no autocomplete attribute on the element. Add a value "off" and observe that the attribute and value are added to the Input as expected