### PR TITLE
fix: pagination: disable next button only when current page is equal to total page count

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { Pagination, PaginationLayoutOptions } from '.';
+import { DefaultButton } from '../Button';
+import { fireEvent, getByTestId, render } from '@testing-library/react';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+let matchMedia: any;
+
+describe('Pagination', () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  test('Pagination should render normally', () => {
+    const { container } = render(
+      <Pagination
+        currentPage={1}
+        onCurrentChange={() => {}}
+        pageSize={10}
+        total={50}
+      />
+    );
+    expect(() => container).not.toThrowError();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pagination should render as dots', () => {
+    const { container } = render(
+      <Pagination
+        currentPage={1}
+        dots
+        onCurrentChange={() => {}}
+        pageSize={10}
+        total={50}
+      />
+    );
+    expect(container.getElementsByClassName('dots')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pagination should render as simplified', () => {
+    const { container } = render(
+      <Pagination
+        currentPage={1}
+        layout={[
+          PaginationLayoutOptions.Previous,
+          PaginationLayoutOptions.Pager,
+          PaginationLayoutOptions.Next,
+          PaginationLayoutOptions.Simplified,
+        ]}
+        onCurrentChange={() => {}}
+        pageSize={10}
+        total={50}
+      />
+    );
+    expect(container.getElementsByClassName('page-tracker')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pagination should render with some elements', () => {
+    const { container } = render(
+      <Pagination
+        currentPage={5}
+        layout={[
+          PaginationLayoutOptions.Previous,
+          PaginationLayoutOptions.Pager,
+          PaginationLayoutOptions.Next,
+          PaginationLayoutOptions.Jumper,
+        ]}
+        onCurrentChange={() => {}}
+        pageSize={100}
+        total={1000}
+      />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pagination should render with all elements', () => {
+    const { container } = render(
+      <Pagination
+        currentPage={4}
+        layout={[
+          PaginationLayoutOptions.Total,
+          PaginationLayoutOptions.Sizes,
+          PaginationLayoutOptions.Previous,
+          PaginationLayoutOptions.Pager,
+          PaginationLayoutOptions.Next,
+          PaginationLayoutOptions.Jumper,
+        ]}
+        onCurrentChange={() => {}}
+        pageSize={100}
+        total={400}
+      />
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pagination next and previous buttons should render as expected', () => {
+    const PaginationTotalViaProps = (): JSX.Element => {
+      const [total, setTotal] = useState(0);
+      return (
+        <>
+          <DefaultButton
+            data-testid="valueButton"
+            onClick={() => {
+              setTotal(12);
+            }}
+            text="Set Value"
+          />
+          <Pagination
+            classNames="my-pagination-class"
+            currentPage={1}
+            onCurrentChange={() => {}}
+            pageSize={10}
+            total={total}
+          />
+        </>
+      );
+    };
+    const { container } = render(<PaginationTotalViaProps />);
+    const valueButton: HTMLElement = getByTestId(container, 'valueButton');
+    expect(container.getElementsByClassName('pager')).toHaveLength(0);
+    fireEvent.click(valueButton);
+    expect(container.getElementsByClassName('pager')).toHaveLength(1);
+    expect(
+      container
+        .getElementsByClassName('pagination-previous')[0]
+        .hasAttribute('disabled')
+    ).toBe(true);
+    expect(
+      container
+        .getElementsByClassName('pagination-next')[0]
+        .hasAttribute('disabled')
+    ).toBe(false);
+    fireEvent.click(container.getElementsByClassName('pagination-next')[0]);
+    expect(
+      container
+        .getElementsByClassName('pagination-previous')[0]
+        .hasAttribute('disabled')
+    ).toBe(false);
+    expect(
+      container
+        .getElementsByClassName('pagination-next')[0]
+        .hasAttribute('disabled')
+    ).toBe(true);
+  });
+});

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -416,10 +416,7 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
                         ])}
                         shape={ButtonShape.Rectangle}
                         key="next"
