### PR TITLE
Avatar status item text and tooltip support

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -9,6 +9,7 @@ import {
   getStatusItemSizeAndPadding,
 } from './';
 import { Stack } from '../Stack';
+import { TooltipTheme } from '../Tooltip';
 
 export default {
   title: 'Avatar',
@@ -226,6 +227,12 @@ const Avatar_StatusItem_Story: ComponentStory<typeof Avatar> = (args) => {
 
 export const Avatar_StatusItem = Avatar_StatusItem_Story.bind({});
 
+const Avatar_Tooltip_Story: ComponentStory<typeof Avatar> = (args) => (
+  <Avatar {...args} theme="red" />
+);
+
+export const Avatar_Tooltip = Avatar_Tooltip_Story.bind({});
+
 const avatarArgs: Object = {
   children: 'JD',
   classNames: 'my-avatar-class',
@@ -285,4 +292,14 @@ Avatar_Fallback_Hashing.args = {
   ...avatarArgs,
   children: 'HF',
   type: 'round',
+};
+
+Avatar_Tooltip.args = {
+  ...avatarArgs,
+  children: 'A',
+  type: 'round',
+  tooltipProps: {
+    content: 'Tooltip text',
+    theme: TooltipTheme.dark,
+  },
 };

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -124,6 +124,7 @@ const Avatar_StatusItem_Story: ComponentStory<typeof Avatar> = (args) => {
           wrapperStyle: { padding: '2px' },
           path: IconName.mdiPencil,
           size: '6px',
+          text: '20',
         },
       },
     },

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -202,12 +202,14 @@ const Avatar_StatusItem_Story: ComponentStory<typeof Avatar> = (args) => {
           backgroundColor: 'var(--red-color-30)',
           onClick: () => alert('Clicked clock icon'),
           path: IconName.mdiClock,
+          text: '3000',
         },
         [StatusItemsPosition.Top]: {
           ...statusItemProps,
           backgroundColor: 'var(--red-color-30)',
           path: IconName.mdiBell,
           text: '4',
+          textMaxLength: 2,
         },
         [StatusItemsPosition.Right]: {
           ...statusItemProps,

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -206,11 +206,13 @@ const Avatar_StatusItem_Story: ComponentStory<typeof Avatar> = (args) => {
           ...statusItemProps,
           backgroundColor: 'var(--red-color-30)',
           path: IconName.mdiBell,
+          text: '4',
         },
         [StatusItemsPosition.Right]: {
           ...statusItemProps,
           backgroundColor: 'var(--blue-color-20)',
           path: IconName.mdiCalendar,
+          text: '20',
         },
       },
     },

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -167,6 +167,7 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
                     fontSize: statusItemProps.size,
                     color: statusItemProps.color,
                   }}
