### PR TITLE
chore: actions: adds build job to octuple publish alerts

### DIFF
--- a/.github/workflows/octuple-publish-alerts.yml
+++ b/.github/workflows/octuple-publish-alerts.yml
@@ -8,6 +8,16 @@ on:
       - completed
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: yarn
+      - run: yarn test
+
   octuple-publish-alerts:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## SUMMARY:
Previous change was failing because the job depends on build and the first job may not contain deps

![action](https://user-images.githubusercontent.com/99700808/216145603-2f8faaa3-50f0-405d-9c4d-1caed6232732.png)

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:
N/A

## TEST PLAN:
Should verify on next release