### PR TITLE
fix: infobar: close icon button should be round

### DIFF
--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -2,7 +2,7 @@ import React, { FC, Ref, useEffect, useState } from 'react';
 import { InfoBarLocale, InfoBarsProps, InfoBarType } from './InfoBar.types';
 import { Icon, IconName } from '../Icon';
 import { mergeClasses } from '../../shared/utilities';
-import { SystemUIButton } from '../Button';
+import { ButtonShape, SystemUIButton } from '../Button';
 import LocaleReceiver, {
   useLocaleReceiver,
 } from '../LocaleProvider/LocaleReceiver';
@@ -99,9 +99,10 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
               )}
               {closable && (
                 <SystemUIButton
-                  iconProps={{ path: closeIcon }}
                   ariaLabel={closeButtonAriaLabelText}
+                  iconProps={{ path: closeIcon }}
                   onClick={onClose}
+                  shape={ButtonShape.Round}
                   {...closeButtonProps}
                   disruptive={type === InfoBarType.disruptive}
                 />


### PR DESCRIPTION
## SUMMARY:
Updates the `InfoBar` close icon button to be round

![close](https://user-images.githubusercontent.com/99700808/211867519-47c60ea3-82c8-4d62-8b0d-9a54c90bc965.png)

## JIRA TASK (Eightfold Employees Only):
ENG-39767

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and run `yarn` and `yarn storybook`. Verify the `InfoBar` stories behave as expected.