### PR TITLE
fix: infobar: updates the default role prop value to alert

### DIFF
--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -23,7 +23,7 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
       icon,
       locale = enUS,
       onClose,
-      role = 'presentation',
+      role = 'alert',
       style,
       type = InfoBarType.neutral,
       ...rest


### PR DESCRIPTION
## SUMMARY:
The default aria `role` of `InfoBar` was `presentation`, this change updates the default `role` to `alert` to improve interaction with screen readers. 

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/503

## JIRA TASK (Eightfold Employees Only):
ENG-41361

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:
N/A

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `InfoBar` stories behave as expected.