### PR TITLE
feat: stepper: adds show active step index prop

### DIFF
--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -56,11 +56,12 @@ export const Stepper: FC<StepperProps> = React.forwardRef(
       scrollLeftAriaLabelText: defaultScrollLeftAriaLabelText,
       scrollRightAriaLabelText: defaultScrollRightAriaLabelText,
       scrollUpAriaLabelText: defaultScrollUpAriaLabelText,
+      showActiveStepIndex,
       size = StepperSize.Medium,
-      theme,
       status,
       steps,
       style,
+      theme,
       variant = StepperVariant.Default,
       width,
       'data-test-id': dataTestId,
@@ -285,15 +286,20 @@ export const Stepper: FC<StepperProps> = React.forwardRef(
           (styles as any)[`${theme}`],
           (styles as any)[`${status}`],
         ])}
-        iconProps={{
-          path: getIcon(icon, active, complete),
-          classNames: styles.checkIcon,
-        }}
+        iconProps={
+          active && showActiveStepIndex
+            ? null
+            : {
+                path: getIcon(icon, active, complete),
+                classNames: styles.checkIcon,
+              }
+        }
         onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) =>
           handleOnClick(event, index)
         }
         shape={ButtonShape.Round}
         size={stepSizeToButtonSizeMap.get(size)}
+        text={active && showActiveStepIndex ? `${index + 1}` : null}
       />
     );
 

--- a/src/components/Stepper/Stepper.types.ts
+++ b/src/components/Stepper/Stepper.types.ts
@@ -205,6 +205,11 @@ export interface StepperProps
    */
   scrollUpAriaLabelText?: string;
   /**
+   * Show active step index.
+   * Use when step is an icon, but an index is desired for the active step.
+   */
+  showActiveStepIndex?: boolean;
+  /**
    * The Stepper size.
    * @default StepperSize.Medium
    */
@@ -214,13 +219,13 @@ export interface StepperProps
    */
   status?: StepperValidationStatus;
   /**
-   * Theme of the Stepper.
-   */
-  theme?: StepperThemeName;
-  /**
    * The Stepper Steps.
    */
   steps?: Step[];
