### PR TITLE
fix: skeleton: ensure wave overflow is hidden in safari browser

### DIFF
--- a/src/components/Skeleton/skeleton.module.scss
+++ b/src/components/Skeleton/skeleton.module.scss
@@ -15,8 +15,9 @@ $skeleton-wave-animation: wave 1.6s linear 0.5s infinite;
   }
 
   &.wave {
-    position: relative;
     overflow: hidden;
+    position: relative;
+    transform: translateZ(0); // Ensures wave crop in Safari
 
     &:after {
       animation: $skeleton-wave-animation;


### PR DESCRIPTION
## SUMMARY:
Curved elements' wave animation was not being cropped in Safari browser, this change fixes the overflow behavior.

Before (Safari):

https://user-images.githubusercontent.com/99700808/220462514-06d4dd3e-5de8-4d92-a365-f4194688c40c.mp4


After (Safari):

https://user-images.githubusercontent.com/99700808/220462562-5555149e-ab8d-4aa5-ba3c-6ed089322a87.mp4

## JIRA TASK (Eightfold Employees Only):
ENG-44138

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist (CSS only change)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Skeleton` stories behave as expected using Safari browser.