### PR TITLE
fix: only generate a unique id once

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,6 @@
 import React, {
   cloneElement,
   FC,
-  Ref,
   SyntheticEvent,
   useEffect,
   useImperativeHandle,
@@ -70,7 +69,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
       });
 
       const [closing, setClosing] = useState<boolean>(false);
-      const [dropdownId] = useState<string>(uniqueId('dropdown-'));
+      const dropdownId: string = uniqueId('dropdown-');
 
       let timeout: ReturnType<typeof setTimeout>;
       const { x, y, reference, floating, strategy, update, refs } = useFloating(

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -71,7 +71,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
 
     const htmlDir: string = useCanvasDirection();
 
-    const [textAreaId] = useState<string>(uniqueId(id || 'textarea-'));
+    const textAreaId: string = uniqueId(id || 'textarea-');
     const [inputValue, setInputValue] = useState(value);
 
     const {

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -88,7 +88,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
     const [inputValue, setInputValue] = useState(value);
 
     const [clearButtonShown, _setClearButtonShown] = useState<boolean>(false);
-    const [inputId] = useState<string>(uniqueId(id || 'input-'));
+    const inputId: string = uniqueId(id || 'input-');
 
     const clearButtonRef: React.MutableRefObject<HTMLButtonElement> =
       useRef<HTMLButtonElement>(null);

--- a/src/shared/utilities/uniqueId.ts
+++ b/src/shared/utilities/uniqueId.ts
@@ -1,8 +1,10 @@
+import { useMemo } from 'react';
 /**
  * Generates a simple unique id
  * @param prefix The sting prefix
  */
 export const uniqueId = ((): ((prefix: string) => string) => {
   let counter: number = 0;
-  return (prefix: string): string => `${prefix}${++counter}`;
+  return (prefix: string): string =>
+    useMemo(() => `${prefix}${++counter}`, [prefix]);
 })();


### PR DESCRIPTION
## SUMMARY:
This fixes a new unique Id being generated on every render

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Before: 

https://user-images.githubusercontent.com/95337653/208393928-9ebc0fa3-6a86-409e-8c66-c7ad8ae7fe8f.mov

After:

https://user-images.githubusercontent.com/95337653/208394228-66dd376d-efd6-4a07-9c61-f9afd8318d89.mov

