### PR TITLE
feat: stack: use flex gap instead of margins

### DIFF
--- a/src/components/Stack/Stack.stories.tsx
+++ b/src/components/Stack/Stack.stories.tsx
@@ -86,7 +86,7 @@ export default {
       options: ['wrap', 'nowrap', 'wrap-reverse'],
       control: { type: 'radio' },
     },
-    gap: {
+    flexGap: {
       options: ['xxxs', 'xxs', 'xs', 's', 'm', 'l', 'xl', 'xxl', 'xxl', 'xxxl'],
       control: { type: 'select' },
     },
@@ -124,7 +124,7 @@ const stackArgs: Object = {
   inline: false,
   align: '',
   wrap: '',
-  gap: '',
+  flexGap: '',
   style: {
     backgroundColor: 'aquamarine',
   },
@@ -159,34 +159,34 @@ const stackArgs: Object = {
 
 Horizontal.args = {
   ...stackArgs,
-  gap: 'm',
+  flexGap: 'm',
 };
 
 Vertical.args = {
   ...stackArgs,
   direction: 'vertical',
-  gap: 'l',
+  flexGap: 'l',
 };
 
 Responsive.args = {
   ...stackArgs,
   direction: 'vertical',
-  gap: 'l',
+  flexGap: 'l',
   breakpoints: {
     xsmall: {
-      gap: 'xxxs',
+      flexGap: 'xxxs',
       direction: 'vertical',
     },
     small: {
-      gap: 's',
+      flexGap: 's',
       direction: 'vertical',
     },
     medium: {
-      gap: 'xl',
+      flexGap: 'xl',
       direction: 'horizontal',
     },
     large: {
-      gap: 'xxxl',
+      flexGap: 'xxxl',
       direction: 'horizontal',
     },
   },
@@ -205,49 +205,49 @@ Sample_Nav_List.args = {
   style: {},
   children: (
     <>
-      <Stack direction="vertical" gap="m" classNames={styles.group}>
+      <Stack direction="vertical" flexGap="m" classNames={styles.group}>
         <h3>Title</h3>
-        <Stack direction="vertical" gap="xs">
+        <Stack direction="vertical" flexGap="xs">
           <p>subheading</p>
           <p>subheading</p>
         </Stack>
       </Stack>
-      <Stack direction="vertical" gap="m" classNames={styles.group}>
+      <Stack direction="vertical" flexGap="m" classNames={styles.group}>
         <h3>Title</h3>
-        <Stack direction="vertical" gap="xs">
-          <p>subheading</p>
-          <p>subheading</p>
-          <p>subheading</p>
-          <p>subheading</p>
-        </Stack>
-      </Stack>
-      <Stack direction="vertical" gap="m" classNames={styles.group}>
-        <h3>Title</h3>
-        <Stack direction="vertical" gap="xs">
-          <p>subheading</p>
-          <p>subheading</p>
-        </Stack>
-      </Stack>
-      <Stack direction="vertical" gap="m" classNames={styles.group}>
-        <h3>Title</h3>
-        <Stack direction="vertical" gap="xs">
-          <p>subheading</p>
-          <p>subheading</p>
-          <p>subheading</p>
-        </Stack>
-      </Stack>
-      <Stack direction="vertical" gap="m" classNames={styles.group}>
-        <h3>Title</h3>
-        <Stack direction="vertical" gap="xs">
+        <Stack direction="vertical" flexGap="xs">
           <p>subheading</p>
           <p>subheading</p>
           <p>subheading</p>
           <p>subheading</p>
         </Stack>
       </Stack>
-      <Stack direction="vertical" gap="m" classNames={styles.group}>
+      <Stack direction="vertical" flexGap="m" classNames={styles.group}>
         <h3>Title</h3>
-        <Stack direction="vertical" gap="xs">
+        <Stack direction="vertical" flexGap="xs">
+          <p>subheading</p>
+          <p>subheading</p>
+        </Stack>
+      </Stack>
+      <Stack direction="vertical" flexGap="m" classNames={styles.group}>
+        <h3>Title</h3>
+        <Stack direction="vertical" flexGap="xs">
+          <p>subheading</p>
+          <p>subheading</p>
+          <p>subheading</p>
+        </Stack>
+      </Stack>
+      <Stack direction="vertical" flexGap="m" classNames={styles.group}>
+        <h3>Title</h3>
+        <Stack direction="vertical" flexGap="xs">
+          <p>subheading</p>
+          <p>subheading</p>
+          <p>subheading</p>
+          <p>subheading</p>
+        </Stack>
+      </Stack>
+      <Stack direction="vertical" flexGap="m" classNames={styles.group}>
+        <h3>Title</h3>
+        <Stack direction="vertical" flexGap="xs">
           <p>subheading</p>
           <p>subheading</p>
           <p>subheading</p>

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,10 +1,11 @@
 import React, { FC, Ref } from 'react';
-import styles from './stack.module.scss';
 import { mergeClasses } from '../../shared/utilities';
 import { StackBreakpoint, StackProps } from './Stack.types';
 import { useMatchMedia } from '../../octuple';
 import { Breakpoints } from '../../hooks/useMatchMedia';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
+
+import styles from './stack.module.scss';
 
 export const Stack: FC<StackProps> = React.forwardRef(
   (
@@ -16,6 +17,7 @@ export const Stack: FC<StackProps> = React.forwardRef(
       align: defaultAlign,
       wrap: defaultWrap,
       gap: defaultGap,
+      flexGap: defaultFlexGap,
       style = {},
       classNames,
       breakpoints = {},
@@ -59,11 +61,12 @@ export const Stack: FC<StackProps> = React.forwardRef(
         align: defaultAlign,
         wrap: defaultWrap,
         gap: defaultGap,
+        flexGap: defaultFlexGap,
       },
       ...(activeBreakPointStackProps || {}),
     };
 
-    const { fullWidth, direction, justify, inline, align, wrap, gap } =
+    const { fullWidth, direction, justify, inline, align, wrap, gap, flexGap } =
       resolvedStackIntrinsicProps;
 
     const stackClassName: string = mergeClasses([
@@ -75,6 +78,7 @@ export const Stack: FC<StackProps> = React.forwardRef(
       { [styles.horizontal]: direction === 'horizontal' },
       { [styles.stackRtl]: htmlDir === 'rtl' },
       styles[gap],
+      styles[`gap-${flexGap}`],
     ]);
 
     return (

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -78,7 +78,7 @@ export const Stack: FC<StackProps> = React.forwardRef(
       { [styles.horizontal]: direction === 'horizontal' },
       { [styles.stackRtl]: htmlDir === 'rtl' },
       styles[gap],
-      styles[`gap-${flexGap}`],
+      { [styles[`gap-${flexGap}`]]: flexGap },
     ]);
 
     return (

--- a/src/components/Stack/Stack.types.ts
+++ b/src/components/Stack/Stack.types.ts
@@ -12,7 +12,6 @@ export type StackGap =
   | 'l'
   | 'xl'
   | 'xxl'
-  | 'xxl'
   | 'xxxl';
 
 type StackIntrinsicProps = {
@@ -36,9 +35,14 @@ type StackIntrinsicProps = {
    */
   fullWidth?: boolean;
   /**
+   * @deprecated Use flex gap instead
    * Space between the child elements
    */
   gap?: StackGap;
+  /**
+   * Flex gap between child elements
+   */
+  flexGap?: StackGap;
   /**
    * Enable stack as an inline element
    */

--- a/src/components/Stack/stack.module.scss
+++ b/src/components/Stack/stack.module.scss
@@ -10,56 +10,33 @@
     width: 100%;
   }
 
+  $gap-space-map: (
+    xxxs: $space-xxxs,
+    xxs: $space-xxs,
+    xs: $space-xs,
+    s: $space-s,
+    m: $space-m,
+    ml: $space-ml,
+    l: $space-l,
+    xl: $space-xl,
+    xxl: $space-xxl,
+    xxxl: $space-xxxl,
+  );
+
+  @each $gap-name, $size-value in $gap-space-map {
+    &.gap-#{$gap-name} {
+      gap: $size-value;
+    }
+  }
+
   &.vertical {
     flex-direction: column;
-    &.xxxl {
-      > * + * {
-        margin-top: $space-xxxl;
-      }
-    }
-    &.xxl {
-      > * + * {
-        margin-top: $space-xxl;
-      }
-    }
-    &.xl {
-      > * + * {
-        margin-top: $space-xl;
-      }
-    }
-    &.l {
-      > * + * {
-        margin-top: $space-l;
-      }
-    }
-    &.ml {
-      > * + * {
-        margin-top: $space-ml;
-      }
-    }
-    &.m {
-      > * + * {
-        margin-top: $space-m;
-      }
-    }
-    &.s {
-      > * + * {
-        margin-top: $space-s;
-      }
-    }
-    &.xs {
-      > * + * {
-        margin-top: $space-xs;
-      }
-    }
-    &.xxs {
-      > * + * {
-        margin-top: $space-xxs;
-      }
-    }
-    &.xxxs {
-      > * + * {
-        margin-top: $space-xxxs;
+
+    @each $gap-name, $size-value in $gap-space-map {
+      &.#{$gap-name} {
+        > * + * {
+          margin-top: $size-value;
+        }
       }
     }
   }
@@ -67,118 +44,23 @@
   &.horizontal {
     flex-direction: row;
 
-    &.xxxl {
-      > * + * {
-        margin-left: $space-xxxl;
-      }
-    }
-    &.xxl {
-      > * + * {
-        margin-left: $space-xxl;
-      }
-    }
-    &.xl {
-      > * + * {
-        margin-left: $space-xl;
-      }
-    }
-    &.l {
-      > * + * {
-        margin-left: $space-l;
-      }
-    }
-    &.m {
-      > * + * {
-        margin-left: $space-m;
-      }
-    }
-    &.ml {
-      > * + * {
-        margin-left: $space-ml;
-      }
-    }
-    &.s {
-      > * + * {
-        margin-left: $space-s;
-      }
-    }
-    &.xs {
-      > * + * {
-        margin-left: $space-xs;
-      }
-    }
-    &.xxs {
-      > * + * {
-        margin-left: $space-xxs;
-      }
-    }
-    &.xxxs {
-      > * + * {
-        margin-left: $space-xxxs;
+    @each $gap-name, $size-value in $gap-space-map {
+      &.#{$gap-name} {
+        > * + * {
+          margin-left: $size-value;
+        }
       }
     }
   }
 
   &-rtl {
     &.horizontal {
-      &.xxxl {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-xxxl;
-        }
-      }
-      &.xxl {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-xxl;
-        }
-      }
-      &.xl {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-xl;
-        }
-      }
-      &.l {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-l;
-        }
-      }
-      &.m {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-m;
-        }
-      }
-      &.ml {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-ml;
-        }
-      }
-      &.s {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-s;
-        }
-      }
-      &.xs {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-xs;
-        }
-      }
-      &.xxs {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-xxs;
-        }
-      }
-      &.xxxs {
-        > * + * {
-          margin-left: unset;
-          margin-right: $space-xxxs;
+      @each $gap-name, $size-value in $gap-space-map {
+        &.#{$gap-name} {
+          > * + * {
+            margin-left: unset;
+            margin-right: $size-value;
+          }
         }
       }
     }


### PR DESCRIPTION
## SUMMARY:
feat: stack: use flex gap instead of margins

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
