### PR TITLE
feat: carousel: add single prop and update api to support single item scroll

### DIFF
--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -96,6 +96,7 @@ const Scroll_Story: ComponentStory<typeof Carousel> = (args) => (
 
 export const Slider = Slide_Story.bind({});
 export const Scroller = Scroll_Story.bind({});
+export const Scroller_Single = Scroll_Story.bind({});
 
 const carouselArgs: Object = {
   classNames: 'my-carousel',
@@ -112,6 +113,7 @@ Slider.args = {
   interval: 5000,
   loop: true,
   pause: 'hover',
+  single: false,
   transition: 'push',
   type: 'slide',
 };
@@ -141,5 +143,34 @@ Scroller.args = {
     gap: 24,
   },
   id: 'myCarouselScrollId',
+  type: 'scroll',
+};
+
+Scroller_Single.args = {
+  ...carouselArgs,
+  carouselScrollMenuProps: {
+    children: sampleList.map((item: SampleItem) => (
+      <div
+        key={item.key}
+        style={{
+          alignItems: 'center',
+          background: 'var(--grey-color-20)',
+          boxShadow:
+            '0px 1px 2px rgba(15, 20, 31, 0.12), 0px 2px 8px rgba(15, 20, 31, 0.16)',
+          display: 'flex',
+          height: 200,
+          justifyContent: 'center',
+          padding: 20,
+          width: 200,
+        }}
+      >
+        {item.name}
+      </div>
+    )),
+    containerPadding: 8,
+    gap: 24,
+  },
+  id: 'myCarouselScrollId',
+  single: true,
   type: 'scroll',
 };

--- a/src/components/Carousel/Carousel.types.ts
+++ b/src/components/Carousel/Carousel.types.ts
@@ -12,6 +12,9 @@ import { autoScrollApiType } from './autoScrollApi';
 import { OcBaseProps } from '../OcBase';
 import { PaginationLocale } from '../Pagination';
 
+export const DEFAULT_GAP_WIDTH: number = 4;
+export const OCCLUSION_AVOIDANCE_BUFFER: number = 72;
+
 export type CarouselTransition = 'push' | 'crossfade';
 export type CarouselType = 'slide' | 'scroll';
 export type CustomScrollBehavior<T> =
@@ -136,6 +139,12 @@ export interface CarouselProps
    * @default 'Previous'
    */
   previousIconButtonAriaLabel?: string;
+  /**
+   * Whether to scroll by 1 item.
+   * Use when type is 'scroll'
+   * @default false
+   */
+  single?: boolean;
   /**
    * Set type of slide transition.
    * @default 'push'

--- a/src/components/Carousel/ItemsMap.ts
+++ b/src/components/Carousel/ItemsMap.ts
@@ -73,14 +73,43 @@ class ItemsMap extends Map<Item[0], Item[1]> {
     );
     return [arr, current];
   }
+
+  public prevGroup(
+    item: string | IntersectionObserverItem,
+    onlyItems?: boolean
+  ): IntersectionObserverItem | undefined {
+    const [arr, current] = this.getCurrentPos(item, !!onlyItems);
+
+    // We scroll to the previous plus two so the next button
+    // doesn't occlude the last occluded item of the initial group.
+    // ---------------------       ---------------------      ----------------------
+    // <4 | {5} | 6 | 7 | 8>  -->  <1 | 2 | 3 | {4} | 5> -->  | {1} | 2 | 3 | 4 | 5>
+    // ---------------------       ---------------------      ----------------------
+    return current !== -1 ? arr[current + 2]?.[1] : undefined;
+  }
+
+  public nextGroup(
+    item: IntersectionObserverItem | string,
+    onlyItems?: boolean
+  ): IntersectionObserverItem | undefined {
+    const [arr, current] = this.getCurrentPos(item, !!onlyItems);
+
+    // We scroll to the next minus one so the previous button
+    // doesn't occlude the last occluded item of the initial group.
+    // ----------------------       ---------------------       -----------------------
+    // | {1} | 2 | 3 | 4 | 5>  -->  <4 | {5} | 6 | 7 | 8>  -->  <7 | {8} | 9 | 10 | 11>
+    // ----------------------       ---------------------       -----------------------
+    return current !== -1 ? arr[current - 1]?.[1] : undefined;
+  }
+
   public prev(
     item: string | IntersectionObserverItem,
     onlyItems?: boolean
   ): IntersectionObserverItem | undefined {
     const [arr, current] = this.getCurrentPos(item, !!onlyItems);
 
-    // We scroll to the previous plus two so the arrow button doesn't occlude the target item.
-    return current !== -1 ? arr[current + 2]?.[1] : undefined;
+    // When single scroll, only ever decrement by 1, don't adjust for occlusion.
+    return current !== -1 ? arr[current - 1]?.[1] : undefined;
   }
 
   public next(
@@ -89,8 +118,8 @@ class ItemsMap extends Map<Item[0], Item[1]> {
   ): IntersectionObserverItem | undefined {
     const [arr, current] = this.getCurrentPos(item, !!onlyItems);
 
-    // We scroll to the next minus one so the arrow button doesn't occlude the target item.
-    return current !== -1 ? arr[current - 1]?.[1] : undefined;
+    // When single scroll, only ever increment by 1, don't adjust for occlusion.
+    return current !== -1 ? arr[current + 1]?.[1] : undefined;
   }
 
   public getVisible(): Item[] {

--- a/src/components/Carousel/Tests/ItemsMap.test.ts
+++ b/src/components/Carousel/Tests/ItemsMap.test.ts
@@ -366,13 +366,32 @@ describe('ItemsMap', () => {
   describe('previous item', () => {
     describe('by key', () => {
       describe('with separators', () => {
+        test('have previous item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          expect(map.nextGroup(data[2][1])).toEqual(data[1][1]);
+          expect(map.nextGroup(data[1][1])).toEqual(data[0][1]);
+        });
+
+        test('does not have prev item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          const key = data[1][0];
+
+          expect(map.prevGroup(key)).toEqual(undefined);
+        });
+
         test('have previous item', () => {
           const map = new ItemsMap();
 
           map.set(data);
 
-          expect(map.next(data[2][1])).toEqual(data[1][1]);
-          expect(map.next(data[1][1])).toEqual(data[0][1]);
+          expect(map.prev(data[1][0])).toEqual(data[0][1]);
+          expect(map.prev(data[2][0])).toEqual(data[1][1]);
         });
 
         test('does not have prev item', () => {
@@ -380,7 +399,7 @@ describe('ItemsMap', () => {
 
           map.set(data);
 
-          const key = data[1][0];
+          const key = data[0][0];
 
           expect(map.prev(key)).toEqual(undefined);
         });
@@ -389,16 +408,39 @@ describe('ItemsMap', () => {
       describe('without separators', () => {
         const onlyItems = true;
 
+        test('have previous item group', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          expect(map.nextGroup(dataWithSeparators[4][1], onlyItems)).toEqual(
+            dataWithSeparators[2][1]
+          );
+          expect(map.nextGroup(dataWithSeparators[2][1], onlyItems)).toEqual(
+            dataWithSeparators[0][1]
+          );
+        });
+
+        test('does not have prev item group', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          expect(map.prevGroup(dataWithSeparators[1][0], onlyItems)).toEqual(
+            undefined
+          );
+        });
+
         test('have previous item', () => {
           const map = new ItemsMap();
 
           map.set(dataWithSeparators);
 
-          expect(map.next(dataWithSeparators[4][1], onlyItems)).toEqual(
-            dataWithSeparators[2][1]
-          );
-          expect(map.next(dataWithSeparators[2][1], onlyItems)).toEqual(
+          expect(map.prev(dataWithSeparators[2][0], onlyItems)).toEqual(
             dataWithSeparators[0][1]
+          );
+          expect(map.prev(dataWithSeparators[4][0], onlyItems)).toEqual(
+            dataWithSeparators[2][1]
           );
         });
 
@@ -407,7 +449,7 @@ describe('ItemsMap', () => {
 
           map.set(dataWithSeparators);
 
-          expect(map.prev(dataWithSeparators[1][0], onlyItems)).toEqual(
+          expect(map.prev(dataWithSeparators[0][0], onlyItems)).toEqual(
             undefined
           );
         });
@@ -421,19 +463,38 @@ describe('ItemsMap', () => {
 
       const item = 'aaa';
 
-      expect(map.prev(item)).toEqual(undefined);
-      expect(map.prev('')).toEqual(undefined);
+      expect(map.prevGroup(item)).toEqual(undefined);
+      expect(map.prevGroup('')).toEqual(undefined);
     });
 
     describe('by value', () => {
       describe('with separators', () => {
+        test('have previous item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          expect(map.nextGroup(data[2][1])).toEqual(data[1][1]);
+          expect(map.nextGroup(data[1][1])).toEqual(data[0][1]);
+        });
+
+        test('does not have prev item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          const item = data[2][1];
+
+          expect(map.prevGroup(item)).toEqual(undefined);
+        });
+
         test('have previous item', () => {
           const map = new ItemsMap();
 
           map.set(data);
 
-          expect(map.next(data[2][1])).toEqual(data[1][1]);
-          expect(map.next(data[1][1])).toEqual(data[0][1]);
+          expect(map.prev(data[1][1])).toEqual(data[0][1]);
+          expect(map.prev(data[2][1])).toEqual(data[1][1]);
         });
 
         test('does not have prev item', () => {
@@ -441,7 +502,7 @@ describe('ItemsMap', () => {
 
           map.set(data);
 
-          const item = data[2][1];
+          const item = data[0][1];
 
           expect(map.prev(item)).toEqual(undefined);
         });
@@ -450,16 +511,39 @@ describe('ItemsMap', () => {
       describe('without separators', () => {
         const onlyItems = true;
 
+        test('have previous item group', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          expect(map.nextGroup(dataWithSeparators[4][1], onlyItems)).toEqual(
+            dataWithSeparators[2][1]
+          );
+          expect(map.nextGroup(dataWithSeparators[2][1], onlyItems)).toEqual(
+            dataWithSeparators[0][1]
+          );
+        });
+
+        test('does not have prev item group', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          expect(map.prevGroup(dataWithSeparators[2][1], onlyItems)).toEqual(
+            undefined
+          );
+        });
+
         test('have previous item', () => {
           const map = new ItemsMap();
 
           map.set(dataWithSeparators);
 
-          expect(map.next(dataWithSeparators[4][1], onlyItems)).toEqual(
-            dataWithSeparators[2][1]
-          );
-          expect(map.next(dataWithSeparators[2][1], onlyItems)).toEqual(
+          expect(map.prev(dataWithSeparators[2][1], onlyItems)).toEqual(
             dataWithSeparators[0][1]
+          );
+          expect(map.prev(dataWithSeparators[4][1], onlyItems)).toEqual(
+            dataWithSeparators[2][1]
           );
         });
 
@@ -468,7 +552,7 @@ describe('ItemsMap', () => {
 
           map.set(dataWithSeparators);
 
-          expect(map.prev(dataWithSeparators[2][1], onlyItems)).toEqual(
+          expect(map.prev(dataWithSeparators[0][1], onlyItems)).toEqual(
             undefined
           );
         });
@@ -479,13 +563,32 @@ describe('ItemsMap', () => {
   describe('next item', () => {
     describe('by key', () => {
       describe('with separators', () => {
+        test('have next item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          expect(map.nextGroup(data[1][1])).toEqual(data[0][1]);
+          expect(map.nextGroup(data[2][1])).toEqual(data[1][1]);
+        });
+
+        test('does not have next item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          const key = data[0][0];
+
+          expect(map.nextGroup(key)).toEqual(undefined);
+        });
+
         test('have next item', () => {
           const map = new ItemsMap();
 
           map.set(data);
 
-          expect(map.next(data[1][1])).toEqual(data[0][1]);
-          expect(map.next(data[2][1])).toEqual(data[1][1]);
+          expect(map.next(data[0][0])).toEqual(data[1][1]);
+          expect(map.next(data[1][0])).toEqual(data[2][1]);
         });
 
         test('does not have next item', () => {
@@ -493,7 +596,7 @@ describe('ItemsMap', () => {
 
           map.set(data);
 
-          const key = data[0][0];
+          const key = data[2][0];
 
           expect(map.next(key)).toEqual(undefined);
         });
@@ -502,16 +605,39 @@ describe('ItemsMap', () => {
       describe('without separators', () => {
         const onlyItems = true;
 
+        test('have next item group', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          expect(map.nextGroup(dataWithSeparators[4][1], onlyItems)).toEqual(
+            dataWithSeparators[2][1]
+          );
+          expect(map.nextGroup(dataWithSeparators[2][1], onlyItems)).toEqual(
+            dataWithSeparators[0][1]
+          );
+        });
+
+        test('does not have next item group', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          expect(map.nextGroup(dataWithSeparators[1][0], onlyItems)).toEqual(
+            undefined
+          );
+        });
+
         test('have next item', () => {
           const map = new ItemsMap();
 
           map.set(dataWithSeparators);
 
-          expect(map.next(dataWithSeparators[4][1], onlyItems)).toEqual(
+          expect(map.next(dataWithSeparators[0][0], onlyItems)).toEqual(
             dataWithSeparators[2][1]
           );
-          expect(map.next(dataWithSeparators[2][1], onlyItems)).toEqual(
-            dataWithSeparators[0][1]
+          expect(map.next(dataWithSeparators[2][0], onlyItems)).toEqual(
+            dataWithSeparators[4][1]
           );
         });
 
@@ -520,7 +646,7 @@ describe('ItemsMap', () => {
 
           map.set(dataWithSeparators);
 
-          expect(map.next(dataWithSeparators[1][0], onlyItems)).toEqual(
+          expect(map.next(dataWithSeparators[4][0], onlyItems)).toEqual(
             undefined
           );
         });
@@ -534,19 +660,38 @@ describe('ItemsMap', () => {
 
       const item = 'aaa';
 
-      expect(map.next(item)).toEqual(undefined);
-      expect(map.next('')).toEqual(undefined);
+      expect(map.nextGroup(item)).toEqual(undefined);
+      expect(map.nextGroup('')).toEqual(undefined);
     });
 
     describe('by value', () => {
       describe('without separators', () => {
+        test('have next item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          expect(map.nextGroup(data[1][1])).toEqual(data[0][1]);
+          expect(map.nextGroup(data[2][1])).toEqual(data[1][1]);
+        });
+
+        test('does not have next item group', () => {
+          const map = new ItemsMap();
+
+          map.set(data);
+
+          const item = data.slice(-3)[0][1];
+
+          expect(map.nextGroup(item)).toEqual(undefined);
+        });
+
         test('have next item', () => {
           const map = new ItemsMap();
 
           map.set(data);
 
-          expect(map.next(data[1][1])).toEqual(data[0][1]);
-          expect(map.next(data[2][1])).toEqual(data[1][1]);
+          expect(map.next(data[0][1])).toEqual(data[1][1]);
+          expect(map.next(data[1][1])).toEqual(data[2][1]);
         });
 
         test('does not have next item', () => {
@@ -554,7 +699,7 @@ describe('ItemsMap', () => {
 
           map.set(data);
 
-          const item = data.slice(-3)[0][1];
+          const item = data.slice(-1)[0][1];
 
           expect(map.next(item)).toEqual(undefined);
         });
@@ -563,18 +708,41 @@ describe('ItemsMap', () => {
       describe('without separators', () => {
         const onlyItems = true;
 
-        test('have next item', () => {
+        test('have next item group', () => {
           const map = new ItemsMap();
 
           map.set(dataWithSeparators);
 
           console.log(dataWithSeparators);
 
-          expect(map.next(dataWithSeparators[4][1], onlyItems)).toEqual(
+          expect(map.nextGroup(dataWithSeparators[4][1], onlyItems)).toEqual(
+            dataWithSeparators[2][1]
+          );
+          expect(map.nextGroup(dataWithSeparators[2][1], onlyItems)).toEqual(
+            dataWithSeparators[0][1]
+          );
+        });
+
+        test('does not have next item group', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          const item = dataWithSeparators.slice(-2)[0][1];
+
+          expect(map.nextGroup(item, onlyItems)).toEqual(undefined);
+        });
+
+        test('have next item', () => {
+          const map = new ItemsMap();
+
+          map.set(dataWithSeparators);
+
+          expect(map.next(dataWithSeparators[0][1], onlyItems)).toEqual(
             dataWithSeparators[2][1]
           );
           expect(map.next(dataWithSeparators[2][1], onlyItems)).toEqual(
-            dataWithSeparators[0][1]
+            dataWithSeparators[4][1]
           );
         });
 
@@ -583,7 +751,7 @@ describe('ItemsMap', () => {
 
           map.set(dataWithSeparators);
 
-          const item = dataWithSeparators.slice(-2)[0][1];
+          const item = dataWithSeparators.slice(-1)[0][1];
 
           expect(map.next(item, onlyItems)).toEqual(undefined);
         });

--- a/src/components/Carousel/Tests/ScrollMenu.test.tsx
+++ b/src/components/Carousel/Tests/ScrollMenu.test.tsx
@@ -473,13 +473,22 @@ function comparePublicApi(call: autoScrollApiType) {
   const {
     getItemById,
     getItemByIndex,
+    getNextElement,
+    getNextElementGroup,
     getNextItem,
+    getNextItemGroup,
+    getPrevElement,
+    getPrevElementGroup,
     getPrevItem,
+    getPrevItemGroup,
     isItemVisible,
     isLastItem,
     scrollNext,
+    scrollNextGroup,
     scrollPrev,
+    scrollPrevGroup,
     scrollToItem,
+    scrollBySingleItem,
     visibleElementsWithSeparators,
     visibleElements,
     initComplete,
@@ -491,11 +500,20 @@ function comparePublicApi(call: autoScrollApiType) {
 
   expect(getItemById).toEqual(expect.any(Function));
   expect(getItemByIndex).toEqual(expect.any(Function));
+  expect(getNextElement).toEqual(expect.any(Function));
+  expect(getNextElementGroup).toEqual(expect.any(Function));
   expect(getNextItem).toEqual(expect.any(Function));
+  expect(getNextItemGroup).toEqual(expect.any(Function));
+  expect(getPrevElement).toEqual(expect.any(Function));
+  expect(getPrevElementGroup).toEqual(expect.any(Function));
   expect(getPrevItem).toEqual(expect.any(Function));
+  expect(getPrevItemGroup).toEqual(expect.any(Function));
   expect(isItemVisible).toEqual(expect.any(Function));
   expect(isLastItem).toEqual(expect.any(Function));
+  expect(scrollBySingleItem).toEqual(expect.any(Function));
   expect(scrollNext).toEqual(expect.any(Function));
+  expect(scrollNextGroup).toEqual(expect.any(Function));
+  expect(scrollPrevGroup).toEqual(expect.any(Function));
   expect(scrollPrev).toEqual(expect.any(Function));
   expect(scrollToItem).toEqual(expect.any(Function));
   expect(visibleElementsWithSeparators).toEqual(defaultItemsWithSeparators);

--- a/src/components/Carousel/Tests/Utilities.test.tsx
+++ b/src/components/Carousel/Tests/Utilities.test.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-  filterSeparators,
-  getElementOrConstructor,
-  getItemElementById,
-  getItemElementByIndex,
-  getItemId,
-  getNodesFromRefs,
-  observerEntriesToItems,
-  scrollToItem,
-} from '../Utilities';
+import * as utilities from '../Utilities';
 import { observerOptions } from '../Settings';
 import { IntersectionObserverItem } from '../Carousel.types';
 import scrollIntoView from 'smooth-scroll-into-view-if-needed';
@@ -22,7 +13,7 @@ describe('getNodesFromRefs', () => {
       node2: { current: null as any },
     };
 
-    expect(getNodesFromRefs(refs)).toEqual([]);
+    expect(utilities.getNodesFromRefs(refs)).toEqual([]);
   });
 
   test('should return array of nodes for existing regs', () => {
@@ -33,13 +24,13 @@ describe('getNodesFromRefs', () => {
 
     const result = Object.values(refs).map((ref) => ref.current);
 
-    expect(getNodesFromRefs(refs as any)).toEqual(result);
+    expect(utilities.getNodesFromRefs(refs as any)).toEqual(result);
   });
 });
 
 describe('observerEntriesToItems', () => {
   test('should return empty array if no entries', () => {
-    expect(observerEntriesToItems([], observerOptions)).toEqual([]);
+    expect(utilities.observerEntriesToItems([], observerOptions)).toEqual([]);
   });
 
   test('should return items if entries exist', () => {
@@ -98,7 +89,10 @@ describe('observerEntriesToItems', () => {
     ];
 
     expect(
-      observerEntriesToItems(entries, { ...observerOptions, ratio: 0.5 })
+      utilities.observerEntriesToItems(entries, {
+        ...observerOptions,
+        ratio: 0.5,
+      })
     ).toEqual(result);
   });
 });
@@ -120,7 +114,7 @@ describe('scrollToItem', () => {
       duration: 400,
     };
 
-    scrollToItem(item);
+    utilities.scrollToItem(item);
 
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
     expect(scrollIntoView).toHaveBeenNthCalledWith(
@@ -140,7 +134,14 @@ describe('scrollToItem', () => {
     } as unknown as IntersectionObserverItem;
 
     const noPolyfill = true;
-    scrollToItem(item, undefined, undefined, undefined, undefined, noPolyfill);
+    utilities.scrollToItem(
+      item,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      noPolyfill
+    );
 
     expect(scrollIntoView).not.toHaveBeenCalled();
     expect(standartScrollIntoViewMock).toHaveBeenCalled();
@@ -156,7 +157,7 @@ describe('scrollToItem', () => {
       ease: (t: number) => t / 2,
       boundary: document.createElement('div'),
     };
-    scrollToItem(item, 'auto', 'end', 'center', options);
+    utilities.scrollToItem(item, 'auto', 'end', 'center', options);
 
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
     expect(scrollIntoView).toHaveBeenNthCalledWith(1, item.entry.target, {
@@ -168,7 +169,7 @@ describe('scrollToItem', () => {
   });
 
   test('should not scroll if target not provided', () => {
-    scrollToItem(undefined);
+    utilities.scrollToItem(undefined);
 
     expect(scrollIntoView).not.toHaveBeenCalled();
   });
@@ -182,7 +183,7 @@ describe('getItemElementById', () => {
     <div>other node</div>
     <div data-key=123 />other2</div>`;
 
-    const result = getItemElementById(id);
+    const result = utilities.getItemElementById(id);
 
     expect(result instanceof HTMLDivElement).toBeTruthy();
     expect(result?.textContent).toEqual(id);
@@ -195,9 +196,9 @@ describe('getItemElementById', () => {
     <div>other node</div>
     <div data-key=123 />other2</div>`;
 
-    expect(getItemElementById('test456')).toEqual(null);
-    expect(getItemElementById(456)).toEqual(null);
-    expect(getItemElementById('')).toEqual(null);
+    expect(utilities.getItemElementById('test456')).toEqual(null);
+    expect(utilities.getItemElementById(456)).toEqual(null);
+    expect(utilities.getItemElementById('')).toEqual(null);
   });
 });
 
@@ -209,7 +210,7 @@ describe('getItemElementByIndex', () => {
     <div>other node</div>
     <div data-key=123 />other2</div>`;
 
-    const result = getItemElementByIndex(index);
+    const result = utilities.getItemElementByIndex(index);
 
     expect(result instanceof HTMLDivElement).toBeTruthy();
     expect(result?.textContent).toEqual(index);
@@ -222,9 +223,9 @@ describe('getItemElementByIndex', () => {
     <div>other node</div>
     <div data-key=123 />other2</div>`;
 
-    expect(getItemElementByIndex('456')).toEqual(null);
-    expect(getItemElementByIndex(456)).toEqual(null);
-    expect(getItemElementByIndex('')).toEqual(null);
+    expect(utilities.getItemElementByIndex('456')).toEqual(null);
+    expect(utilities.getItemElementByIndex(456)).toEqual(null);
+    expect(utilities.getItemElementByIndex('')).toEqual(null);
   });
 });
 
@@ -233,24 +234,24 @@ describe('getElementOrConstructor', () => {
   const JsxElemConstructor = () => JsxElem;
 
   test('should return jsx element if jsx elem passed', () => {
-    expect(getElementOrConstructor(JsxElem)).toEqual(JsxElem);
+    expect(utilities.getElementOrConstructor(JsxElem)).toEqual(JsxElem);
   });
 
   test('should return a jsx elem if constructor passed', () => {
-    expect(getElementOrConstructor(JsxElemConstructor)).toEqual(
+    expect(utilities.getElementOrConstructor(JsxElemConstructor)).toEqual(
       <JsxElemConstructor />
     );
   });
 
   test('should return null if no element passed', () => {
-    expect(getElementOrConstructor(undefined)).toEqual(null);
+    expect(utilities.getElementOrConstructor(undefined)).toEqual(null);
   });
 });
 
 describe('filterSeparators', () => {
   test('should filter separators from items', () => {
     expect(
-      filterSeparators([
+      utilities.filterSeparators([
         'test0',
         'test0-separator',
         'test1',
@@ -266,8 +267,11 @@ describe('filterSeparators', () => {
   });
 
   test('should return argument if nothing to filter', () => {
-    expect(filterSeparators(['test0', 'test1'])).toEqual(['test0', 'test1']);
-    expect(filterSeparators([])).toEqual([]);
+    expect(utilities.filterSeparators(['test0', 'test1'])).toEqual([
+      'test0',
+      'test1',
+    ]);
+    expect(utilities.filterSeparators([])).toEqual([]);
   });
 });
 
@@ -279,23 +283,25 @@ describe('getItemId', () => {
     );
 
     it('should return itemId if exists', () => {
-      expect(getItemId(<Elem itemId={id} />)).toEqual(id);
-      expect(getItemId(<Elem itemId={id} key={id} />)).toEqual(id);
+      expect(utilities.getItemId(<Elem itemId={id} />)).toEqual(id);
+      expect(utilities.getItemId(<Elem itemId={id} key={id} />)).toEqual(id);
     });
 
     it('should work if "id" is number', () => {
       const id = 123;
       const expected = String(id);
-      expect(getItemId(<Elem itemId={id} />)).toEqual(expected);
-      expect(getItemId(<Elem itemId={id} key={id} />)).toEqual(expected);
+      expect(utilities.getItemId(<Elem itemId={id} />)).toEqual(expected);
+      expect(utilities.getItemId(<Elem itemId={id} key={id} />)).toEqual(
+        expected
+      );
     });
 
     it('should return key if itemId does not exists', () => {
-      expect(getItemId(<Elem key={id} />)).toEqual(id);
+      expect(utilities.getItemId(<Elem key={id} />)).toEqual(id);
     });
 
     it('should return empty string if itemId and key does not exists', () => {
-      expect(getItemId(<Elem />)).toEqual('');
+      expect(utilities.getItemId(<Elem />)).toEqual('');
     });
   });
 });

--- a/src/components/Carousel/Tests/autoScrollApi.test.ts
+++ b/src/components/Carousel/Tests/autoScrollApi.test.ts
@@ -174,6 +174,28 @@ describe('autoScrollApi', () => {
       });
     });
 
+    describe('scrollBySingleItem', () => {
+      test('should call scrollBy', () => {
+        const scrollBySingleItemSpy = jest.spyOn(
+          utilities,
+          'scrollBySingleItem'
+        );
+        const { items, visibleElementsWithSeparators } = setup([0.7, 0, 0]);
+        const boundary = { current: document.createElement('div') };
+        autoScrollApi(
+          items,
+          visibleElementsWithSeparators,
+          boundary
+        ).scrollBySingleItem(
+          document.createElement('div'),
+          'smooth',
+          'next',
+          8
+        );
+        expect(scrollBySingleItemSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+
     test('getItemElementById', () => {
       const { items, visibleElementsWithSeparators } = setup([0.7, 0, 0]);
 
@@ -322,11 +344,11 @@ describe('autoScrollApi', () => {
 
       expect(
         autoScrollApi(items, visibleElementsWithSeparators).getPrevItem()
-      ).toEqual(nodes[0.1]);
+      ).toEqual(nodes[0]);
     });
 
     test('does not have previous item', () => {
-      const { items, visibleElementsWithSeparators } = setup([0, 0.1, 1]);
+      const { items, visibleElementsWithSeparators } = setup([1, 0.1, 0.3]);
 
       expect(
         autoScrollApi(items, visibleElementsWithSeparators).getPrevItem()
@@ -334,18 +356,38 @@ describe('autoScrollApi', () => {
     });
   });
 
+  describe('getPrevItemGroup', () => {
+    test('have previous item group', () => {
+      const { items, nodes, visibleElementsWithSeparators } = setup([
+        0.1, 1, 0.9,
+      ]);
+
+      expect(
+        autoScrollApi(items, visibleElementsWithSeparators).getPrevItemGroup()
+      ).toEqual(nodes[0.1]);
+    });
+
+    test('does not have previous item group', () => {
+      const { items, visibleElementsWithSeparators } = setup([0, 0.1, 1]);
+
+      expect(
+        autoScrollApi(items, visibleElementsWithSeparators).getPrevItemGroup()
+      ).toEqual(undefined);
+    });
+  });
+
   describe('getPrevElement', () => {
-    test('have previous item', () => {
+    test('have previous element', () => {
       const { items, nodes, visibleElementsWithSeparators } = setup([
         0.1, 1, 0.9,
       ]);
 
       expect(
         autoScrollApi(items, visibleElementsWithSeparators).getPrevElement()
-      ).toEqual(nodes[0.1]);
+      ).toEqual(nodes[0]);
     });
 
-    test('does not have previous item', () => {
+    test('does not have previous element', () => {
       const { items, visibleElementsWithSeparators } = setup([1, 0.1, 0.3]);
 
       expect(
@@ -354,18 +396,44 @@ describe('autoScrollApi', () => {
     });
   });
 
+  describe('getPrevElementGroup', () => {
+    test('have previous element group', () => {
+      const { items, nodes, visibleElementsWithSeparators } = setup([
+        0.1, 1, 0.9,
+      ]);
+
+      expect(
+        autoScrollApi(
+          items,
+          visibleElementsWithSeparators
+        ).getPrevElementGroup()
+      ).toEqual(nodes[0.1]);
+    });
+
+    test('does not have previous element group', () => {
+      const { items, visibleElementsWithSeparators } = setup([1, 0.1, 0.3]);
+
+      expect(
+        autoScrollApi(
+          items,
+          visibleElementsWithSeparators
+        ).getPrevElementGroup()
+      ).toEqual(undefined);
+    });
+  });
+
   describe('getNextItem', () => {
     test('have next item', () => {
       const { items, nodes, visibleElementsWithSeparators } = setup([
-        1, 1, 1.1,
+        1, 1, 0.3,
       ]);
       expect(
         autoScrollApi(items, visibleElementsWithSeparators).getNextItem()
-      ).toEqual(nodes[1]);
+      ).toEqual(nodes[2]);
     });
 
     test('does not have next item', () => {
-      const { items, visibleElementsWithSeparators } = setup([0, 0.1]);
+      const { items, visibleElementsWithSeparators } = setup([0, 0.1, 0.9]);
 
       expect(
         autoScrollApi(items, visibleElementsWithSeparators).getNextItem()
@@ -373,21 +441,65 @@ describe('autoScrollApi', () => {
     });
   });
 
+  describe('getNextItemGroup', () => {
+    test('have next item group', () => {
+      const { items, nodes, visibleElementsWithSeparators } = setup([
+        1, 1, 1.1,
+      ]);
+      expect(
+        autoScrollApi(items, visibleElementsWithSeparators).getNextItemGroup()
+      ).toEqual(nodes[1]);
+    });
+
+    test('does not have next item group', () => {
+      const { items, visibleElementsWithSeparators } = setup([0, 0.1]);
+
+      expect(
+        autoScrollApi(items, visibleElementsWithSeparators).getNextItemGroup()
+      ).toEqual(undefined);
+    });
+  });
+
   describe('getNextElement', () => {
-    test('have next item', () => {
+    test('have next element', () => {
+      const { items, nodes, visibleElementsWithSeparators } = setup([
+        1, 1, 0.1,
+      ]);
+      expect(
+        autoScrollApi(items, visibleElementsWithSeparators).getNextElement()
+      ).toEqual(nodes[2]);
+    });
+
+    test('does not have next element', () => {
+      const { items, visibleElementsWithSeparators } = setup([0, 0.1, 0.9]);
+
+      expect(
+        autoScrollApi(items, visibleElementsWithSeparators).getNextElement()
+      ).toEqual(undefined);
+    });
+  });
+
+  describe('getNextElementGroup', () => {
+    test('have next element group', () => {
       const { items, nodes, visibleElementsWithSeparators } = setup([
         0, 0.1, 1, 1.1, 2,
       ]);
       expect(
-        autoScrollApi(items, visibleElementsWithSeparators).getNextElement()
+        autoScrollApi(
+          items,
+          visibleElementsWithSeparators
+        ).getNextElementGroup()
       ).toEqual(nodes[0]);
     });
 
-    test('does not have next item', () => {
+    test('does not have next element group', () => {
       const { items, visibleElementsWithSeparators } = setup([0, 0.1]);
 
       expect(
-        autoScrollApi(items, visibleElementsWithSeparators).getNextElement()
+        autoScrollApi(
+          items,
+          visibleElementsWithSeparators
+        ).getNextElementGroup()
       ).toEqual(undefined);
     });
   });
@@ -416,7 +528,7 @@ describe('autoScrollApi', () => {
 
   describe('scrollPrev', () => {
     test('have previous item', () => {
-      const { items, nodes, visibleElementsWithSeparators } = setup([1, 2, 3]);
+      const { items, nodes, visibleElementsWithSeparators } = setup([0, 1, 1]);
 
       const boundary = { current: document.createElement('li') };
       autoScrollApi(
@@ -426,7 +538,7 @@ describe('autoScrollApi', () => {
       ).scrollPrev();
 
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
-      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[2].entry.target, {
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[0].entry.target, {
         behavior: 'smooth',
         block: 'nearest',
         inline: 'end',
@@ -436,8 +548,37 @@ describe('autoScrollApi', () => {
       });
     });
 
+    describe('scrollPrevGroup', () => {
+      test('have previous group', () => {
+        const { items, nodes, visibleElementsWithSeparators } = setup([
+          1, 2, 3,
+        ]);
+
+        const boundary = { current: document.createElement('li') };
+        autoScrollApi(
+          items,
+          visibleElementsWithSeparators,
+          boundary
+        ).scrollPrevGroup();
+
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        expect(scrollIntoView).toHaveBeenNthCalledWith(
+          1,
+          nodes[2].entry.target,
+          {
+            behavior: 'smooth',
+            block: 'nearest',
+            inline: 'end',
+            duration: undefined,
+            ease: undefined,
+            boundary: boundary.current,
+          }
+        );
+      });
+    });
+
     test('no prev item', () => {
-      const { items, visibleElementsWithSeparators } = setup([0, 1]);
+      const { items, visibleElementsWithSeparators } = setup([1, 1, 1]);
 
       autoScrollApi(items, visibleElementsWithSeparators).scrollPrev();
 
@@ -445,7 +586,7 @@ describe('autoScrollApi', () => {
     });
 
     test('should pass rtl to scrollToItem', () => {
-      const { items, visibleElementsWithSeparators } = setup([0, 1, 2, 3]);
+      const { items, visibleElementsWithSeparators } = setup([0, 1, 1]);
       const scrollToItemSpy = jest.spyOn(utilities, 'scrollToItem');
 
       const rtl = true;
@@ -481,8 +622,35 @@ describe('autoScrollApi', () => {
       expect(noPolyfillrop).toEqual(noPolyfill);
     });
 
-    test('with transition options', () => {
+    test('group with transition options', () => {
       const { items, nodes, visibleElementsWithSeparators } = setup([1, 2, 3]);
+
+      const boundary = { current: document.createElement('div') };
+      const transitionOptions = {
+        duration: 400,
+        ease: (t: number) => t,
+        behavior: () => false,
+      };
+      autoScrollApi(
+        items,
+        visibleElementsWithSeparators,
+        boundary,
+        transitionOptions
+      ).scrollPrevGroup();
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[2].entry.target, {
+        behavior: transitionOptions.behavior,
+        block: 'nearest',
+        inline: 'end',
+        duration: transitionOptions.duration,
+        ease: transitionOptions.ease,
+        boundary: boundary.current,
+      });
+    });
+
+    test('default with transition options', () => {
+      const { items, nodes, visibleElementsWithSeparators } = setup([0, 1, 1]);
 
       const boundary = { current: document.createElement('div') };
       const transitionOptions = {
@@ -498,7 +666,7 @@ describe('autoScrollApi', () => {
       ).scrollPrev();
 
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
-      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[2].entry.target, {
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[0].entry.target, {
         behavior: transitionOptions.behavior,
         block: 'nearest',
         inline: 'end',
@@ -508,7 +676,7 @@ describe('autoScrollApi', () => {
       });
     });
 
-    test('arguments should have priority over transitionOptions', () => {
+    test('group arguments should have priority over transitionOptions', () => {
       const { items, nodes, visibleElementsWithSeparators } = setup([1, 2, 3]);
 
       const boundary = { current: document.createElement('div') };
@@ -522,7 +690,7 @@ describe('autoScrollApi', () => {
         visibleElementsWithSeparators,
         boundary,
         transitionOptions
-      ).scrollPrev('auto', 'center', 'center');
+      ).scrollPrevGroup('auto', 'center', 'center');
 
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
       expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[2].entry.target, {
@@ -536,11 +704,36 @@ describe('autoScrollApi', () => {
     });
   });
 
+  test('default arguments should have priority over transitionOptions', () => {
+    const { items, nodes, visibleElementsWithSeparators } = setup([0, 1, 1]);
+
+    const boundary = { current: document.createElement('div') };
+    const transitionOptions = {
+      duration: 500,
+      ease: (t: number) => t,
+      behavior: () => false,
+    };
+    autoScrollApi(
+      items,
+      visibleElementsWithSeparators,
+      boundary,
+      transitionOptions
+    ).scrollPrev('auto', 'center', 'center');
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[0].entry.target, {
+      behavior: 'auto',
+      block: 'center',
+      inline: 'center',
+      duration: transitionOptions.duration,
+      ease: transitionOptions.ease,
+      boundary: boundary.current,
+    });
+  });
+
   describe('scrollNext', () => {
     test('have next item', () => {
-      const { items, nodes, visibleElementsWithSeparators } = setup([
-        1, 2, 3, 4,
-      ]);
+      const { items, nodes, visibleElementsWithSeparators } = setup([1, 1, 0]);
 
       const boundary = { current: document.createElement('li') };
       autoScrollApi(
@@ -550,13 +743,42 @@ describe('autoScrollApi', () => {
       ).scrollNext();
 
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
-      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[1].entry.target, {
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[2].entry.target, {
         behavior: 'smooth',
         block: 'nearest',
         inline: 'start',
         duration: undefined,
         ease: undefined,
         boundary: boundary.current,
+      });
+    });
+
+    describe('scrollNextGroup', () => {
+      test('have next group', () => {
+        const { items, nodes, visibleElementsWithSeparators } = setup([
+          1, 2, 3, 4,
+        ]);
+
+        const boundary = { current: document.createElement('li') };
+        autoScrollApi(
+          items,
+          visibleElementsWithSeparators,
+          boundary
+        ).scrollNextGroup();
+
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        expect(scrollIntoView).toHaveBeenNthCalledWith(
+          1,
+          nodes[1].entry.target,
+          {
+            behavior: 'smooth',
+            block: 'nearest',
+            inline: 'start',
+            duration: undefined,
+            ease: undefined,
+            boundary: boundary.current,
+          }
+        );
       });
     });
 
@@ -605,7 +827,34 @@ describe('autoScrollApi', () => {
       expect(noPolyfillrop).toEqual(noPolyfill);
     });
 
-    test('with transition options', () => {
+    test('group with transition options', () => {
+      const { items, nodes, visibleElementsWithSeparators } = setup([1, 1, 0]);
+
+      const boundary = { current: document.createElement('li') };
+      const transitionOptions = {
+        duration: 400,
+        ease: (t: number) => t,
+        behavior: () => false,
+      };
+      autoScrollApi(
+        items,
+        visibleElementsWithSeparators,
+        boundary,
+        transitionOptions
+      ).scrollNextGroup();
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[0].entry.target, {
+        behavior: transitionOptions.behavior,
+        block: 'nearest',
+        inline: 'start',
+        duration: transitionOptions.duration,
+        ease: transitionOptions.ease,
+        boundary: boundary.current,
+      });
+    });
+
+    test('default with transition options', () => {
       const { items, nodes, visibleElementsWithSeparators } = setup([1, 1, 0]);
 
       const boundary = { current: document.createElement('li') };
@@ -622,7 +871,7 @@ describe('autoScrollApi', () => {
       ).scrollNext();
 
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
-      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[0].entry.target, {
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[2].entry.target, {
         behavior: transitionOptions.behavior,
         block: 'nearest',
         inline: 'start',
@@ -632,7 +881,34 @@ describe('autoScrollApi', () => {
       });
     });
 
-    test('arguments should have priority over transitionOptions', () => {
+    test('group arguments should have priority over transitionOptions', () => {
+      const { items, nodes, visibleElementsWithSeparators } = setup([1, 1, 0]);
+
+      const boundary = { current: document.createElement('div') };
+      const transitionOptions = {
+        duration: 400,
+        ease: (t: number) => t,
+        behavior: () => false,
+      };
+      autoScrollApi(
+        items,
+        visibleElementsWithSeparators,
+        boundary,
+        transitionOptions
+      ).scrollNextGroup('auto', 'center', 'center');
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[0].entry.target, {
+        behavior: 'auto',
+        block: 'center',
+        inline: 'center',
+        duration: transitionOptions.duration,
+        ease: transitionOptions.ease,
+        boundary: boundary.current,
+      });
+    });
+
+    test('default arguments should have priority over transitionOptions', () => {
       const { items, nodes, visibleElementsWithSeparators } = setup([1, 1, 0]);
 
       const boundary = { current: document.createElement('div') };
@@ -649,7 +925,7 @@ describe('autoScrollApi', () => {
       ).scrollNext('auto', 'center', 'center');
 
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
-      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[0].entry.target, {
+      expect(scrollIntoView).toHaveBeenNthCalledWith(1, nodes[2].entry.target, {
         behavior: 'auto',
         block: 'center',
         inline: 'center',

--- a/src/components/Carousel/Tests/useItemsChanged.test.tsx
+++ b/src/components/Carousel/Tests/useItemsChanged.test.tsx
@@ -155,7 +155,6 @@ describe('useItemsChanged', () => {
         'child1',
         'child1-separator',
         'chidl2',
-        'child2-separator',
       ]);
 
       const newHash = JSON.parse(utils.getByTestId('hash').textContent!);

--- a/src/components/Carousel/Utilities/index.ts
+++ b/src/components/Carousel/Utilities/index.ts
@@ -6,3 +6,4 @@ export * from './getItemId';
 export * from './getNodesFromRefs';
 export * from './observerEntriesToItems';
 export * from './scrollToItem';
+export * from './scrollBySingleItem';

--- a/src/components/Carousel/Utilities/scrollBySingleItem.tsx
+++ b/src/components/Carousel/Utilities/scrollBySingleItem.tsx
@@ -1,0 +1,32 @@
+import { CustomScrollBehaviorCallback } from 'scroll-into-view-if-needed/typings/types';
+import {
+  CustomScrollBehavior,
+  IntersectionObserverItem,
+  ItemOrElement,
+} from '../Carousel.types';
+
+// TODO: Currently, scrollIntoView API, nor it's extended versions afford an offset to avoid
+// occlusion of menu items when single scroll. For now use scrollBy API, then find a normailized solution.
+export function scrollBySingleItem<T>(
+  item: ItemOrElement,
+  behavior?: ScrollBehavior | CustomScrollBehavior<T>,
+  direction?: string,
+  gap?: number,
+  offset?: number
+): T | Promise<T> | void {
+  const _item: Element =
+    (item as IntersectionObserverItem)?.entry?.target || (item as Element);
+  const _behavior: ScrollBehavior | CustomScrollBehaviorCallback<T> =
+    behavior || 'smooth';
+
+  if (_item) {
+    const gapMultiplierValue: number = gap * 2;
+    const scrollDistance: number =
+      _item.getBoundingClientRect().width - gapMultiplierValue + offset;
+
+    return _item.parentElement?.scrollBy({
+      left: direction === 'next' ? scrollDistance : -scrollDistance,
+      behavior: _behavior as ScrollBehavior,
+    });
+  }
+}

--- a/src/components/Carousel/autoScrollApi.ts
+++ b/src/components/Carousel/autoScrollApi.ts
@@ -1,6 +1,7 @@
 import {
   filterSeparators,
   scrollToItem,
+  scrollBySingleItem,
   getItemElementById,
   getItemElementByIndex,
 } from './Utilities';
@@ -42,6 +43,18 @@ export const autoScrollApi = (
   const isItemVisible: (id: string) => boolean = (id: string) =>
     visibleElements.includes(String(id));
 
+  const getPrevItemGroup: () => IntersectionObserverItem = () =>
+    items.prevGroup(items.getVisible()?.[0]?.[1]);
+
+  const getPrevElementGroup: () => IntersectionObserverItem = () =>
+    items.prevGroup(items.getVisibleElements()?.[0]?.[1], true);
+
+  const getNextItemGroup: () => IntersectionObserverItem = () =>
+    items.nextGroup(items.getVisible()?.slice?.(-1)?.[0]?.[1]);
+
+  const getNextElementGroup: () => IntersectionObserverItem = () =>
+    items.nextGroup(items.getVisibleElements()?.slice?.(-1)?.[0]?.[1], true);
+
   const getPrevItem: () => IntersectionObserverItem = () =>
     items.prev(items.getVisible()?.[0]?.[1]);
 
@@ -56,6 +69,60 @@ export const autoScrollApi = (
 
   const isLastItem: (id: string) => boolean = (id: string) =>
     items.last() === getItemById(id);
+
+  const scrollPrevGroup = <T>(
+    behavior?: CustomScrollBehavior<T>,
+    inline?: ScrollLogicalPosition,
+    block?: ScrollLogicalPosition,
+    {
+      duration,
+      ease,
+      boundary = boundaryElement?.current,
+    }: scrollToItemOptions = {}
+  ) => {
+    const _behavior = (behavior ??
+      transitionOptions?.behavior) as ScrollBehavior;
+
+    return scrollToItem(
+      getPrevItemGroup(),
+      _behavior,
+      inline || 'end',
+      block || 'nearest',
+      {
+        boundary,
+        duration: duration ?? transitionOptions?.duration,
+        ease: ease ?? transitionOptions?.ease,
+      },
+      rtl || noPolyfill
+    );
+  };
+
+  const scrollNextGroup = <T>(
+    behavior?: CustomScrollBehavior<T>,
+    inline?: ScrollLogicalPosition,
+    block?: ScrollLogicalPosition,
+    {
+      duration,
+      ease,
+      boundary = boundaryElement?.current,
+    }: scrollToItemOptions = {}
+  ) => {
+    const _behavior = (behavior ??
+      transitionOptions?.behavior) as ScrollBehavior;
+
+    return scrollToItem(
+      getNextItemGroup(),
+      _behavior,
+      inline || 'start',
+      block || 'nearest',
+      {
+        boundary,
+        duration: duration ?? transitionOptions?.duration,
+        ease: ease ?? transitionOptions?.ease,
+      },
+      rtl || noPolyfill
+    );
+  };
 
   const scrollPrev = <T>(
     behavior?: CustomScrollBehavior<T>,
@@ -117,15 +184,39 @@ export const autoScrollApi = (
     getItemByIndex,
     getItemElementByIndex,
     getNextItem,
+    getNextItemGroup,
     getNextElement,
+    getNextElementGroup,
     getPrevItem,
+    getPrevItemGroup,
     getPrevElement,
+    getPrevElementGroup,
     isFirstItemVisible,
     isItemVisible,
     isLastItem,
     isLastItemVisible,
+    scrollBySingleItem: <T>(
+      target?: ItemOrElement,
+      behavior?: CustomScrollBehavior<T>,
+      direction?: string,
+      gap?: number,
+      offset?: number
+    ) => {
+      const _behavior: string | Function =
+        behavior ?? transitionOptions?.behavior;
+
+      return scrollBySingleItem(
+        target,
+        _behavior as ScrollBehavior | CustomScrollBehavior<T>,
+        direction,
+        gap,
+        offset
+      );
+    },
     scrollNext,
+    scrollNextGroup,
     scrollPrev,
+    scrollPrevGroup,
     scrollToItem: <T>(
       target?: ItemOrElement,
       behavior?: CustomScrollBehavior<T>,


### PR DESCRIPTION
## SUMMARY:

- Adds `single` prop to `Carousel`
- Handle mouse wheel scroll when it's over the carousel, so that scrolling the view vertically is prevented
- Adds `scrollBySingleItem` utility to take advantage of the `scrollBy` api to account for various occlusion offsets needed because the paddles overlap the content of the scrollable list
- Updates API methods to isolate group scroll
- Updates UTs

https://user-images.githubusercontent.com/99700808/217393035-bd24777b-d550-49ec-a972-68b76ebd7485.mp4

## JIRA TASK (Eightfold Employees Only):
ENG-42767

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Carousel` stories behave as expected.