### PR TITLE
feat: pill: enable white theme and custom close icon

### DIFF
--- a/src/components/Pills/Pill.test.tsx
+++ b/src/components/Pills/Pill.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { Pill, PillThemeName, PillType } from '.';
+import { IconName } from '../Icon';
+import { render } from '@testing-library/react';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+let matchMedia: any;
+
+describe('Pill', () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  test('Pill should render normally', () => {
+    const { container } = render(<Pill label="A pill" />);
+    expect(() => container).not.toThrowError();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pill should render as closable', () => {
+    const { container } = render(
+      <Pill label="A closable pill" type={PillType.closable} />
+    );
+    expect(container.getElementsByClassName('close-button')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pill should render with icon', () => {
+    const { container } = render(
+      <Pill
+        label="A pill with icon"
+        iconProps={{
+          path: IconName.mdiInformationOutline,
+        }}
+      />
+    );
+    expect(container.getElementsByClassName('icon')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pill should render with button', () => {
+    const { container } = render(
+      <Pill
+        label="A button pill"
+        pillButtonProps={{
+          iconProps: { path: IconName.mdiThumbUpOutline },
+          text: '2',
+          ariaLabel: 'Thumbs up',
+        }}
+        type={PillType.withButton}
+      />
+    );
+    expect(container.getElementsByClassName('button')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pill should render with a theme', () => {
+    const themes: PillThemeName[] = [
+      'red',
+      'redOrange',
+      'orange',
+      'yellow',
+      'yellowGreen',
+      'green',
+      'blueGreen',
+      'blue',
+      'blueViolet',
+      'violet',
+      'violetRed',
+      'grey',
+      'white',
+    ];
+    const { container } = render(
+      <Pill label="A themed pill" theme={themes[12]} />
+    );
+    expect(container.getElementsByClassName('white')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -59,18 +59,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
     const tagClassName: string = mergeClasses([
       styles.tagPills,
       classNames,
-      { [styles.red]: theme === 'red' },
-      { [styles.redOrange]: theme === 'redOrange' },
-      { [styles.orange]: theme === 'orange' },
-      { [styles.yellow]: theme === 'yellow' },
-      { [styles.yellowGreen]: theme === 'yellowGreen' },
-      { [styles.green]: theme === 'green' },
-      { [styles.blueGreen]: theme === 'blueGreen' },
-      { [styles.blue]: theme === 'blue' },
-      { [styles.blueViolet]: theme === 'blueViolet' },
-      { [styles.violet]: theme === 'violet' },
-      { [styles.violetRed]: theme === 'violetRed' },
-      { [styles.grey]: theme === 'grey' },
+      (styles as any)[theme],
       { [styles.xsmall]: size === PillSize.XSmall },
       { [styles.tagPillsDisabled]: mergedDisabled },
       { [styles.tagPillsRtl]: htmlDir === 'rtl' },
@@ -104,8 +93,8 @@ export const Pill: FC<PillProps> = React.forwardRef(
         )}
         {type === PillType.closable && (
           <DefaultButton
-            {...closeButtonProps}
             iconProps={{ path: IconName.mdiClose }}
+            {...closeButtonProps}
             onClick={!mergedDisabled ? onClose : null}
             size={pillSizeToButtonSizeMap.get(size)}
             classNames={styles.closeButton}

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Pill, PillSize, PillType } from './';
-import { OcThemeName } from '../ConfigProvider';
+import { Pill, PillSize, PillThemeName, PillType } from './';
 import { IconName } from '../Icon';
 import { Stack } from '../Stack';
 
@@ -51,7 +50,7 @@ export default {
   },
 } as ComponentMeta<typeof Pill>;
 
-const themes: OcThemeName[] = [
+const themes: PillThemeName[] = [
   'red',
   'redOrange',
   'orange',
@@ -64,6 +63,7 @@ const themes: OcThemeName[] = [
   'violet',
   'violetRed',
   'grey',
+  'white',
 ];
 
 const Default_Story: ComponentStory<typeof Pill> = (args) => (
@@ -95,6 +95,16 @@ const Closable_Story: ComponentStory<typeof Pill> = (args) => (
 );
 
 export const Closable = Closable_Story.bind({});
+
+const Custom_Closable_Story: ComponentStory<typeof Pill> = (args) => (
+  <Stack direction="vertical" gap="l">
+    {themes.map((theme) => (
+      <Pill {...args} label={theme} theme={theme} key={theme} />
+    ))}
+  </Stack>
+);
+
+export const Custom_Closable = Custom_Closable_Story.bind({});
 
 const With_Button_Story: ComponentStory<typeof Pill> = (args) => (
   <Stack direction="vertical" gap="l">
@@ -138,6 +148,18 @@ With_Icon.args = {
 
 Closable.args = {
   ...pillArgs,
+  type: PillType.closable,
+};
+
+Custom_Closable.args = {
+  ...pillArgs,
+  closeButtonProps: {
+    ariaLabel: 'Remove',
+    iconProps: {
+      path: IconName.mdiTrashCanOutline,
+    },
+  },
+  size: PillSize.Medium,
   type: PillType.closable,
 };
 

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -34,6 +34,21 @@ export type pillButtonProps = Omit<
   'onClick' | 'size' | 'classNames'
 >;
 
+export type PillThemeName =
+  | 'red'
+  | 'redOrange'
+  | 'orange'
+  | 'yellow'
+  | 'yellowGreen'
+  | 'green'
+  | 'blueGreen'
+  | 'blue'
+  | 'blueViolet'
+  | 'violet'
+  | 'violetRed'
+  | 'grey'
+  | 'white';
+
 export interface PillProps extends OcBaseProps<HTMLElement> {
   /**
    * Props for the close button,
@@ -83,7 +98,7 @@ export interface PillProps extends OcBaseProps<HTMLElement> {
    * Theme of the pill
    * @default blue
    */
-  theme?: OcThemeName;
+  theme?: OcThemeName | PillThemeName;
   /**
    * Type of the pill
    * @default PillType.default

--- a/src/components/Pills/__snapshots__/Pill.test.tsx.snap
+++ b/src/components/Pills/__snapshots__/Pill.test.tsx.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pill Pill should render as closable 1`] = `
+<div>
+  <div
+    class="tag-pills blue"
+  >
+    <span
+      class="label medium"
+    >
+      A closable pill
+    </span>
+    <button
+      aria-disabled="false"
+      class="close-button button button-default button-small pill-shape icon-left"
+    >
+      <span
+        aria-hidden="false"
+        class="icon icon-wrapper"
+        role="presentation"
+      >
+        <svg
+          role="presentation"
+          style="width: 16px; height: 16px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Pill Pill should render normally 1`] = `
+<div>
+  <div
+    class="tag-pills blue read-only"
+  >
+    <span
+      class="label medium"
+    >
+      A pill
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Pill Pill should render with a theme 1`] = `
+<div>
+  <div
+    class="tag-pills white read-only"
+  >
+    <span
+      class="label medium"
+    >
+      A themed pill
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Pill Pill should render with button 1`] = `
+<div>
+  <div
+    class="tag-pills blue"
+  >
+    <span
+      class="label medium"
+    >
+      A button pill
+    </span>
+    <button
+      aria-disabled="false"
+      aria-label="Thumbs up"
+      class="button button button-default button-small pill-shape icon-left"
+    >
+      <span>
+        <span
+          aria-hidden="false"
+          class="icon icon-wrapper"
+          role="presentation"
+        >
+          <svg
+            role="presentation"
+            style="width: 16px; height: 16px;"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M5,9V21H1V9H5M9,21A2,2 0 0,1 7,19V9C7,8.45 7.22,7.95 7.59,7.59L14.17,1L15.23,2.06C15.5,2.33 15.67,2.7 15.67,3.11L15.64,3.43L14.69,8H21C22.11,8 23,8.9 23,10V12C23,12.26 22.95,12.5 22.86,12.73L19.84,19.78C19.54,20.5 18.83,21 18,21H9M9,19H18.03L21,12V10H12.21L13.34,4.68L9,9.03V19Z"
+              style="fill: currentColor;"
+            />
+          </svg>
+        </span>
+        <span
+          class="button-text-small"
+        >
+          2
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Pill Pill should render with icon 1`] = `
+<div>
+  <div
+    class="tag-pills blue read-only"
+  >
+    <span
+      aria-hidden="false"
+      class="icon icon-wrapper"
+      role="presentation"
+    >
+      <svg
+        role="presentation"
+        style="width: 16px; height: 16px;"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
+          style="fill: currentColor;"
+        />
+      </svg>
+    </span>
+    <span
+      class="label medium"
+    >
+      A pill with icon
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -108,6 +108,13 @@
     --hover-bg: var(--grey-color-30);
   }
 
+  &.white {
+    --bg: var(--white-color);
+    --label: var(--grey-color-60);
+    --hover-bg: var(--grey-color-30);
+    border: 1px solid var(--grey-color-60);
+  }
+
   &:hover:not(.tag-pills-disabled) {
     --bg: var(--hover-bg);
     --label: var(--hover-label);

--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -111,7 +111,7 @@
   &.white {
     --bg: var(--white-color);
     --label: var(--grey-color-60);
-    --hover-bg: var(--grey-color-30);
+    --hover-bg: var(--grey-color-10);
     border: 1px solid var(--grey-color-60);
   }
 

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -83,7 +83,7 @@ import { Pagination, PaginationLayoutOptions } from './components/Pagination';
 
 import { PersistentBar, PersistentBarType } from './components/PersistentBar';
 
-import { Pill, PillSize, PillType } from './components/Pills';
+import { Pill, PillSize, PillThemeName, PillType } from './components/Pills';
 
 import {
   SearchBox,
@@ -267,6 +267,7 @@ export {
   PersistentBarType,
   Pill,
   PillSize,
+  PillThemeName,
   PillType,
   Portal,
   PrimaryButton,


### PR DESCRIPTION
## SUMMARY:

- Adds `PillThemeName` and updates props to accept a union of `OCThemeName` or `PillThemeName`
- Allow custom close icon by moving the default prop before the spread
- Adds white theme support
- Adds unit tests
- Updates storybook to include the custom close icon scenario

![pill](https://user-images.githubusercontent.com/99700808/214141218-26f36279-98f2-439b-bcda-b99da6fdfb25.png)

## JIRA TASK (Eightfold Employees Only):
ENG-41058
ENG-39144

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Pill` stories behave as expected.