### PR TITLE
fix: label: exposes all tooltip props and fixes hover pixel shift

### DIFF
--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -80,8 +80,11 @@ Default_Info_Button.args = {
   size: LabelSize.Medium,
   labelIconButtonProps: {
     show: true,
-    toolTipContent: 'A tooltip',
-    toolTipPlacement: 'right',
+    tooltipprops: {
+      content: 'A tooltip',
+      placement: 'right',
+      portal: true,
+    },
     onClick: () => _alertClicked(),
   },
   classNames: 'my-label-class',

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -80,7 +80,7 @@ Default_Info_Button.args = {
   size: LabelSize.Medium,
   labelIconButtonProps: {
     show: true,
-    tooltipprops: {
+    tooltipProps: {
       content: 'A tooltip',
       placement: 'right',
       portal: true,

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -96,7 +96,7 @@ export const Label: FC<LabelProps> = ({
             placement={labelIconButtonProps?.toolTipPlacement || 'top'}
             positionStrategy={labelIconButtonProps?.toolTipPositionStrategy}
             theme={labelIconButtonProps?.toolTipTheme}
-            {...labelIconButtonProps.tooltipprops}
+            {...labelIconButtonProps.tooltipProps}
           >
             <DefaultButton
               classNames={styles.labelIconButton}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -96,6 +96,7 @@ export const Label: FC<LabelProps> = ({
             placement={labelIconButtonProps?.toolTipPlacement || 'top'}
             positionStrategy={labelIconButtonProps?.toolTipPositionStrategy}
             theme={labelIconButtonProps?.toolTipTheme}
+            {...labelIconButtonProps.tooltipprops}
           >
             <DefaultButton
               classNames={styles.labelIconButton}

--- a/src/components/Label/Label.types.ts
+++ b/src/components/Label/Label.types.ts
@@ -21,30 +21,30 @@ export interface LabelIconButtonProps extends ButtonProps {
    * The tooltip props.
    * @default false
    */
-  tooltipprops?: TooltipProps;
+  tooltipProps?: TooltipProps;
   /**
    * Unique id used to target element for testing.
    */
   'data-test-id'?: string;
   /**
-   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * @deprecated Use labelIconButtonProps.tooltipProps instead.
    * Content to show on the tooltip.
    */
   toolTipContent?: React.ReactNode;
   /**
-   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * @deprecated Use labelIconButtonProps.tooltipProps instead.
    * Placement of the tooltip.
    * @default top
    */
   toolTipPlacement?: Placement;
   /**
-   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * @deprecated Use labelIconButtonProps.tooltipProps instead.
    * Positioning strategy for the tooltip.
    * @default absolute
    */
   toolTipPositionStrategy?: Strategy;
   /**
-   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * @deprecated Use labelIconButtonProps.tooltipProps instead.
    * Theme of the tooltip.
    * @default light
    */

--- a/src/components/Label/Label.types.ts
+++ b/src/components/Label/Label.types.ts
@@ -1,6 +1,6 @@
 import { ButtonProps } from '../Button';
 import { Placement, Strategy } from '@floating-ui/react-dom';
-import { TooltipTheme } from '../Tooltip';
+import { TooltipTheme, TooltipProps } from '../Tooltip';
 import { OcBaseProps } from '../OcBase';
 import { Size } from '../ConfigProvider';
 
@@ -13,33 +13,42 @@ export enum LabelSize {
 
 export interface LabelIconButtonProps extends ButtonProps {
   /**
-   * The label icon button is shown
+   * The label icon button is shown.
    * @default false
    */
   show?: boolean;
   /**
-   * Content to show on the tooltip
+   * The tooltip props.
+   * @default false
+   */
+  tooltipprops?: TooltipProps;
+  /**
+   * Unique id used to target element for testing.
+   */
+  'data-test-id'?: string;
+  /**
+   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * Content to show on the tooltip.
    */
   toolTipContent?: React.ReactNode;
   /**
-   * Placement of the tooltip
+   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * Placement of the tooltip.
    * @default top
    */
   toolTipPlacement?: Placement;
   /**
-   * Positioning strategy for the tooltip
+   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * Positioning strategy for the tooltip.
    * @default absolute
    */
   toolTipPositionStrategy?: Strategy;
   /**
-   * Theme of the tooltip
+   * @deprecated Use labelIconButtonProps.tooltipprops instead.
+   * Theme of the tooltip.
    * @default light
    */
   toolTipTheme?: TooltipTheme;
-  /**
-   * Unique id used to target element for testing
-   */
-  'data-test-id'?: string;
 }
 
 export interface LabelProps extends OcBaseProps<HTMLDivElement> {

--- a/src/components/Label/label.module.scss
+++ b/src/components/Label/label.module.scss
@@ -82,7 +82,7 @@
 
   .label-icon-button {
     box-sizing: border-box;
-    border-width: 1px;
+    border-width: var(--button-default-border-width);
   }
 }
 


### PR DESCRIPTION
## SUMMARY:
Exposes all tooltip props via `labelIconButtonProps.tooltipprops`, marks others as deprecated in `labelIconButtonProps`.

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/473

## JIRA TASK (Eightfold Employees Only):
ENG-39123

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Label` stories behave as expected.