### PR TITLE
feat: stat tabs: enable stat themes by validation status

### DIFF
--- a/src/components/Tabs/Stat/Stat.tsx
+++ b/src/components/Tabs/Stat/Stat.tsx
@@ -24,6 +24,7 @@ export const Stat: FC<StatProps> = React.forwardRef(
       ratioA,
       ratioB,
       size = TabSize.Medium,
+      status,
       theme,
       value,
       ...rest
@@ -49,6 +50,9 @@ export const Stat: FC<StatProps> = React.forwardRef(
       {
         [styles.readOnly]: !!readOnly,
         [styles.active]: isActive && !readOnly,
+        [styles.statusSuccess]: status === 'success',
+        [styles.statusWarning]: status === 'warning',
+        [styles.statusError]: status === 'error',
         [styles.tabRtl]: htmlDir === 'rtl',
       },
       classNames,

--- a/src/components/Tabs/StatTabs.stories.tsx
+++ b/src/components/Tabs/StatTabs.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Stat, StatThemeNames, Tabs, TabSize, TabVariant } from './';
+import type { StatValidationStatus } from './';
 import { IconName } from '../Icon';
 
 export default {
@@ -90,6 +91,7 @@ const statTabs = [1, 2, 3, 4].map((i) => ({
   label: `Label ${i}`,
   ratioA: 2,
   ratioB: '(5%)',
+  status: i === 3 ? ('success' as StatValidationStatus) : null,
   value: `tab${i}`,
   ...(i === 4 ? { disabled: true } : {}),
 }));
@@ -100,6 +102,7 @@ const statTabsThemed = [1, 2, 3, 4].map((i) => ({
   label: `Label ${i}`,
   ratioA: 2,
   ratioB: '(5%)',
+  status: i === 3 ? ('success' as StatValidationStatus) : null,
   value: `tab${i}`,
   ...(i === 2 ? { theme: themes[8] } : {}),
   ...(i === 4 ? { disabled: true } : {}),

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -4,6 +4,7 @@ import { IconName } from '../Icon';
 import { OcBaseProps } from '../OcBase';
 import { Ref } from 'react';
 import { Value } from '../ConfigProvider';
+import { InputStatus } from '../../shared/utilities';
 
 export type SelectTabEvent<E = HTMLElement> =
   | React.MouseEvent<E>
@@ -33,6 +34,7 @@ export enum TabVariant {
 }
 
 export type StatThemeNames = OcThemeNames;
+export type StatValidationStatus = InputStatus;
 
 export interface TabsContextProps {
   /**
@@ -143,6 +145,10 @@ export interface StatProps extends Omit<TabProps, 'badgeContent'> {
    * The stat tab 'b' ratio value, e.g. 1/[2].
    */
   ratioB?: string | number;
+  /**
+   * the validation status.
+   */
+  status?: StatValidationStatus;
   /**
    * Theme of the stat tab.
    */

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -255,7 +255,7 @@
     }
 
     .tab {
-      --active-border: var(stat-tab-active-border-color);
+      --active-border: var(--stat-tab-active-border-color);
       --bg: var(--stat-tab-background-color);
       --border: var(--stat-tab-border-color);
       --border-radius: var(--stat-tab-border-radius);
@@ -435,6 +435,39 @@
         --icon-bg: var(--grey-color-20);
         --hover-bg: var(--grey-color-20);
         --hover-border: var(--grey-color-20);
+      }
+
+      &.status-error {
+        --active-border: var(--error-border-color);
+        --bg: var(--white-color);
+        --border: var(--white-color);
+        --icon: var(--error-color);
+        --icon-bg: var(--error-background-color);
+        --hover-bg: var(--error-background-color);
+        --hover-border: var(--error-border-color);
+        --label: var(--error-color);
+      }
+
+      &.status-success {
+        --active-border: var(--success-border-color);
+        --bg: var(--white-color);
+        --border: var(--white-color);
+        --icon: var(--success-color);
+        --icon-bg: var(--success-background-color);
+        --hover-bg: var(--success-background-color);
+        --hover-border: var(--success-border-color);
+        --label: var(--success-color);
+      }
+
+      &.status-warning {
+        --active-border: var(--warning-border-color);
+        --bg: var(--white-color);
+        --border: var(--white-color);
+        --icon: var(--warning-color);
+        --icon-bg: var(--warning-background-color);
+        --hover-bg: var(--warning-background-color);
+        --hover-border: var(--warning-border-color);
+        --label: var(--warning-color);
       }
 
       &.read-only {

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -110,7 +110,14 @@ import { Spinner, SpinnerSize } from './components/Spinner';
 
 import { Stack } from './components/Stack';
 
-import { Stat, Tabs, Tab, TabSize, TabVariant } from './components/Tabs';
+import {
+  Stat,
+  StatValidationStatus,
+  Tabs,
+  Tab,
+  TabSize,
+  TabVariant,
+} from './components/Tabs';
 
 import TimePicker from './components/DateTimePicker/TimePicker/TimePicker';
 
@@ -274,6 +281,7 @@ export {
   SpinnerSize,
   Stack,
   Stat,
+  StatValidationStatus,
   SystemUIButton,
   Table,
   TablePaginationConfig,

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -171,8 +171,14 @@
   --text-tertiary-color: #69717f;
   --text-inverse-color: #fff;
   --success-color: #2b715f;
+  --success-background-color: #b9f4e4;
+  --success-border-color: #3d8f79;
   --warning-color: #9d6309;
+  --warning-background-color: #ffe3b0;
+  --warning-border-color: #c97e19;
   --error-color: #993838;
+  --error-background-color: #ffc6c6;
+  --error-border-color: #c15151;
   --info-color: #4f5666;
   --white-color: #fff;
   --black-color: #000;


### PR DESCRIPTION
## SUMMARY:
Enables validation status theming for individual stats, e.g. `error`, `success`, `warning`.
Fixes css variable typo that caused `Stat` borders not to render.


https://user-images.githubusercontent.com/99700808/210459828-b0698bee-7731-4408-bf23-572f291c94f9.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-34522

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch, run `yarn` and `yarn storybook`. Verify `Stat Tabs` stories behave as expected.

[ENG-34522]: https://eightfoldai.atlassian.net/browse/ENG-34522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