### PR TITLE
chore: actions: update how the tag version is defined using workflow run

### DIFF
--- a/.github/workflows/octuple-publish-alerts.yml
+++ b/.github/workflows/octuple-publish-alerts.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get version from tag
         id: tag_name
         run: |
-          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
+          echo ::set-output name=current_version::${{ github.event.workflow_run.head_commit.tag_name }}
         shell: bash
       - name: Prerelease check
         id: prerelease_check


### PR DESCRIPTION
## SUMMARY:
To get the current tag on the `workflow_run` instead of `push`, this change uses the `github.event.workflow_run.head_commit.tag` context in the `octuple-publish-alerts` workflow. 
