### PR TITLE
fix: update git-blame-ignore-revs to correct commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,6 +1,2 @@
-# To leverage this file and skip commits marked for ignore by git blame,
-# use command `git config blame.ignoreRevsFile .git-blame-ignore-revs`
-# to configure git to skip the below commits.
-
 # Moving to two space indent
-a558d293574f84d0bffcd37e652b50b32798cd22
+2b2c5710fe8160604ef78fa3bc1a1f3752e5e255

--- a/src/CONTRIBUTING.md
+++ b/src/CONTRIBUTING.md
@@ -47,7 +47,6 @@ One-time setup activities to start contributing:
 - Choose a local folder for the cloned files
 - Clone the repository to your local machine
 - Configure the upstream remote value
-- Configure git to ignore specified commits via `git config blame.ignoreRevsFile .git-blame-ignore-revs`
 
 ### Overview
 


### PR DESCRIPTION
## SUMMARY:
Squash and commit changed the commit hash referenced on previous 2 space indent. Also removing added line from CONTRIBUTING.md as the command update .git/config

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
No functional library changes