### PR TITLE
fix: button: update button loader z index to map to updated layout with nudge option

### DIFF
--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -227,4 +227,12 @@ describe('Button', () => {
     await sleep(500);
     expect(container.getElementsByClassName('size')).toHaveLength(1);
   });
+
+  test('Button is loading', () => {
+    const { container } = render(
+      <PrimaryButton loading size={ButtonSize.Medium} text="test" />
+    );
+    expect(container.getElementsByClassName('loader')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -30,6 +30,35 @@ exports[`Button Button is large 1`] = `
 </div>
 `;
 
+exports[`Button Button is loading 1`] = `
+<div>
+  <button
+    aria-disabled="true"
+    class="button button-primary button-medium pill-shape loading"
+    disabled=""
+  >
+    <span
+      class="button-text-medium"
+    >
+      test
+    </span>
+    <div
+      class="loader-container loader"
+    >
+      <div
+        class="dot medium"
+      />
+      <div
+        class="dot medium"
+      />
+      <div
+        class="dot medium"
+      />
+    </div>
+  </button>
+</div>
+`;
+
 exports[`Button Button is medium 1`] = `
 <div>
   <button

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -428,17 +428,18 @@
   }
 
   .loader {
-    position: absolute;
-    background: inherit;
-    width: 100%;
-    height: 100%;
-    display: flex;
     align-items: center;
-    justify-content: center;
-    border-radius: inherit;
-    left: 0;
-    top: 0;
     animation: fadeIn $motion-duration-normal $motion-easing-easein forwards;
+    background: inherit;
+    border-radius: inherit;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 1;
   }
 }
 


### PR DESCRIPTION
## SUMMARY:
Adds missing zIndex selector property.
Adds unit test and snap validation.

https://user-images.githubusercontent.com/99700808/216103883-22ba37cb-91e2-4cdf-957a-9c2c9de2de20.mp4

## JIRA TASK (Eightfold Employees Only):
ENG-42127

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Button` loader.