### PR TITLE
feat: make focus highlighting varTheme friendly

### DIFF
--- a/src/components/Accordion/accordion.module.scss
+++ b/src/components/Accordion/accordion.module.scss
@@ -118,7 +118,7 @@
     .accordion-summary {
       &.focus-visible,
       &:focus-visible {
-        border: 2px solid $focus-visible-shadow-color;
+        border: 2px solid var(--focus-visible-shadow-color);
         border-radius: $border-radius-xl;
         padding: calc(#{$space-l} - 2px);
 

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -711,10 +711,10 @@
   .button {
     &.focus-visible,
     &:focus-visible {
-      box-shadow: $focus-visible-box-shadow;
+      box-shadow: var(--focus-visible-box-shadow);
 
       &.drop-shadow {
-        box-shadow: $focus-visible-box-shadow, $shadow-object-s;
+        box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;
       }
 
       .counter {
@@ -750,7 +750,7 @@
         background-color: var(--grey-color-10);
 
         &.drop-shadow {
-          box-shadow: $focus-visible-box-shadow, $shadow-object-s;
+          box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;
         }
       }
     }
@@ -761,7 +761,7 @@
         background-color: var(--background-color);
 
         &.drop-shadow {
-          box-shadow: $focus-visible-box-shadow, $shadow-object-s;
+          box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;
         }
       }
     }

--- a/src/components/DateTimePicker/Internal/ocpicker.module.scss
+++ b/src/components/DateTimePicker/Internal/ocpicker.module.scss
@@ -74,7 +74,7 @@
   }
 
   &-focused:not(.picker-disabled):not(.picker-underline):not(.picker-borderless) {
-    border-color: $focus-visible-shadow-color;
+    border-color: var(--focus-visible-shadow-color);
   }
 
   &-disabled {
@@ -95,7 +95,7 @@
     box-shadow: $picker-box-shadow;
 
     &-focused {
-      border-color: $focus-visible-shadow-color;
+      border-color: var(--focus-visible-shadow-color);
     }
   }
 
@@ -1627,13 +1627,13 @@
   .picker {
     &-focused {
       border-color: transparent;
-      box-shadow: $focus-visible-box-shadow;
+      box-shadow: var(--focus-visible-box-shadow);
     }
 
     &-partial {
       &-focused {
         border-color: transparent;
-        box-shadow: $focus-visible-box-shadow, $picker-box-shadow;
+        box-shadow: var(--focus-visible-box-shadow), $picker-box-shadow;
       }
     }
   }

--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -346,7 +346,7 @@
     }
 
     &:focus {
-      border-color: $focus-visible-shadow-color;
+      border-color: var(--focus-visible-shadow-color);
       transition: border-color $motion-duration-extra-fast
         $motion-easing-easeinout;
 
@@ -986,7 +986,7 @@
     }
 
     &:focus:not(.underline) {
-      border-color: $focus-visible-shadow-color;
+      border-color: var(--focus-visible-shadow-color);
       transition: border-color $motion-duration-extra-fast
         $motion-easing-easeinout;
     }
@@ -1540,7 +1540,7 @@
       &.focus-visible,
       &:focus-visible {
         border-color: var(--background-color);
-        box-shadow: $focus-visible-box-shadow;
+        box-shadow: var(--focus-visible-box-shadow);
 
         &.underline {
           border-color: transparent;
@@ -1553,7 +1553,7 @@
       .input-group,
       .text-area-group {
         &:after {
-          border-bottom-color: $focus-visible-shadow-color;
+          border-bottom-color: var(--focus-visible-shadow-color);
           border-bottom-width: $space-xxxs;
         }
       }
@@ -1574,7 +1574,7 @@
       &.focus-visible,
       &:focus-visible {
         background-color: transparent;
-        box-shadow: $focus-visible-box-shadow;
+        box-shadow: var(--focus-visible-box-shadow);
 
         svg {
           color: var(--grey-color-80);
@@ -1586,7 +1586,7 @@
       &.focus-visible,
       &:focus-visible {
         border-color: var(--background-color);
-        box-shadow: $focus-visible-box-shadow;
+        box-shadow: var(--focus-visible-box-shadow);
 
         &.underline {
           border-color: transparent;

--- a/src/components/Link/link.module.scss
+++ b/src/components/Link/link.module.scss
@@ -23,7 +23,7 @@
   .link-style {
     &.focus-visible,
     &:focus-visible {
-      box-shadow: $focus-visible-box-shadow;
+      box-shadow: var(--focus-visible-box-shadow);
     }
   }
 }

--- a/src/components/Table/Styles/table.module.scss
+++ b/src/components/Table/Styles/table.module.scss
@@ -745,7 +745,7 @@
       &-row-expand-icon {
         &.focus-visible,
         &:focus-visible {
-          box-shadow: $focus-visible-box-shadow;
+          box-shadow: var(--focus-visible-box-shadow);
         }
       }
     }

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -507,7 +507,7 @@
     .tab {
       &.focus-visible,
       &:focus-visible {
-        box-shadow: $focus-visible-box-shadow;
+        box-shadow: var(--focus-visible-box-shadow);
       }
     }
   }

--- a/src/components/Upload/upload.module.scss
+++ b/src/components/Upload/upload.module.scss
@@ -1018,10 +1018,10 @@ $upload-picture-card-size: 104px;
       a {
         &.focus-visible,
         &:focus-visible {
-          box-shadow: $focus-visible-box-shadow;
+          box-shadow: var(--focus-visible-box-shadow);
 
           &.drop-shadow {
-            box-shadow: $focus-visible-box-shadow, $shadow-object-s;
+            box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;
           }
         }
       }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -185,6 +185,11 @@
 
   --anchor-color: var(--primary-color-70);
 
+  --focus-visible-shadow-color: var(--blueviolet-color-50);
+  --focus-visible-shadow-width: 2px;
+  --focus-visible-box-shadow: 0 0 0 var(--focus-visible-shadow-width)
+    var(--focus-visible-shadow-color);
+
   --border-radius-xs: 2px;
   --border-radius-s: 4px;
   --border-radius-m: 8px;

--- a/src/styles/themes/_definitions.scss
+++ b/src/styles/themes/_definitions.scss
@@ -110,13 +110,6 @@ $shadow-panel-right: -1px 0px 2px rgba(15, 20, 31, 0.12),
   -8px 0px 32px rgba(15, 20, 31, 0.16);
 $shadow-panel-behind: 0px -4px 16px rgba(0, 0, 0, 0.12);
 
-// Focus visible Definitions
-
-$focus-visible-shadow-color: var(--blueviolet-color-50);
-$focus-visible-shadow-width: 2px;
-$focus-visible-box-shadow: 0 0 0 $focus-visible-shadow-width
-  $focus-visible-shadow-color;
-
 // Layout
 
 $layout-body-background: var(--background-color);


### PR DESCRIPTION
## SUMMARY:
Makes the standard octuple focus styling varTheme friendly.

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
NA

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Checkout PR locally
2. Startup storybook
3.  Visual inspect focus styling on inputs and buttons to confirm they still work as expected