### PR TITLE
fix: link: isolate css display inline block to variants other than default

### DIFF
--- a/src/components/Link/link.module.scss
+++ b/src/components/Link/link.module.scss
@@ -1,6 +1,5 @@
 .link-style {
   cursor: pointer;
-  display: inline-block;
   font-family: $octuple-font-family;
   font-weight: $text-font-weight-semibold;
   font-size: $text-font-size-2;
@@ -78,6 +77,7 @@
   &.primary,
   &.secondary,
   &.disruptive {
+    display: inline-block;
     text-decoration: none;
 
     &:active:not(.disabled),


### PR DESCRIPTION
## SUMMARY:
`display: inline-block` was causing layout issues in vscode app Navbar implementation. This change isolates the display type to explicitly defined variants only, fixing the focus-visible borders in the app for already existing primary button variants. Also removes the need for link variants to require hard-coded widths.