-                        disabled={
-                          (!loop && _currentPage === getPageCount()) ||
-                          _pageCount === 0
-                        }
+                        disabled={!loop && _currentPage === getPageCount()}
                         iconProps={{
                           role: 'presentation',
                           path:

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1,0 +1,738 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination Pagination should render as dots 1`] = `
+<div>
+  <div
+    class="pagination dots"
+    role="navigation"
+  >
+    <span />
+    <button
+      aria-disabled="true"
+      aria-label="Previous"
+      class="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
+      disabled=""
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      class="pager"
+    >
+      <li>
+        <button
+          aria-current="true"
+          aria-disabled="false"
+          class="pagination-button active button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            1
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            2
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            3
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            4
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            5
+          </span>
+        </button>
+      </li>
+    </ul>
+    <button
+      aria-disabled="false"
+      aria-label="Next"
+      class="pagination-button pagination-next button button-neutral button-medium icon-left"
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Pagination Pagination should render as simplified 1`] = `
+<div>
+  <div
+    class="pagination"
+    role="navigation"
+  >
+    <span />
+    <button
+      aria-disabled="true"
+      aria-label="Previous"
+      class="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
+      disabled=""
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      class="pager page-tracker"
+    >
+      <li>
+        <span>
+          1 of
+        </span>
+      </li>
+      <li>
+        <span>
+          5
+        </span>
+      </li>
+    </ul>
+    <button
+      aria-disabled="false"
+      aria-label="Next"
+      class="pagination-button pagination-next button button-neutral button-medium icon-left"
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Pagination Pagination should render normally 1`] = `
+<div>
+  <div
+    class="pagination"
+    role="navigation"
+  >
+    <span />
+    <button
+      aria-disabled="true"
+      aria-label="Previous"
+      class="pagination-button pagination-previous button button-neutral button-medium icon-left disabled"
+      disabled=""
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      class="pager"
+    >
+      <li>
+        <button
+          aria-current="true"
+          aria-disabled="false"
+          class="pagination-button active button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            1
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            2
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            3
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            4
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            5
+          </span>
+        </button>
+      </li>
+    </ul>
+    <button
+      aria-disabled="false"
+      aria-label="Next"
+      class="pagination-button pagination-next button button-neutral button-medium icon-left"
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Pagination Pagination should render with all elements 1`] = `
+<div>
+  <div
+    class="pagination"
+    role="navigation"
+  >
+    <span
+      class="sizes"
+    >
+      <div
+        class="main-wrapper"
+      >
+        <button
+          aria-controls="dropdown-"
+          aria-disabled="false"
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="Selected page size"
+          class="button button-neutral button-medium icon-right"
+          role="button"
+          tabindex="0"
+        >
+          <span>
+            <span
+              aria-hidden="false"
+              class="icon icon-wrapper"
+              role="presentation"
+            >
+              <svg
+                role="presentation"
+                style="width: 20px; height: 20px;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                  style="fill: currentColor;"
+                />
+              </svg>
+            </span>
+            <span
+              class="button-text-medium"
+            >
+              100 / page
+            </span>
+          </span>
+        </button>
+      </div>
+    </span>
+    <span
+      class="total"
+    >
+      Total 400
+    </span>
+    <button
+      aria-disabled="false"
+      aria-label="Previous"
+      class="pagination-button pagination-previous button button-neutral button-medium icon-left"
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      class="pager"
+    >
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            1
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            2
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            3
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="true"
+          aria-disabled="false"
+          class="pagination-button active button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            4
+          </span>
+        </button>
+      </li>
+    </ul>
+    <button
+      aria-disabled="true"
+      aria-label="Next"
+      class="pagination-button pagination-next button button-neutral button-medium icon-left disabled"
+      disabled=""
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+    <span
+      class="jump"
+    >
+      Go to
+      <div
+        class="input-wrapper input-medium left-icon"
+      >
+        <div
+          class="expandable-wrapper"
+        >
+          <div
+            class="input-group left-icon"
+          >
+            <input
+              aria-disabled="false"
+              class="editor input-medium pill-shape left-icon clear-not-visible"
+              id="input-"
+              max="4"
+              min="1"
+              role="textbox"
+              tabindex="0"
+              type="number"
+              value="4"
+            />
+            <div
+              class="action-wrapper"
+            >
+              <div
+                class="overlay"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Pagination Pagination should render with some elements 1`] = `
+<div>
+  <div
+    class="pagination"
+    role="navigation"
+  >
+    <span />
+    <button
+      aria-disabled="false"
+      aria-label="Previous"
+      class="pagination-button pagination-previous button button-neutral button-medium icon-left"
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+    <ul
+      class="pager"
+    >
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            1
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            2
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            3
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            4
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="true"
+          aria-disabled="false"
+          class="pagination-button active button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            5
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            6
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            7
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            8
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            9
+          </span>
+        </button>
+      </li>
+      <li>
+        <button
+          aria-current="false"
+          aria-disabled="false"
+          class="pagination-button button button-neutral button-medium"
+        >
+          <span
+            class="button-text-medium"
+          >
+            10
+          </span>
+        </button>
+      </li>
+    </ul>
+    <button
+      aria-disabled="false"
+      aria-label="Next"
+      class="pagination-button pagination-next button button-neutral button-medium icon-left"
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+    <span
+      class="jump"
+    >
+      Go to
+      <div
+        class="input-wrapper input-medium left-icon"
+      >
+        <div
+          class="expandable-wrapper"
+        >
+          <div
+            class="input-group left-icon"
+          >
+            <input
+              aria-disabled="false"
+              class="editor input-medium pill-shape left-icon clear-not-visible"
+              id="input-"
+              max="10"
+              min="1"
+              role="textbox"
+              tabindex="0"
+              type="number"
+              value="5"
+            />
+            <div
+              class="action-wrapper"
+            >
+              <div
+                class="overlay"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </span>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## SUMMARY:
Updates condition to disable the next button
Adds unit tests to validate the scenario, along with a few others. 

## JIRA TASK (Eightfold Employees Only):
ENG-41053

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Pagination` stories behave as expected.