+                  className={styles.avatarStatusItemText}
                 >
                   {statusItemProps.text}
                 </span>

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -14,6 +14,8 @@ import {
 import { mergeClasses } from '../../shared/utilities';
 import { Icon } from '../Icon';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
+import { Tooltip } from '../Tooltip';
+import { ConditionalWrapper } from '../../shared/utilities';
 
 export const AVATAR_THEME_SET = [
   styles.red,
@@ -263,6 +265,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
       hashingFunction,
       theme,
       randomiseTheme,
+      tooltipProps = undefined,
     },
     ref: Ref<HTMLDivElement>
   ) => {
@@ -301,20 +304,30 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
 
     if (src) {
       return (
-        <div ref={ref} style={wrapperContainerStyle} className={classNames}>
-          <img
-            src={src}
-            className={imageClasses}
-            alt={alt}
-            width={size}
-            height={size}
-          />
-          <AvatarStatusItems
-            outline={calculatedOutline}
-            size={size}
-            statusItems={statusItems}
-          />
-        </div>
+        <ConditionalWrapper
+          condition={tooltipProps !== undefined}
+          wrapper={(
+            children: React.ReactElement<
+              any,
+              string | React.JSXElementConstructor<any>
+            >
+          ): JSX.Element => <Tooltip {...tooltipProps}>{children}</Tooltip>}
+        >
+          <div ref={ref} style={wrapperContainerStyle} className={classNames}>
+            <img
+              src={src}
+              className={imageClasses}
+              alt={alt}
+              width={size}
+              height={size}
+            />
+            <AvatarStatusItems
+              outline={calculatedOutline}
+              size={size}
+              statusItems={statusItems}
+            />
+          </div>
+        </ConditionalWrapper>
       );
     }
 
@@ -322,38 +335,58 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
 
     if (iconProps) {
       return (
-        <AvatarIcon
-          iconProps={iconProps}
+        <ConditionalWrapper
+          condition={tooltipProps !== undefined}
+          wrapper={(
+            children: React.ReactElement<
+              any,
+              string | React.JSXElementConstructor<any>
+            >
+          ): JSX.Element => <Tooltip {...tooltipProps}>{children}</Tooltip>}
+        >
+          <AvatarIcon
+            iconProps={iconProps}
+            classNames={wrapperClasses}
+            style={wrapperContainerStyle}
+            fontSize={fontSize}
+            ref={ref}
+          >
+            <AvatarStatusItems
+              outline={calculatedOutline}
+              size={size}
+              statusItems={statusItems}
+            />
+          </AvatarIcon>
+        </ConditionalWrapper>
+      );
+    }
+
+    return (
+      <ConditionalWrapper
+        condition={tooltipProps !== undefined}
+        wrapper={(
+          children: React.ReactElement<
+            any,
+            string | React.JSXElementConstructor<any>
+          >
+        ): JSX.Element => <Tooltip {...tooltipProps}>{children}</Tooltip>}
+      >
+        <AvatarFallback
           classNames={wrapperClasses}
           style={wrapperContainerStyle}
-          fontSize={fontSize}
           ref={ref}
+          hashingFunction={hashingFunction}
+          theme={theme}
+          randomiseTheme={randomiseTheme}
         >
+          {children}
           <AvatarStatusItems
             outline={calculatedOutline}
             size={size}
             statusItems={statusItems}
           />
-        </AvatarIcon>
-      );
-    }
-
-    return (
-      <AvatarFallback
-        classNames={wrapperClasses}
-        style={wrapperContainerStyle}
-        ref={ref}
-        hashingFunction={hashingFunction}
-        theme={theme}
-        randomiseTheme={randomiseTheme}
-      >
-        {children}
-        <AvatarStatusItems
-          outline={calculatedOutline}
-          size={size}
-          statusItems={statusItems}
-        />
-      </AvatarFallback>
+        </AvatarFallback>
+      </ConditionalWrapper>
     );
   }
 );

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -162,7 +162,18 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
                 ? { 'aria-label': statusItemProps.ariaLabel }
                 : {})}
             >
-              {statusItemProps.text ?? ''}
+              {statusItemProps.text ? (
+                <span
+                  style={{
+                    fontSize: `calc(2px + ${statusItemProps.size})`,
+                    color: statusItemProps.color,
+                  }}
+                >
+                  {statusItemProps.text}
+                </span>
+              ) : (
+                ''
+              )}
               <Icon {...statusItemProps} />
             </div>
           );

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -40,6 +40,10 @@ export const getStatusItemSizeAndPadding = (
   return [statusItemSize, (statusItemSize * 6) / 16];
 };
 
