### PR TITLE
fix: dropdown now stays within the viewport

### DIFF
--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -30,7 +30,7 @@
   opacity: 0;
   white-space: normal;
   z-index: $z-index-400;
-  max-height: min(50vh, 600px);
+  max-height: min(45vh, 600px);
   overflow-y: auto;
 
   &.open {


### PR DESCRIPTION
## SUMMARY:
CSS change to ensure dropdown menu stays within the viewport

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
ENG-39856

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Ensure https://eightfoldai.github.io/octuple.github.io/?path=/story/dropdown--dropdown-button continues to work as expected.