+  /**
+   * Theme of the Stepper.
+   */
+  theme?: StepperThemeName;
   /**
    * The Stepper variant.
    * options: Default, Timeline

--- a/src/components/Stepper/Timeline.stories.tsx
+++ b/src/components/Stepper/Timeline.stories.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { useArgs } from '@storybook/client-api';
 import {
   Stepper,
   StepperLineStyle,
@@ -167,21 +168,89 @@ const Default_Story: ComponentStory<typeof Stepper> = (args) => {
   );
 };
 
+const Show_Small_Active_Index_Story: ComponentStory<typeof Stepper> = (
+  args
+) => {
+  const [_, updateArgs] = useArgs();
+
+  const handle = (index: number = 3) => {
+    updateArgs({
+      ...args,
+      activeStepIndex: index,
+      index: index,
+      steps: [1, 2, 3, 4, 5].map((i: number) => ({
+        index: i,
+        content: `Timeline label ${i}`,
+        complete: i > 2 ? false : true,
+        nodeAriaLabelText: i === 5 ? 'Finish' : null,
+        nodeIcon: i === 5 ? IconName.mdiFlagCheckered : null,
+        size: i === index + 1 ? StepSize.Large : StepSize.Small,
+      })),
+    });
+  };
+
+  return (
+    <Row>
+      <Col span="12">
+        <Stepper {...args} onChange={(step: number) => handle(step)} />
+      </Col>
+    </Row>
+  );
+};
+
+const Show_Medium_Active_Index_Story: ComponentStory<typeof Stepper> = (
+  args
+) => {
+  const [_, updateArgs] = useArgs();
+
+  const handle = (index: number = 3) => {
+    updateArgs({
+      ...args,
+      activeStepIndex: index,
+      index: index,
+      steps: [1, 2, 3, 4, 5].map((i: number) => ({
+        index: i,
+        content: <TimelineItem index={i} />,
+        complete: i > 2 ? false : true,
+        nodeAriaLabelText: i === 5 ? 'Finish' : null,
+        nodeIcon: i === 5 ? IconName.mdiFlagCheckered : null,
+        size: i === index + 1 ? StepSize.Large : StepSize.Small,
+      })),
+    });
+  };
+
+  return (
+    <Row>
+      <Col span="12">
+        <Stepper {...args} onChange={(step: number) => handle(step)} />
+      </Col>
+    </Row>
+  );
+};
+
 export const Default_Horizontal_Small = Default_Story.bind({});
 export const Default_Horizontal_Small_Required = Default_Story.bind({});
 export const Default_Horizontal_Small_Read_Only = Default_Story.bind({});
+export const Default_Horizontal_Small_Show_Active_Index =
+  Show_Small_Active_Index_Story.bind({});
 export const Default_Horizontal_Small_Custom = Default_Story.bind({});
 export const Default_Horizontal_Medium = Default_Story.bind({});
 export const Default_Horizontal_Medium_Required = Default_Story.bind({});
 export const Default_Horizontal_Medium_Read_Only = Default_Story.bind({});
+export const Default_Horizontal_Medium_Show_Active_Index =
+  Show_Medium_Active_Index_Story.bind({});
 export const Default_Horizontal_Medium_Custom = Default_Story.bind({});
 export const Default_Vertical_Small = Default_Story.bind({});
 export const Default_Vertical_Small_Required = Default_Story.bind({});
 export const Default_Vertical_Small_Read_Only = Default_Story.bind({});
+export const Default_Vertical_Small_Show_Active_Index =
+  Show_Small_Active_Index_Story.bind({});
 export const Default_Vertical_Small_Custom = Default_Story.bind({});
 export const Default_Vertical_Medium = Default_Story.bind({});
 export const Default_Vertical_Medium_Required = Default_Story.bind({});
 export const Default_Vertical_Medium_Read_Only = Default_Story.bind({});
+export const Default_Vertical_Medium_Show_Active_Index =
+  Show_Medium_Active_Index_Story.bind({});
 export const Default_Vertical_Medium_Scroll = Default_Story.bind({});
 export const Default_Vertical_Medium_Custom = Default_Story.bind({});
 
@@ -245,6 +314,20 @@ Default_Horizontal_Small_Read_Only.args = {
   })),
 };
 
+Default_Horizontal_Small_Show_Active_Index.args = {
+  ...timelineArgs,
+  showActiveStepIndex: true,
+  size: StepperSize.Small,
+  steps: [1, 2, 3, 4, 5].map((i: number) => ({
+    index: i,
+    content: `Timeline label ${i}`,
+    complete: i > 2 ? false : true,
+    nodeAriaLabelText: i === 5 ? 'Finish' : null,
+    nodeIcon: i === 5 ? IconName.mdiFlagCheckered : null,
+    size: i === 3 ? StepSize.Large : StepSize.Small,
+  })),
+};
+
 Default_Horizontal_Small_Custom.args = {
   ...timelineArgs,
   classNames: 'custom-stepper-line',
@@ -280,6 +363,19 @@ Default_Horizontal_Medium_Required.args = {
 Default_Horizontal_Medium_Read_Only.args = {
   ...timelineArgs,
   readonly: true,
+};
+
+Default_Horizontal_Medium_Show_Active_Index.args = {
+  ...timelineArgs,
+  showActiveStepIndex: true,
+  steps: [1, 2, 3, 4, 5].map((i: number) => ({
+    index: i,
+    content: <TimelineItem index={i} />,
+    complete: i > 2 ? false : true,
+    nodeAriaLabelText: i === 5 ? 'Finish' : null,
+    nodeIcon: i === 5 ? IconName.mdiFlagCheckered : null,
+    size: i === 3 ? StepSize.Large : StepSize.Small,
+  })),
 };
 
 Default_Horizontal_Medium_Custom.args = {
@@ -345,6 +441,21 @@ Default_Vertical_Small_Read_Only.args = {
   })),
 };
 
+Default_Vertical_Small_Show_Active_Index.args = {
+  ...timelineArgs,
+  layout: 'vertical',
+  showActiveStepIndex: true,
+  size: StepperSize.Small,
+  steps: [1, 2, 3, 4, 5].map((i: number) => ({
+    index: i,
+    content: `Timeline label ${i}`,
+    complete: i > 2 ? false : true,
+    nodeAriaLabelText: i === 5 ? 'Finish' : null,
+    nodeIcon: i === 5 ? IconName.mdiFlagCheckered : null,
+    size: i === 3 ? StepSize.Large : StepSize.Small,
+  })),
+};
+
 Default_Vertical_Small_Custom.args = {
   ...timelineArgs,
   classNames: 'custom-stepper-line',
@@ -384,6 +495,20 @@ Default_Vertical_Medium_Read_Only.args = {
   ...timelineArgs,
   layout: 'vertical',
   readonly: true,
+};
+
+Default_Vertical_Medium_Show_Active_Index.args = {
+  ...timelineArgs,
+  layout: 'vertical',
+  showActiveStepIndex: true,
+  steps: [1, 2, 3, 4, 5].map((i: number) => ({
+    index: i,
+    content: <TimelineItem index={i} />,
+    complete: i > 2 ? false : true,
+    nodeAriaLabelText: i === 5 ? 'Finish' : null,
+    nodeIcon: i === 5 ? IconName.mdiFlagCheckered : null,
+    size: i === 3 ? StepSize.Large : StepSize.Small,
+  })),
 };
 
 Default_Vertical_Medium_Scroll.args = {


### PR DESCRIPTION
## SUMMARY:
Ensures there is an option to show the numerical index for the active timeline step rather than an icon.


https://user-images.githubusercontent.com/99700808/213042076-f4ea761d-9045-4855-bb9a-8ca14ab5fe89.mp4


https://user-images.githubusercontent.com/99700808/213042168-a2c5f969-98f0-472d-98b3-be95d6b7cc76.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-39994

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Timeline` stories behave as expected. 