### PR TITLE
fix: inputs: border color used for inputs is not a11y friendly

### DIFF
--- a/src/components/DateTimePicker/DatePicker/datepicker.module.scss
+++ b/src/components/DateTimePicker/DatePicker/datepicker.module.scss
@@ -49,16 +49,16 @@
   &-status-success.picker-underline {
     div {
       &:before {
-        border-color: var(--border-color);
+        border-color: var(--input-border-color);
       }
 
       &:after {
-        border-color: var(--primary-color-60);
+        border-color: var(--input-border-color-underline-active);
       }
 
       &:hover {
         &:before {
-          border-color: var(--grey-color-60);
+          border-color: var(--input-border-color-underline-hover);
         }
       }
     }

--- a/src/components/DateTimePicker/Internal/ocpicker.module.scss
+++ b/src/components/DateTimePicker/Internal/ocpicker.module.scss
@@ -70,7 +70,7 @@
   }
 
   &:hover:not(.picker-disabled):not(.picker-underline):not(.picker-borderless) {
-    border-color: var(--grey-color-60);
+    border-color: var(--input-border-color);
   }
 
   &-focused:not(.picker-disabled):not(.picker-underline):not(.picker-borderless) {
@@ -1015,7 +1015,7 @@
   &-underline {
     .picker-input {
       &:before {
-        border-bottom: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--input-border-color);
         left: 0;
         bottom: 0;
         content: '';
@@ -1027,7 +1027,7 @@
       }
 
       &:after {
-        border-bottom: 1px solid var(--primary-color-60);
+        border-bottom: 1px solid var(--input-border-color-underline-active);
         left: 0;
         bottom: 0;
         content: '';
@@ -1041,7 +1041,7 @@
 
       &:hover {
         &:before {
-          border-color: var(--grey-color-60);
+          border-color: var(--input-border-color-underline-hover);
         }
       }
 

--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -1,7 +1,4 @@
 .input-wrapper {
-  --input-border-color: var(--grey-color-60);
-  --input-border-color-active: var(--grey-color-80);
-
   position: relative;
   width: fit-content;
   $input-small-size: 28px;
@@ -338,7 +335,7 @@
     }
 
     &:hover:not([disabled]) {
-      border-color: var(--input-border-color-active);
+      border-color: var(--input-border-color-hover);
 
       &.underline {
         border-color: transparent;
@@ -1002,7 +999,7 @@
     }
 
     &:hover:not([disabled]):not(.underline) {
-      border-color: var(--input-border-color-active);
+      border-color: var(--input-border-color-hover);
     }
 
     &.status-success {
@@ -1119,7 +1116,7 @@
       }
 
       &:after {
-        border-bottom: 1px solid var(--primary-color-60);
+        border-bottom: 1px solid var(--input-border-color-underline-active);
         left: 0;
         bottom: 0;
         content: '';
@@ -1133,7 +1130,7 @@
 
       &:hover {
         &:before {
-          border-color: var(--input-border-color-active);
+          border-color: var(--input-border-color-underline-hover);
         }
       }
 
@@ -1143,12 +1140,12 @@
         }
 
         &:after {
-          border-color: var(--primary-color-60);
+          border-color: var(--input-border-color-underline-active);
         }
 
         &:hover {
           &:before {
-            border-color: var(--input-border-color-active);
+            border-color: var(--input-border-color-underline-hover);
           }
         }
       }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -203,7 +203,7 @@
   --border-radius-l: 16px;
   --border-radius-xl: 24px;
 
-  // ------ Border theme ------
+  // ------ Input theme ------
   --input-border-color: var(--grey-color-60);
   --input-border-color-active: var(--grey-color-80);
   --input-border-color-hover: var(--input-border-color-active);

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -203,6 +203,13 @@
   --border-radius-l: 16px;
   --border-radius-xl: 24px;
 
+  // ------ Border theme ------
+  --input-border-color: var(--grey-color-60);
+  --input-border-color-active: var(--grey-color-80);
+  --input-border-color-hover: var(--input-border-color-active);
+  --input-border-color-underline-active: var(--primary-color-70);
+  --input-border-color-underline-hover: var(--input-border-color-active);
+
   // ------ Tabs theme ------
   --tab-label: var(--text-secondary-color);
   --tab-background: transparent;
@@ -257,8 +264,8 @@
   // ------ Picker theme ------
   --picker-background-color: var(--background-color);
   --picker-foreground-color: var(--text-secondary-color);
-  --picker-border-color: var(--border-color);
-  --picker-border-color-active: var(--primary-color);
+  --picker-border-color: var(--input-border-color);
+  --picker-border-color-active: var(--input-border-color-active);
   --picker-cell-background-color: var(--background-color);
   --picker-cell-background-color-active: var(--primary-color-20);
   --picker-cell-background-color-hover: var(--accent-color-30);


### PR DESCRIPTION
## SUMMARY:
Improves CSS Variables by adding more semantically named input border vars
Improves color-contrast ratio of input borders to greater than 4:5:1 for every state

![input1](https://user-images.githubusercontent.com/99700808/211700593-c5b4ce35-7f36-4587-b470-58b8f41aa16b.png)

![input2](https://user-images.githubusercontent.com/99700808/211700608-f95c2a2a-0143-4885-92a7-dd98e0015523.png)

![input3](https://user-images.githubusercontent.com/99700808/211700623-df6a0b4f-797d-4132-b08e-e25cd511f66a.png)

![input4](https://user-images.githubusercontent.com/99700808/211700643-4bb040c4-9c35-4bbe-8fe1-82d2b1a91709.png)

![input5](https://user-images.githubusercontent.com/99700808/211700659-9c9da814-725f-4769-bcc8-8ec90644bcb3.png)

![input6](https://user-images.githubusercontent.com/99700808/211700667-7d7df1f5-982b-4c3f-98f1-994b26aa5572.png)

![input7](https://user-images.githubusercontent.com/99700808/211700680-80d0fdec-1b3a-47ff-a373-33f24867443a.png)

![input8](https://user-images.githubusercontent.com/99700808/211700699-537272b9-b29a-4097-be2b-d69dd38b8f20.png)

![input9](https://user-images.githubusercontent.com/99700808/211700707-3bfad9a2-1183-402c-8520-d5ae4837cd59.png)

![input10](https://user-images.githubusercontent.com/99700808/211700719-1964d975-b8ef-4ac7-b0c7-30628bb22869.png)

![input11](https://user-images.githubusercontent.com/99700808/211700737-e4fa1f1e-0301-40ee-8e6b-672f10e2b546.png)

![input12](https://user-images.githubusercontent.com/99700808/211700747-52167e6c-cd08-485d-b92a-1041a7218b82.png)

![input13](https://user-images.githubusercontent.com/99700808/211700751-2451dee3-68d2-4d65-95b9-e5625b65c0a9.png)

![input14](https://user-images.githubusercontent.com/99700808/211700766-d371227a-4c34-4baa-81a4-1e21d20fbd3d.png)


## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/498

## JIRA TASK (Eightfold Employees Only):
ENG-39677

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify `Input`, `Date Picker` and `Time Picker` stories behave as expected.