### PR TITLE
fix: popup: do not toggle when no content or disabled

### DIFF
--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -103,7 +103,7 @@ Popups.args = {
       >
         <img
           src="https://static.vscdn.net/images/career_hub/upskilling/more_projects.svg"
-          style={{ margin: 4, width: 'calc(100% - 8px)' }}
+          style={{ height: 172, margin: 4, width: 'calc(100% - 8px)' }}
         />
         <div className="octuple">
           <div className="octuple-content" style={{ padding: '16px' }}>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -113,6 +113,9 @@ export const Tooltip: FC<TooltipProps> = React.memo(
       const toggle: Function =
         (show: boolean, showTooltip = (show: boolean) => show): Function =>
         (e: SyntheticEvent): void => {
+          if (!content || disabled) {
+            return;
+          }
           // to control the toggle behaviour
           const updatedShow: boolean = showTooltip(show);
           if (PREVENT_DEFAULT_TRIGGERS.includes(trigger)) {


### PR DESCRIPTION
## SUMMARY:
Initial Popup change omitted this condition, also ensures image flicker does not happen in Popup story