### PR TITLE
fix: nudge: removes unnecessary border calculations in css

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -506,9 +506,6 @@
         border-width: var(--button-primary-border-width);
         border-style: var(--button-primary-border-style);
         border-color: var(--button-primary-border-color);
-        height: calc(100% + calc(var(--button-primary-border-width) * 2));
-        margin: calc(var(--button-primary-border-width) * -1);
-        width: calc(100% + calc(var(--button-primary-border-width) * 2));
       }
     }
   }
@@ -587,9 +584,6 @@
         border-width: var(--button-secondary-border-width);
         border-style: var(--button-secondary-border-style);
         border-color: var(--button-secondary-border-color);
-        height: calc(100% + calc(var(--button-secondary-border-width) * 2));
-        margin: calc(var(--button-secondary-border-width) * -1);
-        width: calc(100% + calc(var(--button-secondary-border-width) * 2));
       }
     }
   }
@@ -698,9 +692,6 @@
         border-width: var(--button-default-border-width);
         border-style: var(--button-default-border-style);
         border-color: var(--button-default-border-color);
-        height: calc(100% + calc(var(--button-default-border-width) * 2));
-        margin: calc(var(--button-default-border-width) * -1);
-        width: calc(100% + calc(var(--button-default-border-width) * 2));
       }
     }
   }
@@ -1182,9 +1173,6 @@
           border-width: var(--button-secondary-border-width);
           border-style: var(--button-secondary-border-style);
           border-color: var(--button-secondary-border-color);
-          height: calc(100% + calc(var(--button-secondary-border-width) * 2));
-          margin: calc(var(--button-secondary-border-width) * -1);
-          width: calc(100% + calc(var(--button-secondary-border-width) * 2));
         }
       }
     }


### PR DESCRIPTION
## SUMMARY:
Using a CSS variable inside of a nested `calc` function isn't valid SASS, this change removes these property overrides to fix the `Size` nudge animation, because border is appended to the client rect, these overrides are unnecessary.


https://user-images.githubusercontent.com/99700808/220772475-8745647d-5bb4-4e11-80e0-0a5c44deb2df.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-44290

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:
N/A CSS only

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `PrimaryButton` story behaves as expected when given the following `nudgeProps`:

```
{
  "animation": "size",
  "delay": 5000,
  "enabled": true,
  "iterations": 5
}
```