### PR TITLE
fix: watch extra item width, padding and line to show for useMaxVisibleSections hook

### DIFF
--- a/src/hooks/useMaxVisibleSections.ts
+++ b/src/hooks/useMaxVisibleSections.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export const useMaxVisibleSections = (
   containerRef: React.MutableRefObject<HTMLElement>,
@@ -54,7 +54,7 @@ export const useMaxVisibleSections = (
     }
     computeVisibleSections();
     return () => {};
-  }, [itemsRef, itemsLength]);
+  }, [itemsRef, itemsLength, extraItemWidth, itemPadding, linesToShow]);
 
   useEffect(() => {
     if (!containerRef.current) {


### PR DESCRIPTION
## SUMMARY:
fix: watch extra item width, padding and line to show for useMaxVisibleSections hook

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
