### PR TITLE
fix: input: expandable search overlay zindex

### DIFF
--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -1412,6 +1412,7 @@
   &.isExpandable {
     .expandable-wrapper {
       position: relative;
+      z-index: 1;
     }
 
     .input-group {


### PR DESCRIPTION
## SUMMARY:
Fix for overlay in expandable search

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/109717425/210336556-2523be80-68f7-45aa-a68b-295708ffeef7.png">


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
