### PR TITLE
fix: twoStateButton: vertical align counter

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -541,6 +541,7 @@
     flex-direction: column;
 
     .column {
+      align-items: center;
       display: flex;
     }
   }


### PR DESCRIPTION
## SUMMARY:
fix: twoStateButton: vertical align counter

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
