### PR TITLE
fix: carousel: limit auto scroll to x axis only

### DIFF
--- a/src/components/Carousel/carousel.module.scss
+++ b/src/components/Carousel/carousel.module.scss
@@ -114,7 +114,8 @@
       height: max-content;
       list-style: none;
       margin: 0;
-      overflow: auto;
+      overflow: hidden;
+      overflow-x: auto;
       padding: 0;
       position: relative;
       scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
## SUMMARY:
limit carousel auto scroll to x axis, potential fix for the below issue.

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/466

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

CSS only

## TEST PLAN:
Pull the pr branch and run `yarn` and `yarn storybook`. Verify the `Carousel` stories behave as expected.