+// 0.06 factor is chosen based on design
+const StatusItemWrapperPaddingFactor: number = 0.06;
+const DefaultStatusItemMaxTextLength: number = 3;
+
 const StatusItemOutlineDefaults: React.CSSProperties = {
   outlineColor: 'var(--grey-color-80)',
   outlineOffset: '0px',
@@ -117,9 +121,13 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
       <>
         {Object.keys(statusItems).map((position: StatusItemsPosition) => {
           const statusItemProps: StatusItemsProps = statusItems[position];
-          // 0.06 factor is chosen based on design
+          const showStatusItemText: boolean =
+            statusItemProps.text &&
+            statusItemProps.text.length <=
+              (statusItemProps.textMaxLength ?? DefaultStatusItemMaxTextLength);
           const wrapperPadding: string | number =
-            statusItemProps?.wrapperStyle?.padding ?? `(${size} * 0.06)`;
+            statusItemProps?.wrapperStyle?.padding ??
+            `(${size} * ${StatusItemWrapperPaddingFactor})`;
           return (
             <div
               key={position}
@@ -161,7 +169,7 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
                 ? { 'aria-label': statusItemProps.ariaLabel }
                 : {})}
             >
-              {statusItemProps.text ? (
+              {showStatusItemText ? (
                 <span
                   style={{
                     fontSize: statusItemProps.size,

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -295,7 +295,6 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
       fontSize: fontSize,
       ...style,
       ...(Object.keys(statusItems).length > 0 ? { position: 'relative' } : {}),
-      ...(calculatedOutline ?? {}),
     };
 
     if (src) {
@@ -314,6 +313,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
             <img
               src={src}
               className={imageClasses}
+              style={calculatedOutline}
               alt={alt}
               width={size}
               height={size}
@@ -341,7 +341,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
           <AvatarIcon
             iconProps={iconProps}
             classNames={wrapperClasses}
-            style={wrapperContainerStyle}
+            style={{ ...wrapperContainerStyle, ...(calculatedOutline ?? {}) }}
             fontSize={fontSize}
             ref={ref}
           >
@@ -364,7 +364,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
       >
         <AvatarFallback
           classNames={wrapperClasses}
-          style={wrapperContainerStyle}
+          style={{ ...wrapperContainerStyle, ...(calculatedOutline ?? {}) }}
           ref={ref}
           hashingFunction={hashingFunction}
           theme={theme}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -72,55 +72,43 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
     const htmlDir: string = useCanvasDirection();
 
     const getStatusItemPositionStyle = (
-      itemPos: StatusItemsPosition,
-      itemProps: StatusItemsProps,
-      wrapperPadding: string | number
+      itemPos: StatusItemsPosition
     ): React.CSSProperties => {
       const outlineWidth: string = outline?.outlineWidth ?? '0px'; // Avatar outline width
-      const avatarWidth: string = size;
-      const itemWidth: string = `(${itemProps.size} + (2 * ${wrapperPadding}))`; // Status item width
+      const outlineOffset: string = outline?.outlineOffset ?? '0px'; // Avatar outline offset
+      const radius: string = `calc((${size} + ${outlineWidth} + ${outlineOffset}) / 2)`;
 
       switch (htmlDir === 'rtl' ? statusItemPositionRtlMap[itemPos] : itemPos) {
         case StatusItemsPosition.TopRight:
           return {
-            top: `calc(-1 * ${outlineWidth})`,
-            right: `calc(-1 * ${outlineWidth})`,
+            transform: `rotate(${-45}deg) translate(${radius}) rotate(${45}deg)`,
           };
         case StatusItemsPosition.TopLeft:
           return {
-            top: `calc(-1 * ${outlineWidth})`,
-            left: `calc(-1 * ${outlineWidth})`,
+            transform: `rotate(${-135}deg) translate(${radius}) rotate(${135}deg)`,
           };
         case StatusItemsPosition.BottomRight:
           return {
-            bottom: `calc(-1 * ${outlineWidth})`,
-            right: `calc(-1 * ${outlineWidth})`,
+            transform: `rotate(${45}deg) translate(${radius}) rotate(${-45}deg)`,
           };
         case StatusItemsPosition.BottomLeft:
           return {
-            bottom: `calc(-1 * ${outlineWidth})`,
-            left: `calc(-1 * ${outlineWidth})`,
+            transform: `rotate(${135}deg) translate(${radius}) rotate(${-135}deg)`,
           };
         case StatusItemsPosition.Left:
           return {
-            bottom: `calc((${avatarWidth} - ${itemWidth}) / 2)`,
-            left: `calc(-1 * ${itemWidth} / 2 - ${outlineWidth})`,
+            transform: `rotate(${180}deg) translate(${radius}) rotate(${-180}deg)`,
           };
         case StatusItemsPosition.Right:
-          return {
-            bottom: `calc((${avatarWidth} - ${itemWidth}) / 2)`,
-            right: `calc(-1 * ${itemWidth} / 2 - ${outlineWidth})`,
-          };
+          return { transform: `translate(${radius})` };
         case StatusItemsPosition.Top:
           return {
-            top: `calc(-1 * ${itemWidth} / 2 - ${outlineWidth})`,
-            left: `calc((${avatarWidth} - ${itemWidth}) / 2)`,
+            transform: `rotate(${-90}deg) translate(${radius}) rotate(${90}deg)`,
           };
         case StatusItemsPosition.Bottom:
         default:
           return {
-            bottom: `calc(-1 * ${itemWidth} / 2 - ${outlineWidth})`,
-            left: `calc((${avatarWidth} - ${itemWidth}) / 2)`,
+            transform: `rotate(${90}deg) translate(${radius}) rotate(${-90}deg)`,
           };
       }
     };
@@ -137,16 +125,13 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
               key={position}
               ref={ref}
               style={{
+                display: 'flex',
                 position: 'absolute',
-                borderRadius: '50%',
+                borderRadius: '999px',
                 background:
                   statusItemProps.backgroundColor ?? 'var(--white-color)',
                 padding: `calc(${wrapperPadding})`,
-                ...getStatusItemPositionStyle(
-                  position,
-                  statusItemProps,
-                  wrapperPadding
-                ),
+                ...getStatusItemPositionStyle(position),
                 ...(statusItemProps.outline
                   ? {
                       outlineColor:
@@ -177,6 +162,7 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
                 ? { 'aria-label': statusItemProps.ariaLabel }
                 : {})}
             >
+              {statusItemProps.text ?? ''}
               <Icon {...statusItemProps} />
             </div>
           );
@@ -313,7 +299,11 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
             >
           ): JSX.Element => <Tooltip {...tooltipProps}>{children}</Tooltip>}
         >
-          <div ref={ref} style={wrapperContainerStyle} className={classNames}>
+          <div
+            ref={ref}
+            style={wrapperContainerStyle}
+            className={`${classNames} ${styles.avatarImgWrapper}`}
+          >
             <img
               src={src}
               className={imageClasses}

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -42,6 +42,7 @@ export const getStatusItemSizeAndPadding = (
 // 0.06 factor is chosen based on design
 const StatusItemWrapperPaddingFactor: number = 0.06;
 const DefaultStatusItemMaxTextLength: number = 3;
+const MinStatusItemFontSize: number = 12;
 
 const StatusItemOutlineDefaults: React.CSSProperties = {
   outlineColor: 'var(--grey-color-80)',
@@ -89,7 +90,8 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
       // We do slice to remove "px"
       setShowStatusItemsText((prevState) => ({
         ...prevState,
-        [position]: parseInt(styles.fontSize.slice(0, -2)) >= 12,
+        [position]:
+          parseInt(styles.fontSize.slice(0, -2)) >= MinStatusItemFontSize,
       }));
     };
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -125,11 +125,9 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
               key={position}
               ref={ref}
               style={{
-                display: 'flex',
-                position: 'absolute',
-                borderRadius: '999px',
                 background:
-                  statusItemProps.backgroundColor ?? 'var(--white-color)',
+                  statusItemProps.backgroundColor ??
+                  'var(--avatar-status-item-background)',
                 padding: `calc(${wrapperPadding})`,
                 ...getStatusItemPositionStyle(position),
                 ...(statusItemProps.outline
@@ -150,10 +148,11 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
                   : {}),
                 ...(statusItemProps.wrapperStyle ?? {}),
               }}
-              className={statusItemProps.wrapperClassName ?? ''}
+              className={`${styles.avatarStatusItem} ${
+                statusItemProps.wrapperClassName ?? ''
+              } ${statusItemProps.onClick ? styles.clickable : ''}`}
               {...(statusItemProps.onClick
                 ? {
-                    className: styles.avatarStatusItem,
                     onClick: statusItemProps.onClick,
                     role: 'button',
                   }
@@ -165,7 +164,7 @@ const AvatarStatusItems: FC<BaseAvatarProps> = React.forwardRef(
               {statusItemProps.text ? (
                 <span
                   style={{
-                    fontSize: `calc(2px + ${statusItemProps.size})`,
+                    fontSize: statusItemProps.size,
                     color: statusItemProps.color,
                   }}
                 >
@@ -303,12 +302,9 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
       return (
         <ConditionalWrapper
           condition={tooltipProps !== undefined}
-          wrapper={(
-            children: React.ReactElement<
-              any,
-              string | React.JSXElementConstructor<any>
-            >
-          ): JSX.Element => <Tooltip {...tooltipProps}>{children}</Tooltip>}
+          wrapper={(children: React.ReactNode): JSX.Element => (
+            <Tooltip {...tooltipProps}>{children}</Tooltip>
+          )}
         >
           <div
             ref={ref}
@@ -338,12 +334,9 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
       return (
         <ConditionalWrapper
           condition={tooltipProps !== undefined}
-          wrapper={(
-            children: React.ReactElement<
-              any,
-              string | React.JSXElementConstructor<any>
-            >
-          ): JSX.Element => <Tooltip {...tooltipProps}>{children}</Tooltip>}
+          wrapper={(children: React.ReactNode): JSX.Element => (
+            <Tooltip {...tooltipProps}>{children}</Tooltip>
+          )}
         >
           <AvatarIcon
             iconProps={iconProps}
@@ -365,12 +358,9 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
     return (
       <ConditionalWrapper
         condition={tooltipProps !== undefined}
-        wrapper={(
-          children: React.ReactElement<
-            any,
-            string | React.JSXElementConstructor<any>
-          >
-        ): JSX.Element => <Tooltip {...tooltipProps}>{children}</Tooltip>}
+        wrapper={(children: React.ReactNode): JSX.Element => (
+          <Tooltip {...tooltipProps}>{children}</Tooltip>
+        )}
       >
         <AvatarFallback
           classNames={wrapperClasses}

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -136,6 +136,10 @@ export interface AvatarProps
    * Image alt text
    */
   alt?: string;
+  /**
+   * Hover tooltip
+   */
+  tooltipProps?: TooltipProps;
 }
 
 interface MaxAvatarProps extends BaseAvatarProps {

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -71,6 +71,11 @@ export interface StatusItemsProps extends IconProps {
    * Text present with icon
    */
   text?: string;
+  /**
+   * Text having length larger than this will not be shown
+   * @default 3
+   */
+  textMaxLength?: number;
 }
 
 export interface BaseAvatarProps extends OcBaseProps<HTMLSpanElement> {

--- a/src/components/Avatar/Avatar.types.ts
+++ b/src/components/Avatar/Avatar.types.ts
@@ -67,6 +67,10 @@ export interface StatusItemsProps extends IconProps {
    * Class for status item wrapper
    */
   wrapperClassName?: string;
+  /**
+   * Text present with icon
+   */
+  text?: string;
 }
 
 export interface BaseAvatarProps extends OcBaseProps<HTMLSpanElement> {

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -186,7 +186,7 @@ const Spaced_With_Avatar_Features_Story: ComponentStory<typeof AvatarGroup> = (
         padding: '21px',
         borderRadius: '16px',
       }}
-      groupVariant="overlapped"
+      groupVariant={AvatarGroupVariant.Spaced}
       avatarListProps={{
         items: sampleList,
         renderItem: (item: User) => (

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -169,63 +169,6 @@ export const List_Group = List_Story.bind({});
 
 export const List_Group_Spaced = List_Story.bind({});
 
-const Spaced_With_Avatar_Features_Story: ComponentStory<typeof AvatarGroup> = (
-  args
-) => {
-  const statusColors = [
-    'var(--success-color)',
-    'var(--error-border-color)',
-    'var(--accent-color-60)',
-    'var(--warning-border-color)',
-  ];
-  return (
-    <AvatarGroup
-      {...args}
-      style={{
-        background: 'rgba(217, 220, 225, 0.5)',
-        padding: '21px',
-        borderRadius: '16px',
-      }}
-      groupVariant={AvatarGroupVariant.Spaced}
-      avatarListProps={{
-        items: sampleList,
-        renderItem: (item: User) => (
-          <Avatar
-            alt={item.alt}
-            classNames={item.classNames}
-            data-test-id={item['data-test-id']}
-            fontSize={args.fontSize}
-            hashingFunction={() => 3}
-            randomiseTheme={item.randomiseTheme}
-            size={args.size}
-            src={item.img}
-            type={args.type}
-            outline={{
-              outlineColor: statusColors[parseInt(`${4 * Math.random()}`)],
-              outlineOffset: `${1 + Math.floor(2 * Math.random())}px`,
-              outlineStyle: 'solid',
-              outlineWidth: `${2 + 2 * Math.floor(2 * Math.random())}px`,
-            }}
-          >
-            {item.children}
-          </Avatar>
-        ),
-      }}
-      maxProps={{
-        count: 8,
-        tooltipProps: {
-          content: 'This is a tooltip.',
-          size: TooltipSize.Large,
-          theme: TooltipTheme.dark,
-        },
-      }}
-    />
-  );
-};
-
-export const Spaced_With_Avatar_Features =
-  Spaced_With_Avatar_Features_Story.bind({});
-
 const avatarGroupArgs: Object = {
   classNames: 'my-avatar-group-class',
   'data-test-id': 'my-avatar-group-test-id',
@@ -250,11 +193,6 @@ List_Group.args = {
 };
 
 List_Group_Spaced.args = {
-  ...avatarGroupArgs,
-  groupVariant: AvatarGroupVariant.Spaced,
-};
-
-Spaced_With_Avatar_Features.args = {
   ...avatarGroupArgs,
   groupVariant: AvatarGroupVariant.Spaced,
 };

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -169,6 +169,63 @@ export const List_Group = List_Story.bind({});
 
 export const List_Group_Spaced = List_Story.bind({});
 
+const Spaced_With_Avatar_Features_Story: ComponentStory<typeof AvatarGroup> = (
+  args
+) => {
+  const statusColors = [
+    'var(--success-color)',
+    'var(--error-border-color)',
+    'var(--accent-color-60)',
+    'var(--warning-border-color)',
+  ];
+  return (
+    <AvatarGroup
+      {...args}
+      style={{
+        background: 'rgba(217, 220, 225, 0.5)',
+        padding: '21px',
+        borderRadius: '16px',
+      }}
+      groupVariant="overlapped"
+      avatarListProps={{
+        items: sampleList,
+        renderItem: (item: User) => (
+          <Avatar
+            alt={item.alt}
+            classNames={item.classNames}
+            data-test-id={item['data-test-id']}
+            fontSize={args.fontSize}
+            hashingFunction={() => 3}
+            randomiseTheme={item.randomiseTheme}
+            size={args.size}
+            src={item.img}
+            type={args.type}
+            outline={{
+              outlineColor: statusColors[parseInt(`${4 * Math.random()}`)],
+              outlineOffset: `${1 + Math.floor(2 * Math.random())}px`,
+              outlineStyle: 'solid',
+              outlineWidth: `${2 + 2 * Math.floor(2 * Math.random())}px`,
+            }}
+          >
+            {item.children}
+          </Avatar>
+        ),
+      }}
+      maxProps={{
+        count: 8,
+        tooltipProps: {
+          content: 'This is a tooltip.',
+          size: TooltipSize.Large,
+          theme: TooltipTheme.dark,
+        },
+      }}
+    />
+  );
+};
+
+export const Spaced_With_Avatar_Features =
+  Spaced_With_Avatar_Features_Story.bind({});
+
 const avatarGroupArgs: Object = {
   classNames: 'my-avatar-group-class',
   'data-test-id': 'my-avatar-group-test-id',
@@ -193,6 +250,11 @@ List_Group.args = {
 };
 
 List_Group_Spaced.args = {
+  ...avatarGroupArgs,
+  groupVariant: AvatarGroupVariant.Spaced,
+};
+
+Spaced_With_Avatar_Features.args = {
   ...avatarGroupArgs,
   groupVariant: AvatarGroupVariant.Spaced,
 };

--- a/src/components/Avatar/AvatarGroup.tsx
+++ b/src/components/Avatar/AvatarGroup.tsx
@@ -67,7 +67,7 @@ export const AvatarGroup: React.FC<AvatarGroupProps> = React.forwardRef(
         size={size}
         type={type}
         fontSize={styles.maxCountFontSize}
-        {...maxProps}
+        {...{ ...maxProps, tooltipProps: undefined }}
         classNames={mergeClasses([
           styles.avatarGroupMaxCount,
           maxProps?.classNames,

--- a/src/components/Avatar/Styles/group.scss
+++ b/src/components/Avatar/Styles/group.scss
@@ -7,7 +7,10 @@
 
   &.spaced {
     :not(:first-child):not(.avatar-group-tooltip) {
-      margin-left: -$space-xxxs;
+      margin-left: $space-xxxs;
+    }
+    & .avatar {
+      border: 0;
     }
   }
 

--- a/src/components/Avatar/Styles/group.scss
+++ b/src/components/Avatar/Styles/group.scss
@@ -1,16 +1,13 @@
 .avatar-group {
   display: inline-flex;
 
-  :not(:first-child):not(.avatar-group-tooltip) {
+  :not(:first-child):not(.avatar-group-tooltip):not(.avatar-status-item) {
     margin-left: -$space-xs;
   }
 
   &.spaced {
-    :not(:first-child):not(.avatar-group-tooltip) {
-      margin-left: $space-xxxs;
-    }
-    & .avatar {
-      border: 0;
+    :not(:first-child):not(.avatar-group-tooltip):not(.avatar-status-item) {
+      margin-left: -$space-xxxs;
     }
   }
 

--- a/src/components/Avatar/Styles/rtl.scss
+++ b/src/components/Avatar/Styles/rtl.scss
@@ -1,13 +1,13 @@
 .avatar-group {
   &-rtl {
-    :not(:first-child):not(.avatar-group-tooltip) {
+    :not(:first-child):not(.avatar-group-tooltip):not(.avatar-status-item) {
       margin-right: -$space-xs;
       margin-left: 0;
     }
 
     &.spaced {
-      :not(:first-child):not(.avatar-group-spaced-tooltip) {
-        margin-right: $space-xxxs;
+      :not(:first-child):not(.avatar-group-spaced-tooltip):not(.avatar-status-item) {
+        margin-right: -$space-xxxs;
         margin-left: 0;
       }
     }

--- a/src/components/Avatar/Styles/rtl.scss
+++ b/src/components/Avatar/Styles/rtl.scss
@@ -7,7 +7,7 @@
 
     &.spaced {
       :not(:first-child):not(.avatar-group-spaced-tooltip) {
-        margin-right: -$space-xxxs;
+        margin-right: $space-xxxs;
         margin-left: 0;
       }
     }

--- a/src/components/Avatar/avatar.module.scss
+++ b/src/components/Avatar/avatar.module.scss
@@ -74,5 +74,12 @@
   cursor: pointer;
 }
 
+.avatar-img-wrapper {
+  align-items: center;
+  display: flex;
+  font-family: var(--avatar-font-family);
+  justify-content: center;
+}
+
 @import './Styles/group';
 @import './Styles/rtl';

--- a/src/components/Avatar/avatar.module.scss
+++ b/src/components/Avatar/avatar.module.scss
@@ -71,7 +71,13 @@
 }
 
 .avatar-status-item {
-  cursor: pointer;
+  display: flex;
+  position: absolute;
+  border-radius: var(--avatar-status-item-border-radius);
+
+  .clickable {
+    cursor: pointer;
+  }
 }
 
 .avatar-img-wrapper {

--- a/src/components/Avatar/avatar.module.scss
+++ b/src/components/Avatar/avatar.module.scss
@@ -80,6 +80,10 @@
   }
 }
 
+.avatar-status-item-text {
+  margin-right: 2px;
+}
+
 .avatar-img-wrapper {
   align-items: center;
   display: flex;

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -620,6 +620,8 @@
   --avatar-font-family: var(--font-stack-full);
   --avatar-border-radius: 0;
   --avatar-round-border-radius: 50%;
+  --avatar-status-item-background: var(--background-color);
+  --avatar-status-item-border-radius: 999px;
   // ------ Avatar theme ------
 
   // ------ Card theme ------


### PR DESCRIPTION
## SUMMARY:
- Add `Avatar` status item **text** and **tooltip** support (this is needed because we required `Avatar+Tooltip` support in `AvatarGroup` but it was not working because of use of `cloneElement` in `AvatarGroup`)
- Improve `Avatar` status item placement CSS
- Fix undesired `Avatar` status item displacement in `AvatarGroup` due to border
- Fix `Avatar` outline when `src` is passed and `type === 'round'`

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
ENG-40399


## CHANGE TYPE:

- [x] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run yarn and yarn storybook. Verify the Avatar Group stories behave as expected.

Avatar status item text
<img width="481" alt="image" src="https://user-images.githubusercontent.com/110680523/223326139-c7064899-8f52-440e-845f-d0ae345d33bb.png">

Avatar tooltip
<img width="391" alt="image" src="https://user-images.githubusercontent.com/110680523/223326036-0ed416ea-d485-4f99-8b3d-3f02ae15a906.png">

Avatar status item displacement in AvatarGroup - **before** and **after** the fix
<img width="317" alt="image" src="https://user-images.githubusercontent.com/110680523/223327311-5798e2c0-21c7-480a-8b86-b771584586d8.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/110680523/224270399-8d9bd4af-9ff5-431c-a9eb-d0687c4d7695.png">

`Avatar` outline when `src` is passed and `type === 'round'` - **before** and **after** the fix
<img width="258" alt="image" src="https://user-images.githubusercontent.com/110680523/224280153-d3b70376-6dfa-491c-93f1-020f7b831523.png">
<img width="263" alt="image" src="https://user-images.githubusercontent.com/110680523/224280861-8ac2e8d8-a6c1-4d19-a071-da3fde1fe073.png">