### PR TITLE
feat: pill text ellipse

### DIFF
--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -19,6 +19,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
       },
       disabled = false,
       label,
+      lineClamp,
       iconProps,
       theme = 'blue',
       onClose,
@@ -55,6 +56,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
       { [styles.medium]: size === PillSize.Medium },
       { [styles.small]: size === PillSize.Small },
       { [styles.xsmall]: size === PillSize.XSmall },
+      { [styles.lineClamp]: lineClamp },
     ]);
     const tagClassName: string = mergeClasses([
       styles.tagPills,
@@ -82,7 +84,12 @@ export const Pill: FC<PillProps> = React.forwardRef(
             classNames={styles.icon}
           />
         )}
-        <span className={labelClassName}>{label}</span>
+        <span
+          className={labelClassName}
+          style={lineClamp && { WebkitLineClamp: lineClamp }}
+        >
+          {label}
+        </span>
         {type === PillType.withButton && (
           <DefaultButton
             {...pillButtonProps}

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -116,6 +116,21 @@ const With_Button_Story: ComponentStory<typeof Pill> = (args) => (
 
 export const With_Button = With_Button_Story.bind({});
 
+const With_Long_Text_Story: ComponentStory<typeof Pill> = (args) => (
+  <Stack direction="vertical" gap="l" style={{ width: 216 }}>
+    {themes.map((theme) => (
+      <Pill
+        {...args}
+        label={'Some very long text is present here'}
+        theme={theme}
+        key={theme}
+      />
+    ))}
+  </Stack>
+);
+
+export const With_Long_Text = With_Long_Text_Story.bind({});
+
 const pillArgs: Object = {
   size: PillSize.Large,
   type: PillType.default,
@@ -166,4 +181,9 @@ Custom_Closable.args = {
 With_Button.args = {
   ...pillArgs,
   type: PillType.withButton,
+};
+
+With_Long_Text.args = {
+  ...pillArgs,
+  lineClamp: 1,
 };

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -77,6 +77,10 @@ export interface PillProps extends OcBaseProps<HTMLElement> {
    */
   label: string;
   /**
+   * Maximum number of lines the pill label can have
+   */
+  lineClamp?: number;
+  /**
    * Callback called on click of the button right of the pill
    */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;

--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -25,6 +25,14 @@
     &.xsmall {
       font-size: $text-font-size-2;
     }
+
+    &.line-clamp {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      word-break: break-all;
+      overflow-y: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   &.readOnly {


### PR DESCRIPTION
## SUMMARY:
Add ellipse functionality to pill text
<img width="728" alt="image" src="https://user-images.githubusercontent.com/110680523/214517178-6d09c060-d37d-4d1e-9d35-b8c580e859f4.png">

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
ENG-39494

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run yarn and yarn storybook. Verify the Pill stories behave as expected.