### PR TITLE
fix: pill: handle jsx when lineclamp is null or zero

### DIFF
--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -86,7 +86,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
         )}
         <span
           className={labelClassName}
-          style={lineClamp && { WebkitLineClamp: lineClamp }}
+          style={lineClamp ? { WebkitLineClamp: lineClamp } : null}
         >
           {label}
         </span>

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -135,6 +135,7 @@ const pillArgs: Object = {
   size: PillSize.Large,
   type: PillType.default,
   label: 'Pill label',
+  lineClamp: 0,
   disabled: false,
   configContextProps: {
     noDisabledContext: false,


### PR DESCRIPTION
## SUMMARY:
When `lineClamp` is `null` or `0`, this causes a JSX exception. Update the expression to pass a null value to handle JSX. Updates storybook to include this test via default props. 

## JIRA TASK (Eightfold Employees Only):
ENG-41517

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist (Storybook)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Pill` stories behave as expected after a hard reload and a `lineClamp` value of `0`.