### PR TITLE
fix: configprovider: export OcThemeNames from a better location, rename to OcThemeName

### DIFF
--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -1,5 +1,5 @@
 import React, { ReactNode, Ref } from 'react';
-import { OcThemeNames } from '../ConfigProvider';
+import { OcThemeName } from '../ConfigProvider';
 import { IconProps } from '../Icon';
 import { ListProps } from '../List';
 import { TooltipProps } from '../Tooltip';
@@ -33,7 +33,7 @@ interface BaseAvatarProps extends OcBaseProps<HTMLSpanElement> {
    * theme of the fallback avatar
    * @default ''
    */
-  theme?: OcThemeNames;
+  theme?: OcThemeName;
   /**
    * Type of avatar style
    * @default 'square'

--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -14,7 +14,7 @@ import { CompactPicker } from 'react-color';
 import {
   ConfigProvider,
   FontOptions,
-  OcThemeNames,
+  OcThemeName,
   ThemeOptions,
   useConfig,
 } from './';
@@ -65,7 +65,7 @@ const ThemedComponents: FC = () => {
   const [customAccentColor, setCustomAccentColor] = useState<string>('');
   const { fontOptions, setFontOptions } = useConfig();
   const { themeOptions, setThemeOptions } = useConfig();
-  const themes: OcThemeNames[] = [
+  const themes: OcThemeName[] = [
     'red',
     'redOrange',
     'orange',
@@ -122,7 +122,7 @@ const ThemedComponents: FC = () => {
             value={themeOptions.name}
             onChange={(e) => {
               setThemeOptions({
-                name: e.target.value as OcThemeNames,
+                name: e.target.value as OcThemeName,
               });
             }}
             style={{ fontSize: '1rem' }}

--- a/src/components/ConfigProvider/Theming/Theming.types.ts
+++ b/src/components/ConfigProvider/Theming/Theming.types.ts
@@ -5,7 +5,7 @@ export type Value = string;
 
 export type OcCustomThemeName = string;
 
-export type OcThemeNames =
+export type OcThemeName =
   | 'red'
   | 'redOrange'
   | 'orange'
@@ -19,7 +19,7 @@ export type OcThemeNames =
   | 'violetRed'
   | 'grey';
 
-export type ThemeName = OcThemeNames | OcCustomThemeName;
+export type ThemeName = OcThemeName | OcCustomThemeName;
 
 /**
  * Used to theme based purely on css var overrides.
@@ -48,7 +48,7 @@ export interface OcBaseTheme {
 export interface OcTheme extends OcBaseTheme {
   /**
    * Name of accent theme.
-   * @type {OcCustomThemeName|OcThemeNames}
+   * @type {OcCustomThemeName|OcThemeName}
    * @default blueGreen
    */
   accentName?: ThemeName;
@@ -61,7 +61,7 @@ export interface OcTheme extends OcBaseTheme {
 export interface ThemeOptions {
   /**
    * Name of the theme.
-   * @type {OcCustomThemeName|OcThemeNames}
+   * @type {OcCustomThemeName|OcThemeName}
    * @default blue
    */
   name?: ThemeName;

--- a/src/components/ConfigProvider/Theming/styleGenerator.ts
+++ b/src/components/ConfigProvider/Theming/styleGenerator.ts
@@ -8,7 +8,7 @@ import {
   IGetStyle,
   IRegisterTheme,
   OcTheme,
-  OcThemeNames,
+  OcThemeName,
   ThemeName,
   ThemeOptions,
   Variables,
@@ -52,12 +52,12 @@ export function getStyle(themeOptions: ThemeOptions): IGetStyle {
 
   const theme: OcTheme = {
     ...themeDefaults,
-    ...OcThemes?.[themeName as OcThemeNames],
+    ...OcThemes?.[themeName as OcThemeName],
     ...themeOptions.customTheme,
   };
 
   const accentTheme: OcTheme = {
-    ...OcThemes?.[theme.accentName as OcThemeNames],
+    ...OcThemes?.[theme.accentName as OcThemeName],
   };
 
   // ================ Use existing primary palette ================

--- a/src/components/ConfigProvider/Theming/themes.ts
+++ b/src/components/ConfigProvider/Theming/themes.ts
@@ -1,4 +1,4 @@
-import { OcBaseTheme, OcTheme, OcThemeNames } from './Theming.types';
+import { OcBaseTheme, OcTheme, OcThemeName } from './Theming.types';
 
 export const themeDefaults: OcBaseTheme = {
   textColor: '#1A212E',
@@ -248,7 +248,7 @@ export const grey: OcTheme = {
   ],
 };
 
-const themes: Record<OcThemeNames, OcTheme> = {
+const themes: Record<OcThemeName, OcTheme> = {
   red,
   redOrange,
   orange,

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Pill, PillSize, PillType } from './';
-import { OcThemeNames } from '../ConfigProvider';
+import { OcThemeName } from '../ConfigProvider';
 import { IconName } from '../Icon';
 import { Stack } from '../Stack';
 
@@ -51,7 +51,7 @@ export default {
   },
 } as ComponentMeta<typeof Pill>;
 
-const themes: OcThemeNames[] = [
+const themes: OcThemeName[] = [
   'red',
   'redOrange',
   'orange',

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IconProps } from '../Icon';
-import { OcThemeNames } from '../ConfigProvider';
+import { OcThemeName } from '../ConfigProvider';
 import { ButtonProps } from '../Button';
 import { OcBaseProps } from '../OcBase';
 import { ConfigContextProps } from '../ConfigProvider';
@@ -83,7 +83,7 @@ export interface PillProps extends OcBaseProps<HTMLElement> {
    * Theme of the pill
    * @default blue
    */
-  theme?: OcThemeNames;
+  theme?: OcThemeName;
   /**
    * Type of the pill
    * @default PillType.default

--- a/src/components/Tabs/Stat/Stat.tsx
+++ b/src/components/Tabs/Stat/Stat.tsx
@@ -1,5 +1,5 @@
 import React, { FC, Ref } from 'react';
-import { StatProps, StatThemeNames, TabSize } from '../Tabs.types';
+import { StatProps, StatThemeName, TabSize } from '../Tabs.types';
 import { useTabs } from '../Tabs.context';
 import { Icon } from '../../Icon';
 import { Loader } from '../../Loader';
@@ -36,7 +36,7 @@ export const Stat: FC<StatProps> = React.forwardRef(
     const { currentActiveTab, statgrouptheme, readOnly, onTabClick } =
       useTabs();
 
-    const mergedTheme: StatThemeNames = theme ?? statgrouptheme;
+    const mergedTheme: StatThemeName = theme ?? statgrouptheme;
 
     const iconExists: boolean = !!icon;
     const labelExists: boolean = !!label;

--- a/src/components/Tabs/StatTabs.stories.tsx
+++ b/src/components/Tabs/StatTabs.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Stat, StatThemeNames, Tabs, TabSize, TabVariant } from './';
+import { Stat, StatThemeName, Tabs, TabSize, TabVariant } from './';
 import type { StatValidationStatus } from './';
 import { IconName } from '../Icon';
 
@@ -70,7 +70,7 @@ export default {
   },
 } as ComponentMeta<typeof Tabs>;
 
-const themes: StatThemeNames[] = [
+const themes: StatThemeName[] = [
   'red',
   'redOrange',
   'orange',

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { OcThemeNames } from '../ConfigProvider';
+import { OcThemeName } from '../ConfigProvider';
 import { IconName } from '../Icon';
 import { OcBaseProps } from '../OcBase';
 import { Ref } from 'react';
@@ -33,7 +33,7 @@ export enum TabVariant {
   small = 'small',
 }
 
-export type StatThemeNames = OcThemeNames;
+export type StatThemeName = OcThemeName;
 export type StatValidationStatus = InputStatus;
 
 export interface TabsContextProps {
@@ -58,7 +58,7 @@ export interface TabsContextProps {
   /**
    * Theme of the Stat Tab group.
    */
-  statgrouptheme?: StatThemeNames;
+  statgrouptheme?: StatThemeName;
   /**
    * The value of the selected tab.
    */
@@ -92,7 +92,7 @@ export interface ITabsContext {
   /**
    * Theme of the Stat Tab group.
    */
-  statgrouptheme?: StatThemeNames;
+  statgrouptheme?: StatThemeName;
   /**
    * Variant of the Tabs.
    * @default default
@@ -152,7 +152,7 @@ export interface StatProps extends Omit<TabProps, 'badgeContent'> {
   /**
    * Theme of the stat tab.
    */
-  theme?: StatThemeNames;
+  theme?: StatThemeName;
 }
 
 export interface TabsProps extends Omit<OcBaseProps<HTMLElement>, 'onChange'> {
@@ -200,7 +200,7 @@ export interface TabsProps extends Omit<OcBaseProps<HTMLElement>, 'onChange'> {
   /**
    * Theme of the Stat Tab group.
    */
-  statgrouptheme?: StatThemeNames;
+  statgrouptheme?: StatThemeName;
   /**
    * If the tabs should have an underline/penline beneath them.
    * NOTE: won't be applied if pill variant is used.

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -35,7 +35,12 @@ import {
   SelectorSize,
 } from './components/CheckBox';
 
-import { ConfigProvider, Shape, Size } from './components/ConfigProvider';
+import {
+  ConfigProvider,
+  OcThemeName,
+  Shape,
+  Size,
+} from './components/ConfigProvider';
 
 import Cropper from './components/Upload/Cropper';
 
@@ -112,6 +117,7 @@ import { Stack } from './components/Stack';
 
 import {
   Stat,
+  StatThemeName,
   StatValidationStatus,
   Tabs,
   Tab,
@@ -239,6 +245,7 @@ export {
   NavbarContent,
   NeutralButton,
   OcFile,
+  OcThemeName,
   Pagination,
   PaginationLayoutOptions,
   Panel,
@@ -281,6 +288,7 @@ export {
   SpinnerSize,
   Stack,
   Stat,
+  StatThemeName,
   StatValidationStatus,
   SystemUIButton,
   Table,


### PR DESCRIPTION
## SUMMARY:
See issue for summary
Also rename and export StatThemeName

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/493

## JIRA TASK (Eightfold Employees Only):
ENG-39328

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist (Rename and export only)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the ps branch and run `yarn` and `yarn storybook`. Verify the `ConfigProvider` story behaves as expected.