### PR TITLE
chore: actions: update node env for publish alerts

### DIFF
--- a/.github/workflows/octuple-publish-alerts.yml
+++ b/.github/workflows/octuple-publish-alerts.yml
@@ -7,6 +7,8 @@ on:
     types:
       - completed
 
+env:
+  NODE_VERSION: 16.14.2
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## SUMMARY:
Ensure the proper node version is used by octuple-publish-alerts action.