### PR TITLE
feat: popup: adds popup component

### DIFF
--- a/src/components/Form/Tests/index.test.js
+++ b/src/components/Form/Tests/index.test.js
@@ -15,7 +15,7 @@ import { Modal } from '../../Modal';
 import { ConfigProvider } from '../../ConfigProvider';
 import zhCN from '../../Locale/zh_CN';
 import { sleep } from '../../../tests/Utilities';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import 'jest-specific-snapshot';
 
 const { RangePicker } = DatePicker;
@@ -944,30 +944,38 @@ describe('Form', () => {
   });
 
   describe('tooltip', () => {
-    test('ReactNode', () => {
-      const wrapper = mount(
+    test('ReactNode', async () => {
+      const { container, getByTestId } = render(
         <Form>
-          <Form.Item label="lola" tooltip={<span>Mia</span>}>
+          <Form.Item
+            label="lola"
+            tooltip={<span data-testid="tooltip-1">Mia</span>}
+          >
             <TextInput />
           </Form.Item>
         </Form>
       );
 
-      const tooltipProps = wrapper.find('Tooltip').props();
-      expect(tooltipProps.content).toEqual(<span>Mia</span>);
+      fireEvent.mouseOver(container.querySelector('.reference-wrapper'));
+      await waitFor(() => getByTestId('tooltip-1'));
+      expect(getByTestId('tooltip-1').innerHTML).toBe('Mia');
     });
 
-    test('config', () => {
-      const wrapper = mount(
+    test('config', async () => {
+      const { container, getByTestId } = render(
         <Form>
-          <Form.Item label="lola" tooltip={{ content: 'Mia' }}>
+          <Form.Item
+            label="lola"
+            tooltip={{ content: <span data-testid="tooltip-2">Mia</span> }}
+          >
             <TextInput />
           </Form.Item>
         </Form>
       );
 
-      const tooltipProps = wrapper.find('Tooltip').props();
-      expect(tooltipProps.content).toEqual('Mia');
+      fireEvent.mouseOver(container.querySelector('.reference-wrapper'));
+      await waitFor(() => getByTestId('tooltip-2'));
+      expect(getByTestId('tooltip-2').innerHTML).toBe('Mia');
     });
   });
 

--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+import { Stories } from '@storybook/addon-docs';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ButtonSize, PrimaryButton } from '../Button';
+import { Icon, IconName, IconSize } from '../Icon';
+import { Link } from '../Link';
+import { Stack } from '../Stack';
+import { Popup, PopupTheme } from './';
+
+export default {
+  title: 'Popup',
+  parameters: {
+    docs: {
+      page: (): JSX.Element => (
+        <main>
+          <article>
+            <section>
+              <h1>Popups</h1>
+              <p>
+                Derived from Tooltip, Popups may also provide actionable
+                elements like links and buttons.
+              </p>
+            </section>
+            <section>
+              <Stories includePrimary title="" />
+            </section>
+          </article>
+        </main>
+      ),
+    },
+  },
+  argTypes: {
+    trigger: {
+      options: ['click', 'hover', 'contextmenu'],
+      control: { type: 'radio' },
+    },
+    placement: {
+      options: [
+        'top',
+        'right',
+        'bottom',
+        'left',
+        'top-start',
+        'top-end',
+        'right-start',
+        'right-end',
+        'bottom-start',
+        'bottom-end',
+        'left-start',
+        'left-end',
+      ],
+      control: { type: 'select' },
+    },
+    height: {
+      control: { type: 'number' },
+    },
+    width: {
+      control: { type: 'number' },
+    },
+    positionStrategy: {
+      options: ['absolute', 'fixed'],
+      control: { type: 'inline-radio' },
+    },
+    theme: {
+      options: ['light', 'dark'],
+      control: { type: 'inline-radio' },
+    },
+    portal: {
+      options: [true, false],
+      control: { type: 'inline-radio' },
+    },
+    triggerAbove: {
+      options: [true, false],
+      control: { type: 'inline-radio' },
+    },
+  },
+} as ComponentMeta<typeof Popup>;
+
+const Popup_Story: ComponentStory<typeof Popup> = (args) => {
+  const [visible, setVisibility] = useState(false);
+  return (
+    <Popup {...args} onVisibleChange={(isVisible) => setVisibility(isVisible)}>
+      <PrimaryButton
+        size={ButtonSize.Medium}
+        text={visible ? 'Hide Popup' : 'Show Popup'}
+      />
+    </Popup>
+  );
+};
+
+export const Popups = Popup_Story.bind({});
+
+Popups.args = {
+  offset: 8,
+  theme: PopupTheme.light,
+  content: (
+    <>
+      <Stack
+        direction="vertical"
+        align="flex-start"
+        justify="space-between"
+        fullWidth
+      >
+        <img
+          src="https://static.vscdn.net/images/career_hub/upskilling/more_projects.svg"
+          style={{ margin: 4, width: 'calc(100% - 8px)' }}
+        />
+        <div className="octuple">
+          <div className="octuple-content" style={{ padding: '16px' }}>
+            <h5>Header 5</h5>
+            <p className="octuple-content__small">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+            <Link tabIndex={0} variant="primary">
+              <span
+                style={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  flexDirection: 'row',
+                }}
+              >
+                <span>Learn more</span>
+                <Icon
+                  size={IconSize.Small}
+                  path={IconName.mdiOpenInNew}
+                  style={{ margin: '0 4px' }}
+                />
+              </span>
+            </Link>
+          </div>
+        </div>
+      </Stack>
+    </>
+  ),
+  placement: 'bottom-start',
+  disabled: false,
+  visibleArrow: true,
+  classNames: 'my-popup-class',
+  closeOnPopupClick: false,
+  openDelay: 0,
+  hideAfter: 200,
+  tabIndex: 0,
+  trigger: 'click',
+  triggerAbove: false,
+  positionStrategy: 'absolute',
+  portal: false,
+  portalId: 'my-portal-id',
+  portalRoot: null,
+};

--- a/src/components/Popup/Popup.test.tsx
+++ b/src/components/Popup/Popup.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { Popup, PopupSize } from './';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+let matchMedia: any;
+
+describe('Popup', () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  test('Popup shows and hides on hover when trigger is hover', async () => {
+    const { container } = render(
+      <Popup
+        content={<div data-testid="popup-1">This is a popup.</div>}
+        trigger="hover"
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.mouseOver(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popup-1'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+    fireEvent.mouseOut(container.querySelector('.test-div'));
+    await waitForElementToBeRemoved(() => screen.getByTestId('popup-1'));
+    expect(container.querySelector('.popup')).toBeFalsy();
+  });
+
+  // TODO: Fix onBlur to use :focus-within, for now people may dismiss Popups by tabbing back to
+  // the trigger and presing the enter key via the useAccessibility hook.
+  test.skip('Popup shows and hides on focus and blur when trigger is hover', async () => {
+    const { container } = render(
+      <Popup
+        content={<div data-testid="popup-2">This is a popup.</div>}
+        trigger="hover"
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.focus(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popup-2'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+    fireEvent.blur(container.querySelector('.test-div'));
+    await waitForElementToBeRemoved(() => screen.getByTestId('popup-2'));
+    expect(container.querySelector('.popup')).toBeFalsy();
+  });
+
+  // For now test that the Popup shows using keyboard
+  test('Popup shows on focus when trigger is hover', async () => {
+    const { container } = render(
+      <Popup
+        content={<div data-testid="popup-2">This is a popup.</div>}
+        trigger="hover"
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.focus(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popup-2'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+  });
+
+  test('Popup shows and hides on click when trigger is click', async () => {
+    const { container } = render(
+      <Popup
+        content={<div data-testid="popup-3">This is a popup.</div>}
+        trigger="click"
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popup-3'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitForElementToBeRemoved(() => screen.getByTestId('popup-3'));
+    expect(container.querySelector('.popup')).toBeFalsy();
+  });
+
+  test('Popup uses custom width and height', async () => {
+    const { container } = render(
+      <Popup
+        content={<div data-testid="popup-4">This is a popup.</div>}
+        height={500}
+        width={500}
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popup-4'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+    expect(container.querySelector('.popup').getAttribute('style')).toContain(
+      'height: 500px'
+    );
+    expect(container.querySelector('.popup').getAttribute('style')).toContain(
+      'width: 500px'
+    );
+  });
+
+  test('Popup is large', async () => {
+    const { container } = render(
+      <Popup
+        size={PopupSize.Large}
+        content={<div data-testid="popupLarge">This is a popup.</div>}
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popupLarge'));
+    expect(container.querySelector('.large')).toBeTruthy();
+  });
+
+  test('Popup is medium', async () => {
+    const { container } = render(
+      <Popup
+        size={PopupSize.Medium}
+        content={<div data-testid="popupMedium">This is a popup.</div>}
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popupMedium'));
+    expect(container.querySelector('.medium')).toBeTruthy();
+  });
+
+  test('Popup is small', async () => {
+    const { container } = render(
+      <Popup
+        size={PopupSize.Small}
+        content={<div data-testid="popupSmall">This is a popup.</div>}
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popupSmall'));
+    expect(container.querySelector('.small')).toBeTruthy();
+  });
+
+  test('Popup is portaled', async () => {
+    const { container } = render(
+      <>
+        <Popup
+          portal
+          content={<div data-testid="popupPortaled-1">This is a popup.</div>}
+        >
+          <div className="test-div">test</div>
+        </Popup>
+      </>,
+      { container: document.body }
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popupPortaled-1'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+  });
+
+  test('Popup is portaled in a defined root element', async () => {
+    const { container } = render(
+      <>
+        <Popup
+          portal
+          portalRoot={document.body}
+          content={<div data-testid="popupPortaled-2">This is a popup.</div>}
+        >
+          <div className="test-div">test</div>
+        </Popup>
+      </>,
+      { container: document.body }
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popupPortaled-2'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+  });
+});

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -1,0 +1,55 @@
+import React, { FC } from 'react';
+import { PopupProps, PopupRef, PopupSize, PopupTheme } from './Popup.types';
+import { Tooltip, TooltipSize, TooltipType } from '../Tooltip';
+import { useCanvasDirection } from '../../hooks/useCanvasDirection';
+import { mergeClasses, uniqueId } from '../../shared/utilities';
+
+import styles from './popup.module.scss';
+
+export const Popup: FC<PopupProps> = React.forwardRef<PopupRef, PopupProps>(
+  (
+    {
+      classNames,
+      closeOnPopupClick = false,
+      id,
+      showPopup,
+      size = PopupSize.Medium,
+      trigger = 'click',
+      popupStyle,
+      ...rest
+    },
+    ref: React.ForwardedRef<PopupRef>
+  ) => {
+    const htmlDir: string = useCanvasDirection();
+    const popupId: string = !!id ? id : uniqueId('popup-');
+    const popupClassNames: string = mergeClasses([
+      styles.popup,
+      { [styles.small]: size === PopupSize.Small },
+      { [styles.medium]: size === PopupSize.Medium },
+      { [styles.large]: size === PopupSize.Large },
+      { [styles.popupRtl]: htmlDir === 'rtl' },
+      classNames,
+    ]);
+
+    const popupSizeToTooltipSizeMap = new Map<PopupSize, TooltipSize>([
+      [PopupSize.Large, TooltipSize.Large],
+      [PopupSize.Medium, TooltipSize.Medium],
+      [PopupSize.Small, TooltipSize.Small],
+    ]);
+
+    return (
+      <Tooltip
+        {...rest}
+        classNames={popupClassNames}
+        closeOnTooltipClick={closeOnPopupClick}
+        id={popupId}
+        ref={ref}
+        showTooltip={showPopup}
+        size={popupSizeToTooltipSizeMap.get(size)}
+        tooltipStyle={popupStyle}
+        trigger={trigger}
+        type={TooltipType.Popup}
+      />
+    );
+  }
+);

--- a/src/components/Popup/Popup.types.ts
+++ b/src/components/Popup/Popup.types.ts
@@ -1,0 +1,48 @@
+import { TooltipProps } from '../Tooltip';
+
+export enum PopupSize {
+  Large = 'large',
+  Medium = 'medium',
+  Small = 'small',
+}
+
+export enum PopupTheme {
+  light = 'light',
+  dark = 'dark',
+}
+
+export interface PopupProps
+  extends Omit<
+    TooltipProps,
+    'closeOnTooltipClick' | 'showTooltip' | 'size' | 'tooltipStyle' | 'type'
+  > {
+  /**
+   * Should close Popup on body click.
+   * @default false
+   */
+  closeOnPopupClick?: boolean;
+  /**
+   * The Popup style.
+   */
+  popupStyle?: React.CSSProperties;
+  /**
+   * Callback to control the show/hide behavior of the Popup.
+   * triggered before the visible change
+   * @param show {boolean}
+   * @returns true or false.
+   */
+  showPopup?: (show: boolean) => boolean;
+  /**
+   * Size of the Popup.
+   * @default PopupSize.small
+   */
+  size?: PopupSize;
+}
+
+export type PopupRef = {
+  /**
+   * Helper method to manually update the position
+   * of the Popup.
+   */
+  update: () => void;
+};

--- a/src/components/Popup/index.ts
+++ b/src/components/Popup/index.ts
@@ -1,0 +1,2 @@
+export * from './Popup.types';
+export * from './Popup';

--- a/src/components/Popup/popup.module.scss
+++ b/src/components/Popup/popup.module.scss
@@ -1,0 +1,28 @@
+.popup {
+  border-radius: $border-radius-m;
+  padding: 0;
+  text-align: left;
+
+  // Popups may be larger than Tooltips
+  // Unset max-width and defer width to props if needed.
+  &.small {
+    max-width: unset;
+    width: 140px;
+  }
+
+  &.medium {
+    max-width: unset;
+    width: 240px;
+  }
+
+  &.large {
+    max-width: unset;
+    width: 360px;
+  }
+}
+
+.popup-rtl {
+  &.popup {
+    text-align: right;
+  }
+}

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -81,6 +81,10 @@ export default {
     },
   },
   argTypes: {
+    trigger: {
+      options: ['click', 'hover', 'contextmenu'],
+      control: { type: 'radio' },
+    },
     placement: {
       options: [
         'top',
@@ -110,6 +114,10 @@ export default {
       options: [true, false],
       control: { type: 'inline-radio' },
     },
+    triggerAbove: {
+      options: [true, false],
+      control: { type: 'inline-radio' },
+    },
   },
 } as ComponentMeta<typeof Tooltip>;
 
@@ -128,8 +136,10 @@ Tooltips.args = {
   visibleArrow: true,
   classNames: 'my-tooltip-class',
   openDelay: 0,
-  hideAfter: 0,
+  hideAfter: 200,
   tabIndex: 0,
+  trigger: 'hover',
+  triggerAbove: false,
   positionStrategy: 'absolute',
   portal: false,
   portalId: 'my-portal-id',
@@ -141,4 +151,5 @@ Tooltips.args = {
       text="Show Tooltip"
     />
   ),
+  height: null,
 };

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -24,9 +24,12 @@ describe('Tooltip', () => {
     matchMedia.clear();
   });
 
-  test('Tooltip shows and hides', async () => {
+  test('Tooltip shows and hides on hover', async () => {
     const { container } = render(
-      <Tooltip content={<div data-testid="tooltip">This is a tooltip.</div>}>
+      <Tooltip
+        content={<div data-testid="tooltip">This is a tooltip.</div>}
+        trigger="hover"
+      >
         <div className="test-div">test</div>
       </Tooltip>
     );
@@ -36,6 +39,44 @@ describe('Tooltip', () => {
     fireEvent.mouseOut(container.querySelector('.test-div'));
     await waitForElementToBeRemoved(() => screen.getByTestId('tooltip'));
     expect(container.querySelector('.tooltip')).toBeFalsy();
+  });
+
+  test('Tooltip shows and hides on focus and blur', async () => {
+    const { container } = render(
+      <Tooltip
+        content={<div data-testid="tooltip">This is a tooltip.</div>}
+        trigger="hover"
+      >
+        <div className="test-div">test</div>
+      </Tooltip>
+    );
+    fireEvent.focus(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+    fireEvent.blur(container.querySelector('.test-div'));
+    await waitForElementToBeRemoved(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeFalsy();
+  });
+
+  test('Tooltip uses custom width and height', async () => {
+    const { container } = render(
+      <Tooltip
+        content={<div data-testid="tooltip">This is a tooltip.</div>}
+        height={500}
+        width={500}
+      >
+        <div className="test-div">test</div>
+      </Tooltip>
+    );
+    fireEvent.mouseOver(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+    expect(container.querySelector('.tooltip').getAttribute('style')).toContain(
+      'height: 500px'
+    );
+    expect(container.querySelector('.tooltip').getAttribute('style')).toContain(
+      'width: 500px'
+    );
   });
 
   test('Tooltip is large', async () => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,11 @@
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, {
+  FC,
+  SyntheticEvent,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import {
   arrow,
   autoUpdate,
@@ -7,181 +14,337 @@ import {
   useFloating,
 } from '@floating-ui/react-dom';
 import { FloatingPortal } from '@floating-ui/react-dom-interactions';
-import { TooltipProps, TooltipSize, TooltipTheme } from './Tooltip.types';
+import {
+  ANIMATION_DURATION,
+  PREVENT_DEFAULT_TRIGGERS,
+  TooltipProps,
+  TooltipRef,
+  TooltipSize,
+  TooltipTheme,
+  TooltipType,
+  TOOLTIP_ARROW_WIDTH,
+  TOOLTIP_DEFAULT_OFFSET,
+  TRIGGER_TO_HANDLER_MAP_ON_ENTER,
+  TRIGGER_TO_HANDLER_MAP_ON_LEAVE,
+} from './Tooltip.types';
+import { useAccessibility } from '../../hooks/useAccessibility';
+import { useMergedState } from '../../hooks/useMergedState';
+import { useOnClickOutside } from '../../hooks/useOnClickOutside';
 import {
   cloneElement,
   ConditionalWrapper,
-  generateId,
   mergeClasses,
+  uniqueId,
 } from '../../shared/utilities';
 
 import styles from './tooltip.module.scss';
 
-const TOOLTIP_ARROW_WIDTH = 8;
-
-export const Tooltip: FC<TooltipProps> = ({
-  children,
-  offset = 8,
-  theme,
-  content,
-  placement = 'bottom',
-  portal = false,
-  portalId,
-  portalRoot,
-  disabled,
-  id,
-  visibleArrow = true,
-  classNames,
-  openDelay = 0,
-  hideAfter = 0,
-  tabIndex = 0,
-  tooltipStyle,
-  positionStrategy = 'absolute',
-  wrapperClassNames,
-  wrapperStyle,
-  size = TooltipSize.Small,
-  ...rest
-}) => {
-  const tooltipSide: string = placement.split('-')?.[0];
-  const [visible, setVisible] = useState<boolean>(false);
-  const arrowRef = useRef<HTMLDivElement>(null);
-  const tooltipId = useRef<string>(id || generateId());
-  let timeout: ReturnType<typeof setTimeout>;
-
-  const {
-    x,
-    y,
-    reference,
-    floating,
-    strategy,
-    update,
-    refs,
-    middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
-  } = useFloating({
-    placement,
-    strategy: positionStrategy,
-    middleware: [
-      shift(),
-      arrow({ element: arrowRef, padding: TOOLTIP_ARROW_WIDTH }),
-      fOffset(offset),
-    ],
-  });
-
-  useEffect(() => {
-    if (!refs.reference.current || !refs.floating.current) {
-      return () => {};
-    }
-
-    // Only call this when the floating element is rendered
-    return autoUpdate(refs.reference.current, refs.floating.current, update);
-  }, [refs.reference, refs.floating, update]);
-
-  const toggle: Function =
-    (show: boolean): Function =>
-    (): void => {
-      if (!content || disabled) {
-        return;
-      }
-      timeout && clearTimeout(timeout);
-      timeout = setTimeout(
-        () => {
-          setVisible(show);
-        },
-        show ? openDelay : hideAfter
-      );
-    };
-
-  const tooltipClasses: string = mergeClasses([
-    classNames,
-    styles.tooltip,
-    { [styles.visible]: visible },
-    { [styles.dark]: theme === TooltipTheme.dark },
-    { [styles.top]: tooltipSide === 'top' },
-    { [styles.bottom]: tooltipSide === 'bottom' },
-    { [styles.left]: tooltipSide === 'left' },
-    { [styles.right]: tooltipSide === 'right' },
-    { [styles.small]: size === TooltipSize.Small },
-    { [styles.medium]: size === TooltipSize.Medium },
-    { [styles.large]: size === TooltipSize.Large },
-  ]);
-
-  const referenceWrapperClasses: string = mergeClasses([
-    styles.referenceWrapper,
-    wrapperClassNames,
-    { [styles.disabled]: disabled },
-  ]);
-
-  const staticSide: string = {
-    top: 'bottom',
-    right: 'left',
-    bottom: 'top',
-    left: 'right',
-  }[tooltipSide];
-
-  const tooltipStyles: object = {
-    position: strategy,
-    top: y ?? '',
-    left: x ?? '',
-    ...tooltipStyle,
-  };
-
-  const arrowStyle: object = {
-    position: strategy,
-    top: arrowY ?? '',
-    left: arrowX ?? '',
-    [staticSide]: `-${TOOLTIP_ARROW_WIDTH / 2}px`,
-  };
-
-  const getChild = (node: React.ReactNode): JSX.Element | React.ReactNode => {
-    // Need this to handle disabled elements.
-    if (React.isValidElement(node) && node.props?.disabled) {
-      const child = React.Children.only(node) as React.ReactElement<any>;
-      return cloneElement(child, {
-        classNames: styles.noPointerEvents,
+export const Tooltip: FC<TooltipProps> = React.memo(
+  React.forwardRef<TooltipRef, TooltipProps>(
+    (
+      {
+        children,
+        classNames,
+        closeOnOutsideClick = true,
+        closeOnTooltipClick = false,
+        content,
+        disabled,
+        height,
+        hideAfter = ANIMATION_DURATION,
+        id,
+        offset = TOOLTIP_DEFAULT_OFFSET,
+        onClickOutside,
+        onVisibleChange,
+        openDelay = 0,
+        placement = 'bottom',
+        portal = false,
+        portalId,
+        portalRoot,
+        positionStrategy = 'absolute',
+        showTooltip,
+        size = TooltipSize.Small,
+        tabIndex = 0,
+        theme,
+        tooltipStyle,
+        trigger = 'hover',
+        triggerAbove = false,
+        type = TooltipType.Default,
+        visible,
+        visibleArrow = true,
+        width,
+        wrapperClassNames,
+        wrapperStyle,
+        ...rest
+      },
+      ref: React.ForwardedRef<TooltipRef>
+    ) => {
+      const tooltipSide: string = placement.split('-')?.[0];
+      const [mergedVisible, setVisible] = useMergedState<boolean>(false, {
+        value: visible,
       });
-    }
-    return node;
-  };
+      const arrowRef: React.MutableRefObject<HTMLDivElement> =
+        useRef<HTMLDivElement>(null);
 
-  return (
-    <>
-      <div
-        className={referenceWrapperClasses}
-        style={wrapperStyle}
-        id={tooltipId.current}
-        onMouseEnter={toggle(true)}
-        onMouseLeave={toggle(false)}
-        onFocus={toggle(true)}
-        onBlur={toggle(false)}
-        ref={reference}
-      >
-        {getChild(children)}
-      </div>
-      <ConditionalWrapper
-        condition={portal}
-        wrapper={(children) => (
-          <FloatingPortal id={portalId} root={portalRoot}>
-            {getChild(children)}
-          </FloatingPortal>
-        )}
-      >
-        {visible && (
+      const [hiding, setHiding] = useState<boolean>(false);
+      const tooltipId: React.MutableRefObject<string> = useRef<string>(
+        id || uniqueId('tooltip-')
+      );
+
+      let timeout: ReturnType<typeof setTimeout>;
+      const {
+        x,
+        y,
+        reference,
+        floating,
+        strategy,
+        update,
+        refs,
+        middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
+      } = useFloating({
+        placement,
+        strategy: positionStrategy,
+        middleware: [
+          shift(),
+          arrow({ element: arrowRef, padding: TOOLTIP_ARROW_WIDTH }),
+          fOffset(offset),
+        ],
+      });
+
+      const toggle: Function =
+        (show: boolean, showTooltip = (show: boolean) => show): Function =>
+        (e: SyntheticEvent): void => {
+          // to control the toggle behaviour
+          const updatedShow: boolean = showTooltip(show);
+          if (PREVENT_DEFAULT_TRIGGERS.includes(trigger)) {
+            e.preventDefault();
+          }
+          setHiding(!updatedShow);
+          timeout && clearTimeout(timeout);
+          timeout = setTimeout(
+            () => {
+              setVisible(updatedShow);
+              onVisibleChange?.(updatedShow);
+            },
+            show ? openDelay : hideAfter
+          );
+        };
+
+      useEffect(() => {
+        if (!refs.reference.current || !refs.floating.current) {
+          return () => {};
+        }
+
+        // Only call this when the floating element is rendered
+        return autoUpdate(
+          refs.reference.current,
+          refs.floating.current,
+          update
+        );
+      }, [refs.reference, refs.floating, update]);
+
+      useImperativeHandle(ref, () => ({
+        update,
+      }));
+
+      useOnClickOutside(
+        refs.floating,
+        (e) => {
+          if (closeOnOutsideClick) {
+            toggle(false)(e);
+          }
+          onClickOutside?.(e);
+        },
+        mergedVisible
+      );
+
+      useAccessibility(
+        trigger,
+        refs.reference,
+        toggle(true),
+        portal
+          ? (e) => {
+              if (e?.key == 'Enter') {
+                toggle(false);
+              }
+            }
+          : toggle(false)
+      );
+
+      // The placement type contains both `Side` and `Alignment`, joined by `-`.
+      // e.g. placement: `${Side}-{Alignment}`
+      const tooltipClassNames: string = mergeClasses([
+        styles.tooltip,
+        { [styles.popup]: type === TooltipType.Popup },
+        classNames,
+        { [styles.visible]: mergedVisible },
+        { [styles.hiding]: hiding },
+        { [styles.hidden]: !mergedVisible },
+        { [styles.dark]: theme === TooltipTheme.dark },
+        { [styles.bottom]: placement === 'bottom' },
+        { [styles.bottomEnd]: placement === 'bottom-end' },
+        { [styles.bottomStart]: placement === 'bottom-start' },
+        { [styles.left]: placement === 'left' },
+        { [styles.leftEnd]: placement === 'left-end' },
+        { [styles.leftStart]: placement === 'left-start' },
+        { [styles.right]: placement === 'right' },
+        { [styles.rightEnd]: placement === 'right-end' },
+        { [styles.rightStart]: placement === 'right-start' },
+        { [styles.top]: placement === 'top' },
+        { [styles.topEnd]: placement === 'top-end' },
+        { [styles.topStart]: placement === 'top-start' },
+        { [styles.small]: size === TooltipSize.Small },
+        { [styles.medium]: size === TooltipSize.Medium },
+        { [styles.large]: size === TooltipSize.Large },
+      ]);
+
+      const referenceWrapperClassNames: string = mergeClasses([
+        styles.referenceWrapper,
+        wrapperClassNames,
+        { [styles.disabled]: disabled },
+      ]);
+
+      // Only use the `placement` type's `Side` property to determine `staticSide`.
+      const staticSide: string = {
+        top: 'bottom',
+        right: 'left',
+        bottom: 'top',
+        left: 'right',
+      }[tooltipSide];
+
+      const tooltipStyles: object = {
+        position: strategy,
+        top: y ?? '',
+        left: x ?? '',
+        width: width ?? '',
+        height: height ?? '',
+        ...tooltipStyle,
+      };
+
+      const arrowStyle: object = {
+        position: strategy,
+        top: arrowY ?? '',
+        left: arrowX ?? '',
+        [staticSide]: `-${TOOLTIP_ARROW_WIDTH / 2}px`,
+      };
+
+      const getChild = (
+        node: React.ReactNode
+      ): JSX.Element | React.ReactNode => {
+        if (React.isValidElement(node)) {
+          const child = React.Children.only(node) as React.ReactElement<any>;
+
+          // Need this to handle disabled elements of default Tooltip.
+          if (type === TooltipType.Default) {
+            if (node.props?.disabled) {
+              return cloneElement(child, {
+                classNames: styles.noPointerEvents,
+              });
+            }
+          }
+
+          // Utilize tha same element clone pattern as Dropdown
+          // for more complex Popup elements.
+          if (type === TooltipType.Popup) {
+            const referenceWrapperClassNames: string = mergeClasses([
+              styles.referenceWrapper,
+              { [styles.triggerAbove]: !!triggerAbove },
+              // Add any classnames added to the reference element
+              { [child.props.className]: child.props.className },
+              { [styles.disabled]: disabled },
+            ]);
+            return cloneElement(child, {
+              ...{
+                [TRIGGER_TO_HANDLER_MAP_ON_ENTER[trigger]]: toggle(true),
+              },
+              onClick: toggle(!mergedVisible),
+              classNames: referenceWrapperClassNames,
+              'aria-controls': tooltipId?.current,
+              'aria-expanded': mergedVisible,
+              'aria-haspopup': true,
+              role: 'button',
+              tabIndex: `${tabIndex}`,
+            });
+          }
+        }
+        return node;
+      };
+
+      const getTooltip = (): JSX.Element =>
+        mergedVisible && (
           <div
             {...rest}
-            role="tooltip"
-            aria-hidden={!visible}
+            aria-hidden={!mergedVisible}
+            className={tooltipClassNames}
+            id={tooltipId?.current}
+            onClick={
+              closeOnTooltipClick && type === TooltipType.Popup
+                ? toggle(false, showTooltip)
+                : null
+            }
             ref={floating}
+            role="tooltip"
             style={tooltipStyles}
-            className={tooltipClasses}
             tabIndex={tabIndex}
           >
             {content}
             {visibleArrow && (
-              <div ref={arrowRef} style={arrowStyle} className={styles.arrow} />
+              <div className={styles.arrow} ref={arrowRef} style={arrowStyle} />
             )}
           </div>
-        )}
-      </ConditionalWrapper>
-    </>
-  );
-};
+        );
+
+      const getConditionalWrapper = (): JSX.Element => (
+        <ConditionalWrapper
+          condition={portal}
+          wrapper={(children) => (
+            <FloatingPortal id={portalId} root={portalRoot}>
+              {getChild(children)}
+            </FloatingPortal>
+          )}
+        >
+          {getTooltip()}
+        </ConditionalWrapper>
+      );
+
+      const getDefault = (): JSX.Element => (
+        <>
+          <div
+            className={referenceWrapperClassNames}
+            style={wrapperStyle}
+            id={tooltipId.current}
+            onMouseEnter={toggle(true, showTooltip)}
+            onMouseLeave={toggle(false, showTooltip)}
+            onFocus={toggle(true, showTooltip)}
+            onBlur={toggle(false, showTooltip)}
+            ref={reference}
+          >
+            {getChild(children)}
+          </div>
+          {getConditionalWrapper()}
+        </>
+      );
+
+      const getPopup = (): JSX.Element => (
+        <div
+          className={referenceWrapperClassNames}
+          id={tooltipId?.current}
+          style={wrapperStyle}
+          ref={reference}
+          {...(TRIGGER_TO_HANDLER_MAP_ON_LEAVE[trigger]
+            ? {
+                [TRIGGER_TO_HANDLER_MAP_ON_LEAVE[trigger]]: toggle(
+                  false,
+                  showTooltip
+                ),
+              }
+            : {})}
+        >
+          {getChild(children)}
+          {getConditionalWrapper()}
+        </div>
+      );
+
+      return type === TooltipType.Default ? getDefault() : getPopup();
+    }
+  )
+);

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -1,11 +1,21 @@
 import { Placement, Strategy } from '@floating-ui/react-dom';
-import React from 'react';
+import React, { Ref } from 'react';
 import { OcBaseProps } from '../OcBase';
 
-export enum TooltipTheme {
-  light = 'light',
-  dark = 'dark',
-}
+export const ANIMATION_DURATION: number = 200;
+export const PREVENT_DEFAULT_TRIGGERS: string[] = ['contextmenu'];
+export const TOOLTIP_ARROW_WIDTH: number = 8;
+export const TOOLTIP_DEFAULT_OFFSET: number = TOOLTIP_ARROW_WIDTH;
+export const TRIGGER_TO_HANDLER_MAP_ON_ENTER = {
+  click: 'onClick',
+  hover: 'onMouseEnter',
+  contextmenu: 'onContextMenu',
+};
+export const TRIGGER_TO_HANDLER_MAP_ON_LEAVE = {
+  click: '',
+  hover: 'onMouseLeave',
+  contextmenu: '',
+};
 
 export enum TooltipSize {
   Large = 'large',
@@ -13,84 +23,164 @@ export enum TooltipSize {
   Small = 'small',
 }
 
-export interface TooltipProps extends OcBaseProps<HTMLDivElement> {
+export enum TooltipTheme {
+  light = 'light',
+  dark = 'dark',
+}
+
+export enum TooltipType {
+  Default = 'default',
+  Popup = 'popup',
+}
+
+export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
   /**
-   * Content to show in the tooltip
+   * Should close Tooltip on click outside.
+   * @default true
+   */
+  closeOnOutsideClick?: boolean;
+  /**
+   * Should close Tooltip on body click.
+   * @default false
+   */
+  closeOnTooltipClick?: boolean;
+  /**
+   * Content to show in the Tooltip.
    */
   content: React.ReactNode;
   /**
-   * Whether to disable the tooltip
+   * Whether to disable the Tooltip.
    * @default false
    */
   disabled?: boolean;
   /**
-   * Timeout in milliseconds to hide the tooltip
+   * Timeout in milliseconds to hide the Tooltip.
    * @default 0
    */
   hideAfter?: number;
   /**
-   * Offset of the tooltip from the reference element
+   * Manually control the height of the Tooltip.
+   */
+  height?: number;
+  /**
+   * Offset of the Tooltip from the reference element.
    * @default 8
    */
   offset?: number;
   /**
-   * Delay of appearance, in milliseconds
+   * Callback method fired on outside click oo Tooltip.
+   * @param event
+   */
+  onClickOutside?: (event: MouseEvent) => void;
+  /**
+   * Callback called when the visibility of the Tooltip changes.
+   * @param visible {boolean}
+   */
+  onVisibleChange?: (visible: boolean) => void;
+  /**
+   * Delay of appearance, in milliseconds.
    * @default 0
    */
   openDelay?: number;
   /**
-   * Placement of the tooltip
+   * Placement of the Tooltip.
    * @default bottom
    */
   placement?: Placement;
   /**
-   * Whether the tooltip is portaled
+   * Whether the Tooltip is portaled.
    * @default false
    */
   portal?: boolean;
   /**
-   * The id of the floating portal
+   * The id of the floating portal.
    */
   portalId?: string;
   /**
-   * The element in which to render the portal
+   * The element in which to render the portal.
    */
   portalRoot?: HTMLElement | null;
   /**
-   * Positioning strategy for the tooltip
+   * Positioning strategy for the Tooltip.
    * @default absolute
    */
   positionStrategy?: Strategy;
   /**
-   * Size of the tooltip
+   * The ref of the Tooltip.
+   */
+  ref?: Ref<TooltipRef>;
+  /**
+   * Callback to control the show/hide behavior of the Tooltip.
+   * triggered before the visible change
+   * @param show {boolean}
+   * @returns true or false.
+   */
+  showTooltip?: (show: boolean) => boolean;
+  /**
+   * Size of the Tooltip.
    * @default TooltipSize.small
    */
   size?: TooltipSize;
   /**
-   * Tabindex of tooltip
+   * Tabindex of Tooltip.
    * @default 0
    */
   tabIndex?: number;
   /**
-   * Theme of the tooltip
+   * Theme of the Tooltip.
    * @default light
    */
   theme?: TooltipTheme;
   /**
-   * Tooltip style
+   * The Tooltip style.
    */
   tooltipStyle?: React.CSSProperties;
   /**
-   * Whether the tooltip arrow is visible
+   * The trigger mode that opens the Tooltip.
+   * @default 'click'
+   */
+  trigger?: 'click' | 'hover' | 'contextmenu';
+  /**
+   * The `z-index` of the trigger is higher than the Tooltip.
+   * Use when type is TooltipType.Popup
+   * @default false
+   */
+  triggerAbove?: boolean;
+  /**
+   * The type of Tooltip
+   * @default TooltipType.Default
+   */
+  type?: TooltipType;
+  /**
+   * Manually control visibility of the Tooltip.
+   */
+  visible?: boolean;
+  /**
+   * Whether the Tooltip arrow is visible.
    * @default true
    */
   visibleArrow?: boolean;
   /**
-   * Wrapper class names
+   * Manually control the width of the Tooltip.
+   * Use only when TooltipType is Popup.
+   * Tooltip Default restricts width as its content
+   * should be informational text only.
+   */
+  width?: number;
+  /**
+   * Wrapper class names.
    */
   wrapperClassNames?: string;
   /**
-   * Wrapper style
+   * The Wrapper style.
    */
   wrapperStyle?: React.CSSProperties;
 }
+
+export type TooltipRef = {
+  /**
+   * Helper method to manually update the position
+   * of the Tooltip.
+   */
+  update: () => void;
+};

--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -1,8 +1,12 @@
-$tooltip-arrow-shadow: 1px 1px 2px rgba(15, 20, 31, 0.12);
+$tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
 
 .referenceWrapper {
-  display: inline-block;
   cursor: pointer;
+  display: inline-block;
+
+  &.trigger-above {
+    z-index: $z-index-500;
+  }
 
   &.disabled {
     cursor: auto;
@@ -16,17 +20,37 @@ $tooltip-arrow-shadow: 1px 1px 2px rgba(15, 20, 31, 0.12);
 .tooltip {
   --bg: var(--background-color);
   --text-color: var(--text-primary-color);
-  display: none;
-  box-shadow: $shadow-object-xs;
   background: var(--bg);
+  border-radius: $border-radius-s;
+  box-shadow: $shadow-object-s;
   color: var(--text-color);
   font-family: $octuple-font-family;
   font-size: $text-font-size-1;
+  overflow-wrap: break-word;
+  padding: $space-xs;
   text-align: center;
   z-index: $z-index-400;
-  padding: $space-xs;
-  border-radius: $border-radius-s;
-  overflow-wrap: break-word;
+
+  // When Popup, adds a pixel buffer equal to the width of the arrow to prevent
+  // floating ui dismiss when hovering from reference to floating element.
+  // Especially helpful when trigger is hover.
+  &.popup {
+    &:after {
+      bottom: -$space-xs;
+      content: '';
+      left: -$space-xs;
+      padding: $space-xs;
+      position: absolute;
+      right: -$space-xs;
+      top: -$space-xs;
+    }
+  }
+
+  // Hides the browser default keyboard focus-visible styles.
+  // Use the ConfigProvider instead.
+  &:focus-visible {
+    outline: none;
+  }
 
   &.dark {
     --bg: var(--grey-color-80);
@@ -34,23 +58,55 @@ $tooltip-arrow-shadow: 1px 1px 2px rgba(15, 20, 31, 0.12);
   }
 
   .arrow {
-    width: 8px;
-    height: 8px;
-    z-index: -1;
     background: inherit;
     box-shadow: $tooltip-arrow-shadow;
+    height: $space-xs;
+    width: $space-xs;
+    z-index: -1;
   }
 
-  &.top {
-    transform-origin: bottom center;
+  &.bottom {
+    transform-origin: top center;
 
     .arrow {
-      transform: rotate(45deg);
+      transform: rotate(225deg);
+    }
+  }
+
+  &.bottom-end {
+    transform-origin: top right;
+
+    .arrow {
+      transform: rotate(225deg);
+    }
+  }
+
+  &.bottom-start {
+    transform-origin: top left;
+
+    .arrow {
+      transform: rotate(225deg);
     }
   }
 
   &.left {
     transform-origin: right center;
+
+    .arrow {
+      transform: rotate(315deg);
+    }
+  }
+
+  &.left-start {
+    transform-origin: right top;
+
+    .arrow {
+      transform: rotate(315deg);
+    }
+  }
+
+  &.left-end {
+    transform-origin: right bottom;
 
     .arrow {
       transform: rotate(315deg);
@@ -65,18 +121,60 @@ $tooltip-arrow-shadow: 1px 1px 2px rgba(15, 20, 31, 0.12);
     }
   }
 
-  &.bottom {
-    transform-origin: top center;
+  &.right-start {
+    transform-origin: left top;
 
     .arrow {
-      transform: rotate(225deg);
+      transform: rotate(135deg);
+    }
+  }
+
+  &.right-end {
+    transform-origin: left bottom;
+
+    .arrow {
+      transform: rotate(135deg);
+    }
+  }
+
+  &.top {
+    transform-origin: bottom center;
+
+    .arrow {
+      transform: rotate(45deg);
+    }
+  }
+
+  &.top-start {
+    transform-origin: bottom left;
+
+    .arrow {
+      transform: rotate(45deg);
+    }
+  }
+
+  &.top-end {
+    transform-origin: bottom right;
+
+    .arrow {
+      transform: rotate(45deg);
     }
   }
 
   &.visible {
     display: block;
-    animation: scaleTooltip $motion-duration-extra-fast $motion-easing-easeinout
-      0s;
+    animation: scaleTooltipIn $motion-duration-extra-fast
+      $motion-easing-easeinout 0s forwards;
+  }
+
+  &.hiding {
+    animation: scaleTooltipOut $motion-duration-extra-fast
+      $motion-easing-easeinout 0s forwards;
+    pointer-events: none;
+  }
+
+  &.hidden {
+    display: none;
   }
 
   &.small {
@@ -92,13 +190,50 @@ $tooltip-arrow-shadow: 1px 1px 2px rgba(15, 20, 31, 0.12);
   }
 }
 
-@keyframes scaleTooltip {
-  from {
-    transform: scale(0);
-    opacity: 0;
+:global(.focus-visible) {
+  .tooltip {
+    // Currently, the design for default tooltips do not include them in a
+    // persisted focus loop, leave 'as-is' for now to prevent UI regressions.
+    &.popup {
+      &.focus-visible,
+      &:focus-visible {
+        &:after {
+          bottom: 0;
+          border-radius: $border-radius-s;
+          content: '';
+          box-shadow: var(--focus-visible-box-shadow);
+          left: 0;
+          position: absolute;
+          right: 0;
+          top: 0;
+        }
+      }
+    }
   }
-  to {
-    transform: scale(1);
+}
+
+@keyframes scaleTooltipIn {
+  0% {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  100% {
     opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes scaleTooltipOut {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  20% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.8);
   }
 }

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -158,6 +158,8 @@ import {
   PanelHeader,
 } from './components/Panel';
 
+import { Popup, PopupSize, PopupTheme } from './components/Popup';
+
 import { Portal } from './components/Portal';
 
 import { RadioButton, RadioGroup } from './components/RadioButton';
@@ -277,6 +279,9 @@ export {
   PillSize,
   PillThemeName,
   PillType,
+  Popup,
+  PopupSize,
+  PopupTheme,
   Portal,
   PrimaryButton,
   Progress,


### PR DESCRIPTION
## SUMMARY:
Adds `Popup` component, derived from `Tooltip`
Updates `Tooltip` component to enable `Popup` `type` using existing patterns via `floating-ui` dependency
Preserves `Tooltip` existing implementation to minimize risk via `getDefault` and `getPopup` functions
Adds `Popup` story
Adds and updates unit tests


https://user-images.githubusercontent.com/99700808/220430583-b6bd8acd-2961-4015-a770-c08a3e102d10.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-2819

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the Tooltip and Popup stories behave as expected.