### PR TITLE
fix: do not provide default colors for ConfigProvider

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -549,30 +549,6 @@ Theming.args = {
   // customizations the storybook user has applied so far.
   themeOptions: {
     name: 'blue',
-    customTheme: {
-      varTheme: undefined,
-      tabsTheme: {
-        label: '--text-secondary-color',
-        activeLabel: '--primary-color',
-        activeBackground: 'transparent',
-        hoverLabel: '--primary-color',
-        hoverBackground: 'transparent',
-        indicatorColor: '--primary-color',
-        smallActiveBackground: 'transparent',
-        smallHoverBackground: 'transparent',
-        pillLabel: '--text-secondary-color',
-        pillActiveLabel: '--primary-color',
-        pillActiveBackground: '--accent-color-20',
-        pillHoverLabel: '--primary-color',
-        pillBackground: '--grey-color-10',
-      },
-      navbarTheme: {
-        background: '--primary-color-80',
-        textColor: '--primary-color-10',
-        textHoverBackground: '--primary-color-80',
-        textHoverColor: '--primary-color-20',
-      },
-    },
   } as ThemeOptions,
   icomoonIconSet: {},
   children: <ThemedComponents />,

--- a/src/components/ConfigProvider/ConfigProvider.types.ts
+++ b/src/components/ConfigProvider/ConfigProvider.types.ts
@@ -88,7 +88,7 @@ export interface ConfigProviderProps {
   size?: Size;
   /**
    * Options for theming
-   * @default { name: 'blue', useSystemTheme: false, customTheme: null }
+   * @default { name: 'blue', customTheme: null }
    */
   themeOptions?: ThemeOptions;
 }

--- a/src/components/ConfigProvider/Theming/Theming.types.ts
+++ b/src/components/ConfigProvider/Theming/Theming.types.ts
@@ -66,12 +66,6 @@ export interface ThemeOptions {
    */
   name?: ThemeName;
   /**
-   * Use system theme or not
-   * @default false
-   * @experimental
-   */
-  useSystemTheme?: boolean;
-  /**
    * Define a custom theme palette
    * @type {OcBaseTheme}
    * @default null

--- a/src/components/ConfigProvider/Theming/themes.ts
+++ b/src/components/ConfigProvider/Theming/themes.ts
@@ -1,36 +1,8 @@
 import { OcBaseTheme, OcTheme, OcThemeName } from './Theming.types';
 
-export const themeDefaults: OcBaseTheme = {
-  textColor: '#1A212E',
-  textColorSecondary: '#4F5666',
-  textColorInverse: '#fff',
-  backgroundColor: '#fff',
-  successColor: '#2B715F',
-  warningColor: '#9D6309',
-  infoColor: '#4F5666',
-  errorColor: '#993838',
-  tabsTheme: {
-    label: '#4F5666',
-    activeLabel: '#146DA6',
-    activeBackground: 'transparent',
-    hoverLabel: '#054D7B',
-    hoverBackground: 'transparent',
-    indicatorColor: '#146DA6',
-    smallActiveBackground: 'transparent',
-    smallHoverBackground: 'transparent',
-    pillLabel: '#4F5666',
-    pillActiveLabel: '#054D7B',
-    pillActiveBackground: '#B0F3FE',
-    pillHoverLabel: '#054D7B',
-    pillBackground: '#F6F7F8',
-  },
-  navbarTheme: {
-    background: '#054D7B',
-    textColor: '#fff',
-    textHoverBackground: '#054D7B',
-    textHoverColor: '#fff',
-  },
-};
+// NOTE: Theme should not provide defaults. The css variables provide
+// the defaults, and the ConfigProvider theme can override them accordingly.
+export const themeDefaults: OcBaseTheme = {};
 
 export const red: OcTheme = {
   primaryColor: '#6C2222',


### PR DESCRIPTION
## SUMMARY:
ConfigProvider is currently providing default values unnecessarily. This makes it necessary to provide empty objects in config in order to avoid the undesired default values.
![Screenshot 2023-02-08 at 2 43 11 PM](https://user-images.githubusercontent.com/106610186/217646757-9a9ff57f-2c71-491f-8cf1-f36dff0a4c0a.png)

In this example, I'm trying to emulate a starbucks green theme, and if I don't provide an empty navbarTheme and tabsTheme then the defaults get copied in and I end up with blue tabs despite my varTheme.

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull down the PR and run storybook locally. Select a new primary and/or accent color in ConfigProvider story. With this change, the tabs get updated appropriately. Current undesirable behavior is that they stay blue based on the default values.