### PR TITLE
feat: menuitem: adds align icon prop and fixes list item rendering bug

### DIFF
--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { Dropdown } from './';
+import {
+  ButtonIconAlign,
+  ButtonTextAlign,
+  ButtonWidth,
+  DefaultButton,
+} from '../Button';
+import { IconName } from '../Icon';
+import { List } from '../List';
+import { render, screen, waitFor } from '@testing-library/react';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+let matchMedia: any;
+
+interface User {
+  name: string;
+  icon: IconName;
+}
+
+const sampleList: User[] = [1, 2, 3].map((i) => ({
+  name: `User profile ${i}`,
+  icon: IconName.mdiAccount,
+}));
+
+const Overlay = () => (
+  <List<User>
+    items={sampleList}
+    renderItem={(item) => (
+      <DefaultButton
+        text={item.name}
+        alignText={ButtonTextAlign.Left}
+        buttonWidth={ButtonWidth.fill}
+        iconProps={{
+          path: item.icon,
+        }}
+        style={{
+          margin: '4px 0',
+        }}
+      />
+    )}
+  />
+);
+
+const DropdownComponent = (): JSX.Element => {
+  const [visible, setVisibility] = useState(false);
+
+  const dropdownProps: object = {
+    trigger: 'click',
+    classNames: 'my-dropdown-class',
+    style: {},
+    dropdownClassNames: 'my-dropdown-class',
+    dropdownStyle: {
+      color: 'red',
+    },
+    placement: 'bottom-start',
+    overlay: Overlay(),
+    offset: 0,
+    positionStrategy: 'absolute',
+    disabled: false,
+    closeOnDropdownClick: true,
+    portal: false,
+  };
+
+  return (
+    <Dropdown
+      {...dropdownProps}
+      onVisibleChange={(isVisible) => setVisibility(isVisible)}
+    >
+      <DefaultButton
+        alignIcon={ButtonIconAlign.Right}
+        text={'Dropdown menu test'}
+        iconProps={{
+          path: IconName.mdiChevronDown,
+          rotate: visible ? 180 : 0,
+        }}
+      />
+    </Dropdown>
+  );
+};
+
+describe('Dropdown', () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  test('Should render a dropdown button', () => {
+    const { container } = render(<DropdownComponent />);
+    const dropdownButton = screen.getByRole('button');
+    expect(dropdownButton).toBeTruthy();
+    expect(() => container).not.toThrowError();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Should show the dropdown options when the button is clicked', async () => {
+    render(<DropdownComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('User profile 1'));
+    const option1 = screen.getByText('User profile 1');
+    const option2 = screen.getByText('User profile 2');
+    const option3 = screen.getByText('User profile 3');
+    expect(option1).toBeTruthy();
+    expect(option2).toBeTruthy();
+    expect(option3).toBeTruthy();
+  });
+
+  test('Should support props such as dropdownClassNames and dropdownStyle', async () => {
+    const { container } = render(<DropdownComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('User profile 1'));
+    expect(container.querySelector('.dropdown-wrapper')?.classList).toContain(
+      'my-dropdown-class'
+    );
+    expect(
+      (container.querySelector('.dropdown-wrapper') as HTMLElement).style.color
+    ).toContain('red');
+  });
+});

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropdown Should render a dropdown button 1`] = `
+<div>
+  <div
+    class="my-dropdown-class main-wrapper"
+  >
+    <button
+      aria-controls="dropdown-"
+      aria-disabled="false"
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="button button-default button-medium pill-shape icon-right"
+      role="button"
+      tabindex="0"
+    >
+      <span>
+        <span
+          aria-hidden="false"
+          class="icon icon-wrapper"
+          role="presentation"
+        >
+          <svg
+            role="presentation"
+            style="width: 20px; height: 20px;"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+              style="fill: currentColor;"
+            />
+          </svg>
+        </span>
+        <span
+          class="button-text-medium"
+        >
+          Dropdown menu test
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -23,7 +23,7 @@
   background: var(--dropdown-background-color);
   padding: $space-xs;
   box-shadow: $shadow-object-m;
-  border-radius: $border-radius-l; // TODO: Add DropdownSize type and handle mapping via trigger size, then L 24px, M 20px, S 16px border-radius determined by size of the trigger.
+  border-radius: $border-radius-l; // TODO: ENG-46367 Add DropdownSize type and handle mapping via trigger size, then L 24px, M 20px, S 16px border-radius determined by size of the trigger.
   font-family: $octuple-font-family;
   min-width: 200px;
   opacity: 0;

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -23,7 +23,7 @@
   background: var(--dropdown-background-color);
   padding: $space-xs;
   box-shadow: $shadow-object-m;
-  border-radius: $border-radius-xl;
+  border-radius: $border-radius-l; // TODO: Add DropdownSize type and handle mapping via trigger size, then L 24px, M 20px, S 16px border-radius determined by size of the trigger.
   font-family: $octuple-font-family;
   transition: all $motion-duration-fast $motion-easing-easeout;
   min-width: 200px;

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -25,7 +25,6 @@
   box-shadow: $shadow-object-m;
   border-radius: $border-radius-l; // TODO: Add DropdownSize type and handle mapping via trigger size, then L 24px, M 20px, S 16px border-radius determined by size of the trigger.
   font-family: $octuple-font-family;
-  transition: all $motion-duration-fast $motion-easing-easeout;
   min-width: 200px;
   opacity: 0;
   white-space: normal;
@@ -45,6 +44,20 @@
 
   &.no-padding {
     padding: 0;
+  }
+
+  // Hides the browser default keyboard focus-visible styles.
+  // Use the ConfigProvider instead.
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+:global(.focus-visible) {
+  .dropdown-wrapper {
+    &:focus-visible {
+      box-shadow: var(--focus-visible-box-shadow);
+    }
   }
 }
 

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -6,6 +6,7 @@ import { Dropdown } from '../Dropdown';
 import { DefaultButton } from '../Button';
 import { RadioGroup } from '../RadioButton';
 import { IconName } from '../Icon';
+import { SelectorSize } from '../CheckBox/Checkbox.types';
 
 export default {
   title: 'Menu',
@@ -137,93 +138,102 @@ const LinkOverlay = (args: any) => (
   />
 );
 
-const SubHeaderOverlay = (args: any) => (
-  <Menu
-    {...args}
-    items={[
-      {
-        iconProps: {
-          path: IconName.mdiCalendar,
+const SubHeaderOverlay = (args: any) => {
+  const menuSizeToSelectorSizeSizeMap = new Map<MenuSize, SelectorSize>([
+    [MenuSize.large, SelectorSize.Large],
+    [MenuSize.medium, SelectorSize.Medium],
+    [MenuSize.small, SelectorSize.Small],
+  ]);
+
+  return (
+    <Menu
+      {...args}
+      items={[
+        {
+          iconProps: {
+            path: IconName.mdiCalendar,
+          },
+          text: 'Date',
+          value: 'date 1',
+          counter: '8',
         },
-        text: 'Date',
-        value: 'date 1',
-        counter: '8',
-      },
-      {
-        text: 'Thumbs up',
-        value: 'date 1',
-        disabled: true,
-      },
-      {
-        iconProps: {
-          path: IconName.mdiCalendar,
+        {
+          text: 'Thumbs up',
+          value: 'date 1',
+          disabled: true,
         },
-        text: 'Date',
-        value: 'date 1',
-        counter: '8',
-      },
-      {
-        text: 'Thumbs up',
-        value: 'date 1',
-      },
-      {
-        type: MenuItemType.subHeader,
-        text: 'Menu Type links',
-      },
-      {
-        type: MenuItemType.link,
-        text: 'Twitter link',
-        href: 'https://twitter.com',
-        target: '_blank',
-      },
-      {
-        type: MenuItemType.link,
-        text: 'Facebook link',
-        href: 'https://facebook.com',
-        target: '_blank',
-      },
-      {
-        type: MenuItemType.subHeader,
-        text: 'Menu type custom',
-      },
-      {
-        type: MenuItemType.custom,
-        render: ({ onChange }) => (
-          <RadioGroup
-            {...{
-              ariaLabel: 'Radio Group',
-              value: 'Radio1',
-              items: [1, 2, 3].map((i) => ({
-                value: `Radio${i}`,
-                label: `Radio${i}`,
-                name: 'group',
-                id: `oea2exk-${i}`,
-              })),
-              layout: 'vertical',
-            }}
-            onChange={onChange}
-          />
-        ),
-      },
-      {
-        iconProps: {
-          path: IconName.mdiCalendar,
+        {
+          iconProps: {
+            path: IconName.mdiCalendar,
+          },
+          text: 'Date',
+          value: 'date 1',
+          counter: '8',
         },
-        text: 'Date',
-        value: 'date 1',
-        counter: '8',
-      },
-      {
-        text: 'Thumbs up',
-        value: 'date 1',
-      },
-    ]}
-    onChange={(item) => {
-      args.onChange(item);
-      console.log(item);
-    }}
-  />
-);
+        {
+          text: 'Thumbs up',
+          value: 'date 1',
+        },
+        {
+          type: MenuItemType.subHeader,
+          text: 'Menu Type links',
+        },
+        {
+          type: MenuItemType.link,
+          text: 'Twitter link',
+          href: 'https://twitter.com',
+          target: '_blank',
+        },
+        {
+          type: MenuItemType.link,
+          text: 'Facebook link',
+          href: 'https://facebook.com',
+          target: '_blank',
+        },
+        {
+          type: MenuItemType.subHeader,
+          text: 'Menu type custom',
+        },
+        {
+          type: MenuItemType.custom,
+          render: ({ onChange }) => (
+            <RadioGroup
+              {...{
+                ariaLabel: 'Radio Group',
+                value: 'Radio1',
+                items: [1, 2, 3].map((i) => ({
+                  value: `Radio${i}`,
+                  label: `Radio${i}`,
+                  name: 'group',
+                  id: `oea2exk-${i}`,
+                })),
+                layout: 'vertical',
+              }}
+              onChange={onChange}
+              size={menuSizeToSelectorSizeSizeMap.get(args.size)}
+            />
+          ),
+        },
+        {
+          iconProps: {
+            path: IconName.mdiCalendar,
+          },
+          text: 'Date',
+          value: 'date 1',
+          counter: '8',
+        },
+        {
+          text: 'Thumbs up',
+          value: 'date 1',
+        },
+      ]}
+      onChange={(item) => {
+        args.onChange(item);
+        console.log(item);
+      }}
+    />
+  );
+};
 
 const Basic_Menu_Story: ComponentStory<typeof Menu> = (args) => (
   <Dropdown overlay={BasicOverlay(args)}>

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { MenuItemType } from './MenuItem/MenuItem.types';
+import { MenuSize, MenuVariant } from './Menu.types';
+import { Menu } from './Menu';
+import { Dropdown } from '../Dropdown';
+import { DefaultButton } from '../Button';
+import { IconName } from '../Icon';
+import { RadioGroup } from '../RadioButton';
+import { SelectorSize } from '../CheckBox';
+import { render, screen, waitFor } from '@testing-library/react';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+let matchMedia: any;
+
+const MenuOverlay = (args: any) => {
+  const menuSizeToSelectorSizeSizeMap = new Map<MenuSize, SelectorSize>([
+    [MenuSize.large, SelectorSize.Large],
+    [MenuSize.medium, SelectorSize.Medium],
+    [MenuSize.small, SelectorSize.Small],
+  ]);
+
+  return (
+    <Menu
+      {...args}
+      items={[
+        {
+          iconProps: {
+            path: IconName.mdiCalendar,
+          },
+          text: 'Date',
+          value: 'menu 1',
+          counter: '8',
+        },
+        {
+          text: 'Disabled button',
+          value: 'menu 2',
+          disabled: true,
+        },
+        {
+          type: MenuItemType.subHeader,
+          text: 'Sub header',
+        },
+        {
+          type: MenuItemType.link,
+          text: 'Twitter link',
+          href: 'https://twitter.com',
+          target: '_blank',
+        },
+        {
+          type: MenuItemType.custom,
+          render: ({ onChange }) => (
+            <RadioGroup
+              {...{
+                ariaLabel: 'Radio Group',
+                value: 'Radio1',
+                items: [1, 2, 3].map((i) => ({
+                  value: `Radio${i}`,
+                  label: `Radio${i}`,
+                  name: 'group',
+                  id: `oea2exk-${i}`,
+                })),
+                layout: 'vertical',
+              }}
+              onChange={onChange}
+              size={menuSizeToSelectorSizeSizeMap.get(args.size)}
+            />
+          ),
+        },
+      ]}
+      onChange={(item) => {
+        args.onChange(item);
+      }}
+    />
+  );
+};
+
+const menuProps: object = {
+  variant: MenuVariant.neutral,
+  classNames: 'my-menu-class',
+  style: {
+    color: 'red',
+  },
+  itemClassNames: 'my-menu-item-class',
+  itemStyle: {},
+  listType: 'ul',
+};
+
+const MenuComponent = (): JSX.Element => {
+  return (
+    <Dropdown overlay={MenuOverlay(menuProps)}>
+      <DefaultButton text={'Menu dropdown'} />
+    </Dropdown>
+  );
+};
+
+const LargeMenuComponent = (): JSX.Element => {
+  const _menuProps: object = {
+    ...menuProps,
+    size: MenuSize.large,
+  };
+
+  return (
+    <Dropdown overlay={MenuOverlay(_menuProps)}>
+      <DefaultButton text={'Menu dropdown'} />
+    </Dropdown>
+  );
+};
+
+const MediumMenuComponent = (): JSX.Element => {
+  const _menuProps: object = {
+    ...menuProps,
+    size: MenuSize.medium,
+  };
+
+  return (
+    <Dropdown overlay={MenuOverlay(_menuProps)}>
+      <DefaultButton text={'Menu dropdown'} />
+    </Dropdown>
+  );
+};
+
+const SmallMenuComponent = (): JSX.Element => {
+  const _menuProps: object = {
+    ...menuProps,
+    size: MenuSize.small,
+  };
+
+  return (
+    <Dropdown overlay={MenuOverlay(_menuProps)}>
+      <DefaultButton text={'Menu dropdown'} />
+    </Dropdown>
+  );
+};
+
+describe('Menu', () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  test('Should render a menu button', () => {
+    const { container } = render(<MenuComponent />);
+    const dropdownButton = screen.getByRole('button');
+    expect(dropdownButton).toBeTruthy();
+    expect(() => container).not.toThrowError();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Should show the menu items when the button is clicked', async () => {
+    render(<MenuComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('Date'));
+    const menuitem1 = screen.getByText('Date');
+    const menuitem2 = screen.getByText('Disabled button');
+    const menuitem3 = screen.getByText('Twitter link');
+    const menuitem4 = screen.getByText('Radio1');
+    const menuitem5 = screen.getByText('Radio2');
+    const menuitem6 = screen.getByText('Radio3');
+    expect(menuitem1).toBeTruthy();
+    expect(menuitem2).toBeTruthy();
+    expect(menuitem3).toBeTruthy();
+    expect(menuitem4).toBeTruthy();
+    expect(menuitem5).toBeTruthy();
+    expect(menuitem6).toBeTruthy();
+  });
+
+  test('Should support sub header', async () => {
+    render(<MenuComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('Sub header'));
+    const subHeader = screen.getByText('Sub header');
+    expect(subHeader).toBeTruthy();
+  });
+
+  test('Should support props such as classNames and style', async () => {
+    const { container } = render(<MenuComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('Date'));
+    expect(container.querySelector('.menu-container')?.classList).toContain(
+      'my-menu-class'
+    );
+    expect(
+      (container.querySelector('.menu-container') as HTMLElement).style.color
+    ).toContain('red');
+  });
+
+  test('Menu is large', async () => {
+    const { container } = render(<LargeMenuComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('Date'));
+    expect(container.querySelector('.menu-container')?.classList).toContain(
+      'large'
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Menu is medium', async () => {
+    const { container } = render(<MediumMenuComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('Date'));
+    expect(container.querySelector('.menu-container')?.classList).toContain(
+      'medium'
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Menu is small', async () => {
+    const { container } = render(<SmallMenuComponent />);
+    const dropdownButton = screen.getByRole('button');
+    dropdownButton.click();
+    await waitFor(() => screen.getByText('Date'));
+    expect(container.querySelector('.menu-container')?.classList).toContain(
+      'small'
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -67,6 +67,7 @@ export const Menu: FC<MenuProps> = ({
 
   const getListItem = (item: MenuItemTypes, index: number): React.ReactNode => (
     <MenuItem
+      classNames={itemClassNames}
       direction={htmlDir}
       key={`oc-menu-item-${index}`}
       variant={variant}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -6,6 +6,7 @@ import { MenuItemType } from './MenuItem/MenuItem.types';
 import { mergeClasses } from '../../shared/utilities';
 import { Stack } from '../Stack';
 import { ButtonSize, NeutralButton, PrimaryButton } from '../Button';
+import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 
 import styles from './menu.module.scss';
 
@@ -16,24 +17,26 @@ const MENU_SIZE_TO_BUTTON_SIZE_MAP: Record<MenuSize, ButtonSize> = {
 };
 
 export const Menu: FC<MenuProps> = ({
-  items,
-  onChange,
-  variant = MenuVariant.neutral,
-  size = MenuSize.medium,
-  classNames,
-  style,
-  itemClassNames,
-  itemStyle,
-  header,
-  listType,
-  itemProps,
-  subHeader,
-  okButtonProps,
   cancelButtonProps,
-  onOk,
+  classNames,
+  header,
+  itemClassNames,
+  itemProps,
+  items,
+  itemStyle,
+  listType,
+  okButtonProps,
   onCancel,
+  onChange,
+  onOk,
+  size = MenuSize.medium,
+  style,
+  subHeader,
+  variant = MenuVariant.neutral,
   ...rest
 }) => {
+  const htmlDir: string = useCanvasDirection();
+
   const headerClasses: string = mergeClasses([
     styles.menuHeaderContainer,
     {
@@ -54,6 +57,7 @@ export const Menu: FC<MenuProps> = ({
 
   const getListItem = (item: MenuItemTypes, index: number): React.ReactNode => (
     <MenuItem
+      direction={htmlDir}
       key={`oc-menu-item-${index}`}
       variant={variant}
       size={size}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -37,7 +37,16 @@ export const Menu: FC<MenuProps> = ({
 }) => {
   const htmlDir: string = useCanvasDirection();
 
-  const headerClasses: string = mergeClasses([
+  const footerClassNames: string = mergeClasses([
+    styles.menuFooterContainer,
+    {
+      [styles.large]: size === MenuSize.large,
+      [styles.medium]: size === MenuSize.medium,
+      [styles.small]: size === MenuSize.small,
+    },
+  ]);
+
+  const headerClassNames: string = mergeClasses([
     styles.menuHeaderContainer,
     {
       [styles.large]: size === MenuSize.large,
@@ -46,8 +55,9 @@ export const Menu: FC<MenuProps> = ({
     },
   ]);
 
-  const footerClasses: string = mergeClasses([
-    styles.menuFooterContainer,
+  const menuClassNames: string = mergeClasses([
+    classNames,
+    styles.menuContainer,
     {
       [styles.large]: size === MenuSize.large,
       [styles.medium]: size === MenuSize.medium,
@@ -70,14 +80,19 @@ export const Menu: FC<MenuProps> = ({
 
   const getHeader = (): JSX.Element =>
     header && (
-      <div className={headerClasses}>
+      <div className={headerClassNames}>
         <div className={styles.heading}>{header}</div>
       </div>
     );
 
   const getFooter = (): JSX.Element =>
     (cancelButtonProps || okButtonProps) && (
-      <Stack gap="s" justify="flex-end" fullWidth classNames={footerClasses}>
+      <Stack
+        flexGap="s"
+        justify="flex-end"
+        fullWidth
+        classNames={footerClassNames}
+      >
         {cancelButtonProps && (
           <NeutralButton
             {...cancelButtonProps}
@@ -95,27 +110,17 @@ export const Menu: FC<MenuProps> = ({
       </Stack>
     );
 
-  const menuClassNames = mergeClasses([
-    classNames,
-    styles.menuContainer,
-    {
-      [styles.large]: size === MenuSize.large,
-      [styles.medium]: size === MenuSize.medium,
-      [styles.small]: size === MenuSize.small,
-    },
-  ]);
-
   return (
     <List<MenuItemTypes>
       {...rest}
-      items={items}
       classNames={menuClassNames}
-      style={style}
-      header={getHeader()}
       footer={getFooter()}
+      getItem={getListItem}
+      header={getHeader()}
+      items={items}
       listType={listType}
       role="menu"
-      getItem={getListItem}
+      style={style}
     />
   );
 };

--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -5,6 +5,11 @@ import { IconProps } from '../../Icon';
 import { LinkProps } from '../../Link';
 import { ButtonProps } from '../../Button';
 
+export enum MenuItemIconAlign {
+  Left = 'left',
+  Right = 'right',
+}
+
 export enum MenuItemType {
   button = 'button',
   custom = 'custom',
@@ -13,6 +18,11 @@ export enum MenuItemType {
 }
 
 export interface MenuItemProps {
+  /**
+   * The Menu item icon alignment.
+   * @default MenuItemIconAlign.Left
+   */
+  alignIcon?: MenuItemIconAlign;
   /**
    * Size of the menu
    * @default MenuSize.Medium
@@ -62,17 +72,17 @@ export interface MenuItemButtonProps
    */
   onClick?: (value: any) => void;
   /**
-   * Display label of the menu item
+   * Secondary action button for the menu item
    */
-  text?: string;
+  secondaryButtonProps?: Omit<ButtonProps, 'text' | 'shape'>;
   /**
    * Display sub text of the menu item
    */
   subText?: string;
   /**
-   * Secondary action button for the menu item
+   * Display label of the menu item
    */
-  secondaryButtonProps?: Omit<ButtonProps, 'text' | 'shape'>;
+  text?: string;
 }
 
 export interface MenuItemLinkProps
@@ -96,13 +106,13 @@ export interface MenuItemLinkProps
    */
   iconProps?: IconProps;
   /**
-   * Display label of the menu item
-   */
-  text?: string;
-  /**
    * Display sub text of the menu item
    */
   subText?: string;
+  /**
+   * Display label of the menu item
+   */
+  text?: string;
 }
 
 export interface MenuItemSubHeaderProps

--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -5,6 +5,8 @@ import { IconProps } from '../../Icon';
 import { LinkProps } from '../../Link';
 import { ButtonProps } from '../../Button';
 
+export interface MenuIconProps extends Omit<IconProps, 'size'> {}
+
 export enum MenuItemIconAlign {
   Left = 'left',
   Right = 'right',
@@ -74,7 +76,7 @@ export interface MenuItemButtonProps
   /**
    * Menu item icon props
    */
-  iconProps?: IconProps;
+  iconProps?: MenuIconProps;
   /**
    * On Click handler of the menu item
    * @param value
@@ -113,7 +115,7 @@ export interface MenuItemLinkProps
   /**
    * Menu item icon props
    */
-  iconProps?: IconProps;
+  iconProps?: MenuIconProps;
   /**
    * Display sub text of the menu item
    */

--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -24,6 +24,10 @@ export interface MenuItemProps {
    */
   alignIcon?: MenuItemIconAlign;
   /**
+   * The canvas direction of the Menu.
+   */
+  direction?: string;
+  /**
    * Size of the menu
    * @default MenuSize.Medium
    */
@@ -42,6 +46,11 @@ export interface MenuItemProps {
    * @default MenuVariant.neutral
    */
   variant?: MenuVariant;
+  /**
+   * The text should wrap
+   * @default false
+   */
+  wrap?: boolean;
 }
 
 type NativeMenuButtonProps = Omit<OcBaseProps<HTMLButtonElement>, 'children'>;

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -9,7 +9,7 @@ import styles from '../menuItem.module.scss';
 
 export const MenuItemButton: FC<MenuItemButtonProps> = ({
   active,
-  alignIcon,
+  alignIcon = MenuItemIconAlign.Left,
   classNames,
   counter,
   direction,
@@ -28,7 +28,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
   wrap = false,
   ...rest
 }) => {
-  const menuItemClasses: string = mergeClasses([
+  const menuItemClassNames: string = mergeClasses([
     styles.menuItem,
     {
       [styles.menuItemRtl]: direction === 'rtl',
@@ -45,7 +45,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
     classNames,
   ]);
 
-  const itemSubTextClasses: string = mergeClasses([
+  const itemSubTextClassNames: string = mergeClasses([
     styles.itemSubText,
     {
       [styles.small]: size === MenuSize.small,
@@ -64,6 +64,10 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
     onClick?.(value);
   };
 
+  const getIcon = (): JSX.Element => (
+    <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
+  );
+
   const menuSizeToIconSizeMap: Map<MenuSize, IconSize> = new Map<
     MenuSize,
     IconSize
@@ -74,7 +78,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
   ]);
 
   return secondaryButtonProps ? (
-    <li role={role} tabIndex={-1} className={menuItemClasses}>
+    <li role={role} tabIndex={-1} className={menuItemClassNames}>
       <span className={styles.menuSecondaryWrapper}>
         <button
           className={styles.menuOuterButton}
@@ -83,17 +87,13 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
           {...rest}
           onClick={handleOnClick}
         >
-          {iconProps && alignIcon !== MenuItemIconAlign.Right && (
-            <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-          )}
+          {iconProps && alignIcon !== MenuItemIconAlign.Right && getIcon()}
           <span className={styles.menuItemWrapper}>
             <span className={styles.itemText}>
               <span className={styles.label}>{text}</span>
             </span>
           </span>
-          {iconProps && alignIcon === MenuItemIconAlign.Right && (
-            <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-          )}
+          {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
         </button>
         <span className={styles.menuInnerButton}>
           {counter && <span>{counter}</span>}
@@ -107,10 +107,10 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
           )}
         </span>
       </span>
-      {subText && <span className={itemSubTextClasses}>{subText}</span>}
+      {subText && <span className={itemSubTextClassNames}>{subText}</span>}
     </li>
   ) : (
-    <li role={role} tabIndex={-1} className={menuItemClasses}>
+    <li role={role} tabIndex={-1} className={menuItemClassNames}>
       <button
         className={styles.menuItemButton}
         disabled={disabled}
@@ -118,19 +118,15 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
         {...rest}
         onClick={handleOnClick}
       >
-        {iconProps && alignIcon !== MenuItemIconAlign.Right && (
-          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-        )}
+        {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
         <span className={styles.menuItemWrapper}>
           <span className={styles.itemText}>
             <span className={styles.label}>{text}</span>
             {counter && <span>{counter}</span>}
           </span>
-          {subText && <span className={itemSubTextClasses}>{subText}</span>}
+          {subText && <span className={itemSubTextClassNames}>{subText}</span>}
         </span>
-        {iconProps && alignIcon === MenuItemIconAlign.Right && (
-          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-        )}
+        {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
       </button>
     </li>
   );

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -12,6 +12,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
   alignIcon,
   classNames,
   counter,
+  direction,
   disabled,
   iconProps,
   onClick,
@@ -24,11 +25,14 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
   type,
   value,
   variant = MenuVariant.neutral,
+  wrap = false,
   ...rest
 }) => {
   const menuItemClasses: string = mergeClasses([
     styles.menuItem,
     {
+      [styles.menuItemRtl]: direction === 'rtl',
+      [styles.wrap]: !!wrap,
       [styles.small]: size === MenuSize.small,
       [styles.medium]: size === MenuSize.medium,
       [styles.large]: size === MenuSize.large,
@@ -70,15 +74,16 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
   ]);
 
   return secondaryButtonProps ? (
-    <li role={role} tabIndex={tabIndex} className={menuItemClasses}>
+    <li role={role} tabIndex={-1} className={menuItemClasses}>
       <span className={styles.menuSecondaryWrapper}>
         <button
-          className={styles.menuInnerButton}
+          className={styles.menuOuterButton}
           disabled={disabled}
+          tabIndex={tabIndex}
           {...rest}
           onClick={handleOnClick}
         >
-          {iconProps && alignIcon === MenuItemIconAlign.Left && (
+          {iconProps && alignIcon !== MenuItemIconAlign.Right && (
             <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
           )}
           <span className={styles.menuItemWrapper}>
@@ -105,14 +110,15 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
       {subText && <span className={itemSubTextClasses}>{subText}</span>}
     </li>
   ) : (
-    <li role={role} tabIndex={tabIndex} className={menuItemClasses}>
+    <li role={role} tabIndex={-1} className={menuItemClasses}>
       <button
         className={styles.menuItemButton}
         disabled={disabled}
+        tabIndex={tabIndex}
         {...rest}
         onClick={handleOnClick}
       >
-        {iconProps && alignIcon === MenuItemIconAlign.Left && (
+        {iconProps && alignIcon !== MenuItemIconAlign.Right && (
           <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
         )}
         <span className={styles.menuItemWrapper}>

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { MenuItemButtonProps, MenuItemIconAlign } from '../MenuItem.types';
 import { MenuSize, MenuVariant } from '../../Menu.types';
 import { mergeClasses } from '../../../../shared/utilities';
-import { Icon } from '../../../Icon';
+import { Icon, IconSize } from '../../../Icon';
 import { ButtonShape, ButtonSize, NeutralButton } from '../../../Button';
 
 import styles from '../menuItem.module.scss';
@@ -60,6 +60,15 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
     onClick?.(value);
   };
 
+  const menuSizeToIconSizeMap: Map<MenuSize, IconSize> = new Map<
+    MenuSize,
+    IconSize
+  >([
+    [MenuSize.large, IconSize.Large],
+    [MenuSize.medium, IconSize.Medium],
+    [MenuSize.small, IconSize.Small],
+  ]);
+
   return secondaryButtonProps ? (
     <li role={role} tabIndex={tabIndex} className={menuItemClasses}>
       <span className={styles.menuSecondaryWrapper}>
@@ -70,7 +79,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
           onClick={handleOnClick}
         >
           {iconProps && alignIcon === MenuItemIconAlign.Left && (
-            <Icon {...iconProps} />
+            <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
           )}
           <span className={styles.menuItemWrapper}>
             <span className={styles.itemText}>
@@ -78,7 +87,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
             </span>
           </span>
           {iconProps && alignIcon === MenuItemIconAlign.Right && (
-            <Icon {...iconProps} />
+            <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
           )}
         </button>
         <span className={styles.menuInnerButton}>
@@ -104,7 +113,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
         onClick={handleOnClick}
       >
         {iconProps && alignIcon === MenuItemIconAlign.Left && (
-          <Icon {...iconProps} />
+          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
         )}
         <span className={styles.menuItemWrapper}>
           <span className={styles.itemText}>
@@ -114,7 +123,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
           {subText && <span className={itemSubTextClasses}>{subText}</span>}
         </span>
         {iconProps && alignIcon === MenuItemIconAlign.Right && (
-          <Icon {...iconProps} />
+          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
         )}
       </button>
     </li>

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { MenuItemButtonProps } from '../MenuItem.types';
+import { MenuItemButtonProps, MenuItemIconAlign } from '../MenuItem.types';
 import { MenuSize, MenuVariant } from '../../Menu.types';
 import { mergeClasses } from '../../../../shared/utilities';
 import { Icon } from '../../../Icon';
@@ -8,19 +8,22 @@ import { ButtonShape, ButtonSize, NeutralButton } from '../../../Button';
 import styles from '../menuItem.module.scss';
 
 export const MenuItemButton: FC<MenuItemButtonProps> = ({
-  iconProps,
-  text,
-  subText,
-  variant = MenuVariant.neutral,
-  size = MenuSize.medium,
-  classNames,
-  onClick,
-  tabIndex = 0,
-  value,
   active,
+  alignIcon,
+  classNames,
   counter,
-  type,
+  disabled,
+  iconProps,
+  onClick,
+  role = 'menuitem',
   secondaryButtonProps,
+  size = MenuSize.medium,
+  subText,
+  tabIndex = 0,
+  text,
+  type,
+  value,
+  variant = MenuVariant.neutral,
   ...rest
 }) => {
   const menuItemClasses: string = mergeClasses([
@@ -33,6 +36,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
       [styles.primary]: variant === MenuVariant.primary,
       [styles.disruptive]: variant === MenuVariant.disruptive,
       [styles.active]: active,
+      [styles.disabled]: disabled,
     },
     classNames,
   ]);
@@ -46,25 +50,42 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
     },
   ]);
 
+  const handleOnClick = (
+    event: React.MouseEvent<HTMLButtonElement | MouseEvent>
+  ): void => {
+    if (disabled) {
+      event.preventDefault();
+      return;
+    }
+    onClick?.(value);
+  };
+
   return secondaryButtonProps ? (
-    <li role="menuitem" tabIndex={tabIndex} className={menuItemClasses}>
+    <li role={role} tabIndex={tabIndex} className={menuItemClasses}>
       <span className={styles.menuSecondaryWrapper}>
         <button
           className={styles.menuInnerButton}
+          disabled={disabled}
           {...rest}
-          onClick={() => onClick?.(value)}
+          onClick={handleOnClick}
         >
-          {iconProps && <Icon {...iconProps} />}
+          {iconProps && alignIcon === MenuItemIconAlign.Left && (
+            <Icon {...iconProps} />
+          )}
           <span className={styles.menuItemWrapper}>
             <span className={styles.itemText}>
               <span className={styles.label}>{text}</span>
             </span>
           </span>
+          {iconProps && alignIcon === MenuItemIconAlign.Right && (
+            <Icon {...iconProps} />
+          )}
         </button>
         <span className={styles.menuInnerButton}>
           {counter && <span>{counter}</span>}
           {secondaryButtonProps && (
             <NeutralButton
+              disabled={disabled}
               size={ButtonSize.Small}
               shape={ButtonShape.Round}
               {...secondaryButtonProps}
@@ -75,21 +96,27 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
       {subText && <span className={itemSubTextClasses}>{subText}</span>}
     </li>
   ) : (
-    <button
-      onClick={() => onClick?.(value)}
-      tabIndex={tabIndex}
-      role="menuitem"
-      className={menuItemClasses}
-      {...rest}
-    >
-      {iconProps && <Icon {...iconProps} />}
-      <span className={styles.menuItemWrapper}>
-        <span className={styles.itemText}>
-          <span className={styles.label}>{text}</span>
-          {counter && <span>{counter}</span>}
+    <li role={role} tabIndex={tabIndex} className={menuItemClasses}>
+      <button
+        className={styles.menuItemButton}
+        disabled={disabled}
+        {...rest}
+        onClick={handleOnClick}
+      >
+        {iconProps && alignIcon === MenuItemIconAlign.Left && (
+          <Icon {...iconProps} />
+        )}
+        <span className={styles.menuItemWrapper}>
+          <span className={styles.itemText}>
+            <span className={styles.label}>{text}</span>
+            {counter && <span>{counter}</span>}
+          </span>
+          {subText && <span className={itemSubTextClasses}>{subText}</span>}
         </span>
-        {subText && <span className={itemSubTextClasses}>{subText}</span>}
-      </span>
-    </button>
+        {iconProps && alignIcon === MenuItemIconAlign.Right && (
+          <Icon {...iconProps} />
+        )}
+      </button>
+    </li>
   );
 };

--- a/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
+++ b/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
@@ -11,7 +11,7 @@ export const MenuItemCustom: FC<MenuItemCustomProps> = ({
   size = MenuSize.medium,
   ...item
 }) => {
-  const menuItemClasses = mergeClasses([
+  const menuItemClassNames: string = mergeClasses([
     styles.menuItemCustom,
     {
       [styles.large]: size === MenuSize.large,
@@ -21,7 +21,7 @@ export const MenuItemCustom: FC<MenuItemCustomProps> = ({
   ]);
 
   return (
-    <div className={menuItemClasses}>
+    <div className={menuItemClassNames}>
       {item.render({ index, value: item, onChange })}
     </div>
   );

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -13,6 +13,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
   classNames,
   counter,
   direction,
+  disabled,
   iconProps,
   size = MenuSize.medium,
   subText,
@@ -21,7 +22,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
   wrap = false,
   ...rest
 }) => {
-  const menuItemClasses: string = mergeClasses([
+  const menuItemClassNames: string = mergeClasses([
     styles.menuItem,
     {
       [styles.menuItemRtl]: direction === 'rtl',
@@ -33,11 +34,12 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
       [styles.primary]: variant === MenuVariant.primary,
       [styles.disruptive]: variant === MenuVariant.disruptive,
       [styles.active]: active,
+      [styles.disabled]: disabled,
     },
     classNames,
   ]);
 
-  const itemSubTextClasses: string = mergeClasses([
+  const itemSubTextClassNames: string = mergeClasses([
     styles.itemSubText,
     {
       [styles.small]: size === MenuSize.small,
@@ -55,22 +57,28 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
     [MenuSize.small, IconSize.Small],
   ]);
 
+  const getIcon = (): JSX.Element => (
+    <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
+  );
+
   return (
-    <li role="menuitem" tabIndex={-1} className={menuItemClasses}>
-      <Link classNames={styles.menuLink} fullWidth tabIndex={0} {...rest}>
-        {iconProps && alignIcon !== MenuItemIconAlign.Right && (
-          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-        )}
+    <li role="menuitem" tabIndex={-1} className={menuItemClassNames}>
+      <Link
+        classNames={styles.menuLink}
+        disabled={disabled}
+        fullWidth
+        tabIndex={0}
+        {...rest}
+      >
+        {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
         <span className={styles.menuItemWrapper}>
           <span className={styles.itemText}>
             <span className={styles.label}>{text}</span>
             {counter && <span>{counter}</span>}
           </span>
-          {subText && <span className={itemSubTextClasses}>{subText}</span>}
+          {subText && <span className={itemSubTextClassNames}>{subText}</span>}
         </span>
-        {iconProps && alignIcon === MenuItemIconAlign.Right && (
-          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-        )}
+        {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
       </Link>
     </li>
   );

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -1,14 +1,15 @@
 import React, { FC } from 'react';
-import { MenuItemLinkProps } from '../MenuItem.types';
+import { MenuItemIconAlign, MenuItemLinkProps } from '../MenuItem.types';
 import { Link } from '../../../Link';
 import { mergeClasses } from '../../../../shared/utilities';
 import { MenuSize, MenuVariant } from '../../Menu.types';
-import { Icon } from '../../../Icon';
+import { Icon, IconSize } from '../../../Icon';
 
 import styles from '../menuItem.module.scss';
 
 export const MenuItemLink: FC<MenuItemLinkProps> = ({
   active,
+  alignIcon = MenuItemIconAlign.Left,
   classNames,
   counter,
   direction,
@@ -45,10 +46,21 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
     },
   ]);
 
+  const menuSizeToIconSizeMap: Map<MenuSize, IconSize> = new Map<
+    MenuSize,
+    IconSize
+  >([
+    [MenuSize.large, IconSize.Large],
+    [MenuSize.medium, IconSize.Medium],
+    [MenuSize.small, IconSize.Small],
+  ]);
+
   return (
     <li role="menuitem" tabIndex={-1} className={menuItemClasses}>
       <Link classNames={styles.menuLink} fullWidth tabIndex={0} {...rest}>
-        {iconProps && <Icon {...iconProps} />}
+        {iconProps && alignIcon !== MenuItemIconAlign.Right && (
+          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
+        )}
         <span className={styles.menuItemWrapper}>
           <span className={styles.itemText}>
             <span className={styles.label}>{text}</span>
@@ -56,6 +68,9 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
           </span>
           {subText && <span className={itemSubTextClasses}>{subText}</span>}
         </span>
+        {iconProps && alignIcon === MenuItemIconAlign.Right && (
+          <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
+        )}
       </Link>
     </li>
   );

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -8,20 +8,23 @@ import { Icon } from '../../../Icon';
 import styles from '../menuItem.module.scss';
 
 export const MenuItemLink: FC<MenuItemLinkProps> = ({
-  variant = MenuVariant.neutral,
-  size = MenuSize.medium,
   active,
   classNames,
-  text,
-  subText,
-  iconProps,
   counter,
+  direction,
+  iconProps,
+  size = MenuSize.medium,
+  subText,
+  text,
+  variant = MenuVariant.neutral,
+  wrap = false,
   ...rest
 }) => {
   const menuItemClasses: string = mergeClasses([
     styles.menuItem,
-    styles.menuLink,
     {
+      [styles.menuItemRtl]: direction === 'rtl',
+      [styles.wrap]: !!wrap,
       [styles.small]: size === MenuSize.small,
       [styles.medium]: size === MenuSize.medium,
       [styles.large]: size === MenuSize.large,
@@ -43,15 +46,17 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
   ]);
 
   return (
-    <Link classNames={menuItemClasses} {...rest} role="menuitem">
-      {iconProps && <Icon {...iconProps} />}
-      <span className={styles.menuItemWrapper}>
-        <span className={styles.itemText}>
-          <span className={styles.label}>{text}</span>
-          {counter && <span>{counter}</span>}
+    <li role="menuitem" tabIndex={-1} className={menuItemClasses}>
+      <Link classNames={styles.menuLink} fullWidth tabIndex={0} {...rest}>
+        {iconProps && <Icon {...iconProps} />}
+        <span className={styles.menuItemWrapper}>
+          <span className={styles.itemText}>
+            <span className={styles.label}>{text}</span>
+            {counter && <span>{counter}</span>}
+          </span>
+          {subText && <span className={itemSubTextClasses}>{subText}</span>}
         </span>
-        {subText && <span className={itemSubTextClasses}>{subText}</span>}
-      </span>
-    </Link>
+      </Link>
+    </li>
   );
 };

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -15,8 +15,10 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
   direction,
   disabled,
   iconProps,
+  role = 'menuitem',
   size = MenuSize.medium,
   subText,
+  tabIndex = 0,
   text,
   variant = MenuVariant.neutral,
   wrap = false,
@@ -62,12 +64,12 @@ export const MenuItemLink: FC<MenuItemLinkProps> = ({
   );
 
   return (
-    <li role="menuitem" tabIndex={-1} className={menuItemClassNames}>
+    <li role={role} tabIndex={-1} className={menuItemClassNames}>
       <Link
         classNames={styles.menuLink}
         disabled={disabled}
         fullWidth
-        tabIndex={0}
+        tabIndex={tabIndex}
         {...rest}
       >
         {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}

--- a/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
+++ b/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
@@ -6,12 +6,16 @@ import { MenuSize } from '../../Menu.types';
 import styles from '../menuItem.module.scss';
 
 export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = ({
-  text,
+  direction,
   size,
+  text,
+  wrap,
 }) => {
   const subHeaderClasses: string = mergeClasses([
     styles.menuItemSubHeader,
     {
+      [styles.menuItemRtl]: direction === 'rtl',
+      [styles.wrap]: !!wrap,
       [styles.large]: size === MenuSize.large,
       [styles.medium]: size === MenuSize.medium,
       [styles.small]: size === MenuSize.small,

--- a/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
+++ b/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
@@ -11,7 +11,7 @@ export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = ({
   text,
   wrap,
 }) => {
-  const subHeaderClasses: string = mergeClasses([
+  const subHeaderClassNames: string = mergeClasses([
     styles.menuItemSubHeader,
     {
       [styles.menuItemRtl]: direction === 'rtl',
@@ -21,5 +21,5 @@ export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = ({
       [styles.small]: size === MenuSize.small,
     },
   ]);
-  return <span className={subHeaderClasses}>{text}</span>;
+  return <span className={subHeaderClassNames}>{text}</span>;
 };

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -12,6 +12,10 @@
   margin: $space-xxs 0;
   white-space: nowrap;
 
+  &.wrap {
+    white-space: normal;
+  }
+
   $text-font-size-map: (
     small: $text-font-size-1,
     medium: $text-font-size-2,
@@ -21,6 +25,13 @@
   .menu-item-button {
     display: flex;
     flex: 1;
+    gap: $space-xs;
+
+    // Hides the browser default keyboard focus-visible styles.
+    // Use the ConfigProvider instead.
+    &:focus-visible {
+      outline: none;
+    }
   }
 
   .menu-item-wrapper {
@@ -38,6 +49,17 @@
       align-items: center;
       display: flex;
       gap: $space-xs;
+    }
+
+    .menu-outer-button {
+      align-items: center;
+      display: flex;
+      flex: inherit;
+      gap: $space-xs;
+
+      &:focus-visible {
+        outline: none;
+      }
     }
   }
 
@@ -61,24 +83,39 @@
     min-height: 44px;
     font-size: $text-font-size-4;
     line-height: $text-line-height-3;
-    padding: $button-padding-vertical-medium $button-padding-horizontal-medium;
     margin: 0 $space-xs $space-xs;
+
+    .menu-item-button,
+    .menu-secondary-wrapper,
+    .menu-link {
+      padding: $button-padding-vertical-medium $button-padding-horizontal-medium;
+    }
   }
 
   &.medium {
     min-height: 36px;
     font-size: $text-font-size-3;
     line-height: $text-line-height-2;
-    padding: $button-padding-vertical-medium $button-padding-horizontal-medium;
     margin: 0 $space-xxs $space-xs;
+
+    .menu-item-button,
+    .menu-secondary-wrapper,
+    .menu-link {
+      padding: $button-padding-vertical-medium $button-padding-horizontal-medium;
+    }
   }
 
   &.small {
     min-height: 28px;
     font-size: $text-font-size-2;
     line-height: $text-line-height-1;
-    padding: $space-xxs $space-xs;
     margin: 0 $space-xxs $space-xxs;
+
+    .menu-item-button,
+    .menu-secondary-wrapper,
+    .menu-link {
+      padding: $space-xxs $space-xs;
+    }
   }
 
   &.primary {
@@ -133,15 +170,26 @@
     pointer-events: none;
   }
 
-  &.menu-link {
-    font-weight: $text-font-weight-regular;
+  .menu-link {
+    align-items: inherit;
+    color: inherit;
+    display: inherit;
+    flex: 1;
+    font-size: inherit;
+    font-weight: inherit;
+    gap: $space-xs;
     text-decoration: none;
+    white-space: inherit;
+
+    &:focus-visible {
+      box-shadow: none;
+    }
   }
 
   .label {
     flex: 1;
     display: flex;
-    align-content: flex-start;
+    text-align: left;
   }
 
   .action-wrapper {
@@ -158,10 +206,14 @@
     margin-bottom: $space-xs;
   }
 
-  // Hides the browser default keyboard focus-visible styles.
-  // Use the ConfigProvider instead.
   &:focus-visible {
     outline: none;
+  }
+
+  &-rtl {
+    .label {
+      text-align: right;
+    }
   }
 }
 
@@ -188,7 +240,7 @@
   }
 
   &.small {
-    padding: $space-s $space-xxxs $space-s;
+    padding: $space-s 0 $space-s;
     @include octuple-content-small();
   }
 }
@@ -211,27 +263,17 @@
 
 :global(.focus-visible) {
   .menu-item {
-    &:focus-visible {
-      outline-offset: -1px;
-      outline-width: $space-xxxs;
-      outline-style: solid;
-    }
-
-    &.primary {
-      &:focus-visible {
-        outline-color: var(--blueviolet-color-50);
-      }
+    &:focus-visible,
+    &:focus-within {
+      box-shadow: var(--focus-visible-box-shadow);
     }
 
     &.disruptive {
-      &:focus-visible {
-        outline-color: var(--blueviolet-color-50);
-      }
-    }
-
-    &.neutral {
-      &:focus-visible {
-        outline-color: var(--blueviolet-color-50);
+      &:focus-visible,
+      &:focus-within {
+        background-color: var(--disruptive-color-10);
+        box-shadow: 0 0 0 var(--focus-visible-shadow-width)
+          var(--disruptive-color-80);
       }
     }
   }

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -180,10 +180,6 @@
     gap: $space-xs;
     text-decoration: none;
     white-space: inherit;
-
-    &:focus-visible {
-      box-shadow: none;
-    }
   }
 
   .label {
@@ -278,6 +274,12 @@
         background-color: var(--disruptive-color-10);
         box-shadow: 0 0 0 var(--focus-visible-shadow-width)
           var(--disruptive-color-80);
+      }
+    }
+
+    .menu-link {
+      &:focus-visible {
+        box-shadow: none;
       }
     }
   }

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -233,7 +233,6 @@
 
   &.medium {
     margin: 0 $space-m $space-m;
-    margin: 0 $space-m $space-m;
     padding: $space-s $space-xxxs $space-s;
     @include octuple-content-medium();
   }

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -230,16 +230,20 @@
   }
 
   &.large {
+    margin: 0 $space-m $space-m;
     padding: $space-s $space-xxs $space-s;
     @include octuple-content-large();
   }
 
   &.medium {
+    margin: 0 $space-m $space-m;
+    margin: 0 $space-m $space-m;
     padding: $space-s $space-xxxs $space-s;
     @include octuple-content-medium();
   }
 
   &.small {
+    margin: 0 $space-s $space-m;
     padding: $space-s 0 $space-s;
     @include octuple-content-small();
   }

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -18,6 +18,11 @@
     large: $text-font-size-3,
   );
 
+  .menu-item-button {
+    display: flex;
+    flex: 1;
+  }
+
   .menu-item-wrapper {
     display: flex;
     flex-direction: column;
@@ -116,10 +121,16 @@
     }
   }
 
-  &[disabled] {
-    pointer-events: none;
-    opacity: $disabled-alpha-value;
+  &.disabled {
     cursor: not-allowed;
+    opacity: $disabled-alpha-value;
+    pointer-events: none;
+  }
+
+  &[disabled],
+  > [disabled] {
+    cursor: not-allowed;
+    pointer-events: none;
   }
 
   &.menu-link {

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Menu Menu is large 1`] = `
           role="menu"
         >
           <li
-            class="menu-item large neutral"
+            class="menu-item large neutral my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -78,7 +78,7 @@ exports[`Menu Menu is large 1`] = `
             </button>
           </li>
           <li
-            class="menu-item large neutral disabled"
+            class="menu-item large neutral disabled my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -108,7 +108,7 @@ exports[`Menu Menu is large 1`] = `
             Sub header
           </span>
           <li
-            class="menu-item large neutral"
+            class="menu-item large neutral my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -266,7 +266,7 @@ exports[`Menu Menu is medium 1`] = `
           role="menu"
         >
           <li
-            class="menu-item medium neutral"
+            class="menu-item medium neutral my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -309,7 +309,7 @@ exports[`Menu Menu is medium 1`] = `
             </button>
           </li>
           <li
-            class="menu-item medium neutral disabled"
+            class="menu-item medium neutral disabled my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -339,7 +339,7 @@ exports[`Menu Menu is medium 1`] = `
             Sub header
           </span>
           <li
-            class="menu-item medium neutral"
+            class="menu-item medium neutral my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -497,7 +497,7 @@ exports[`Menu Menu is small 1`] = `
           role="menu"
         >
           <li
-            class="menu-item small neutral"
+            class="menu-item small neutral my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -540,7 +540,7 @@ exports[`Menu Menu is small 1`] = `
             </button>
           </li>
           <li
-            class="menu-item small neutral disabled"
+            class="menu-item small neutral disabled my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >
@@ -570,7 +570,7 @@ exports[`Menu Menu is small 1`] = `
             Sub header
           </span>
           <li
-            class="menu-item small neutral"
+            class="menu-item small neutral my-menu-item-class"
             role="menuitem"
             tabindex="-1"
           >

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -1,0 +1,718 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Menu Menu is large 1`] = `
+<div>
+  <div
+    class="main-wrapper"
+  >
+    <button
+      aria-controls="dropdown-"
+      aria-disabled="false"
+      aria-expanded="true"
+      aria-haspopup="true"
+      class="button button-default button-medium pill-shape"
+      role="button"
+      tabindex="0"
+    >
+      <span
+        class="button-text-medium"
+      >
+        Menu dropdown
+      </span>
+    </button>
+    <div
+      class="dropdown-wrapper no-padding open"
+      id="dropdown-"
+      style="position: absolute; top: 4px; left: 0px;"
+      tabindex="0"
+    >
+      <div
+        class="my-menu-class menu-container large"
+        style="color: red;"
+      >
+        <ul
+          class="list-container vertical"
+          role="menu"
+        >
+          <li
+            class="menu-item large neutral"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <button
+              class="menu-item-button"
+              tabindex="0"
+            >
+              <span
+                aria-hidden="false"
+                class="icon-wrapper"
+                role="presentation"
+              >
+                <svg
+                  role="presentation"
+                  style="width: 24px; height: 24px;"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z"
+                    style="fill: currentColor;"
+                  />
+                </svg>
+              </span>
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Date
+                  </span>
+                  <span>
+                    8
+                  </span>
+                </span>
+              </span>
+            </button>
+          </li>
+          <li
+            class="menu-item large neutral disabled"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <button
+              class="menu-item-button"
+              disabled=""
+              tabindex="0"
+            >
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Disabled button
+                  </span>
+                </span>
+              </span>
+            </button>
+          </li>
+          <span
+            class="menu-item-sub-header large"
+          >
+            Sub header
+          </span>
+          <li
+            class="menu-item large neutral"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <a
+              aria-disabled="false"
+              class="link-style full-width menu-link"
+              href="https://twitter.com"
+              role="link"
+              tabindex="0"
+              target="_blank"
+            >
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Twitter link
+                  </span>
+                </span>
+              </span>
+            </a>
+          </li>
+          <div
+            class="menu-item-custom large"
+          >
+            <div
+              aria-label="Radio Group"
+              class="radio-group vertical radio-group-large"
+              role="group"
+            >
+              <div
+                class="selector selector-large"
+              >
+                <input
+                  aria-disabled="false"
+                  checked=""
+                  id="oea2exk-1"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio1"
+                />
+                <label
+                  class=""
+                  for="oea2exk-1"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-1-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio1
+                  </span>
+                </label>
+              </div>
+              <div
+                class="selector selector-large"
+              >
+                <input
+                  aria-disabled="false"
+                  id="oea2exk-2"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio2"
+                />
+                <label
+                  class=""
+                  for="oea2exk-2"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-2-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio2
+                  </span>
+                </label>
+              </div>
+              <div
+                class="selector selector-large"
+              >
+                <input
+                  aria-disabled="false"
+                  id="oea2exk-3"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio3"
+                />
+                <label
+                  class=""
+                  for="oea2exk-3"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-3-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio3
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Menu Menu is medium 1`] = `
+<div>
+  <div
+    class="main-wrapper"
+  >
+    <button
+      aria-controls="dropdown-"
+      aria-disabled="false"
+      aria-expanded="true"
+      aria-haspopup="true"
+      class="button button-default button-medium pill-shape"
+      role="button"
+      tabindex="0"
+    >
+      <span
+        class="button-text-medium"
+      >
+        Menu dropdown
+      </span>
+    </button>
+    <div
+      class="dropdown-wrapper no-padding open"
+      id="dropdown-"
+      style="position: absolute; top: 4px; left: 0px;"
+      tabindex="0"
+    >
+      <div
+        class="my-menu-class menu-container medium"
+        style="color: red;"
+      >
+        <ul
+          class="list-container vertical"
+          role="menu"
+        >
+          <li
+            class="menu-item medium neutral"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <button
+              class="menu-item-button"
+              tabindex="0"
+            >
+              <span
+                aria-hidden="false"
+                class="icon-wrapper"
+                role="presentation"
+              >
+                <svg
+                  role="presentation"
+                  style="width: 20px; height: 20px;"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z"
+                    style="fill: currentColor;"
+                  />
+                </svg>
+              </span>
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Date
+                  </span>
+                  <span>
+                    8
+                  </span>
+                </span>
+              </span>
+            </button>
+          </li>
+          <li
+            class="menu-item medium neutral disabled"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <button
+              class="menu-item-button"
+              disabled=""
+              tabindex="0"
+            >
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Disabled button
+                  </span>
+                </span>
+              </span>
+            </button>
+          </li>
+          <span
+            class="menu-item-sub-header medium"
+          >
+            Sub header
+          </span>
+          <li
+            class="menu-item medium neutral"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <a
+              aria-disabled="false"
+              class="link-style full-width menu-link"
+              href="https://twitter.com"
+              role="link"
+              tabindex="0"
+              target="_blank"
+            >
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Twitter link
+                  </span>
+                </span>
+              </span>
+            </a>
+          </li>
+          <div
+            class="menu-item-custom medium"
+          >
+            <div
+              aria-label="Radio Group"
+              class="radio-group vertical radio-group-medium"
+              role="group"
+            >
+              <div
+                class="selector selector-medium"
+              >
+                <input
+                  aria-disabled="false"
+                  checked=""
+                  id="oea2exk-1"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio1"
+                />
+                <label
+                  class=""
+                  for="oea2exk-1"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-1-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio1
+                  </span>
+                </label>
+              </div>
+              <div
+                class="selector selector-medium"
+              >
+                <input
+                  aria-disabled="false"
+                  id="oea2exk-2"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio2"
+                />
+                <label
+                  class=""
+                  for="oea2exk-2"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-2-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio2
+                  </span>
+                </label>
+              </div>
+              <div
+                class="selector selector-medium"
+              >
+                <input
+                  aria-disabled="false"
+                  id="oea2exk-3"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio3"
+                />
+                <label
+                  class=""
+                  for="oea2exk-3"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-3-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio3
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Menu Menu is small 1`] = `
+<div>
+  <div
+    class="main-wrapper"
+  >
+    <button
+      aria-controls="dropdown-"
+      aria-disabled="false"
+      aria-expanded="true"
+      aria-haspopup="true"
+      class="button button-default button-medium pill-shape"
+      role="button"
+      tabindex="0"
+    >
+      <span
+        class="button-text-medium"
+      >
+        Menu dropdown
+      </span>
+    </button>
+    <div
+      class="dropdown-wrapper no-padding open"
+      id="dropdown-"
+      style="position: absolute; top: 4px; left: 0px;"
+      tabindex="0"
+    >
+      <div
+        class="my-menu-class menu-container small"
+        style="color: red;"
+      >
+        <ul
+          class="list-container vertical"
+          role="menu"
+        >
+          <li
+            class="menu-item small neutral"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <button
+              class="menu-item-button"
+              tabindex="0"
+            >
+              <span
+                aria-hidden="false"
+                class="icon-wrapper"
+                role="presentation"
+              >
+                <svg
+                  role="presentation"
+                  style="width: 16px; height: 16px;"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z"
+                    style="fill: currentColor;"
+                  />
+                </svg>
+              </span>
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Date
+                  </span>
+                  <span>
+                    8
+                  </span>
+                </span>
+              </span>
+            </button>
+          </li>
+          <li
+            class="menu-item small neutral disabled"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <button
+              class="menu-item-button"
+              disabled=""
+              tabindex="0"
+            >
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Disabled button
+                  </span>
+                </span>
+              </span>
+            </button>
+          </li>
+          <span
+            class="menu-item-sub-header small"
+          >
+            Sub header
+          </span>
+          <li
+            class="menu-item small neutral"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <a
+              aria-disabled="false"
+              class="link-style full-width menu-link"
+              href="https://twitter.com"
+              role="link"
+              tabindex="0"
+              target="_blank"
+            >
+              <span
+                class="menu-item-wrapper"
+              >
+                <span
+                  class="item-text"
+                >
+                  <span
+                    class="label"
+                  >
+                    Twitter link
+                  </span>
+                </span>
+              </span>
+            </a>
+          </li>
+          <div
+            class="menu-item-custom small"
+          >
+            <div
+              aria-label="Radio Group"
+              class="radio-group vertical radio-group-small"
+              role="group"
+            >
+              <div
+                class="selector selector-small"
+              >
+                <input
+                  aria-disabled="false"
+                  checked=""
+                  id="oea2exk-1"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio1"
+                />
+                <label
+                  class=""
+                  for="oea2exk-1"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-1-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio1
+                  </span>
+                </label>
+              </div>
+              <div
+                class="selector selector-small"
+              >
+                <input
+                  aria-disabled="false"
+                  id="oea2exk-2"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio2"
+                />
+                <label
+                  class=""
+                  for="oea2exk-2"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-2-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio2
+                  </span>
+                </label>
+              </div>
+              <div
+                class="selector selector-small"
+              >
+                <input
+                  aria-disabled="false"
+                  id="oea2exk-3"
+                  name="group"
+                  readonly=""
+                  type="radio"
+                  value="Radio3"
+                />
+                <label
+                  class=""
+                  for="oea2exk-3"
+                >
+                  <span
+                    class="radio-button"
+                    id="oea2exk-3-custom-radio"
+                  />
+                  <span
+                    class="selector-label selector-label-end"
+                  >
+                    Radio3
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Menu Should render a menu button 1`] = `
+<div>
+  <div
+    class="main-wrapper"
+  >
+    <button
+      aria-controls="dropdown-"
+      aria-disabled="false"
+      aria-expanded="false"
+      aria-haspopup="true"
+      class="button button-default button-medium pill-shape"
+      role="button"
+      tabindex="0"
+    >
+      <span
+        class="button-text-medium"
+      >
+        Menu dropdown
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -23,8 +23,9 @@ const defaultOptions: SelectOption[] = [
   },
   {
     iconProps: { path: IconName.mdiFlagVariant },
-    text: 'Supercalifragilisticexpialidocious',
+    text: 'Supercalifragilisticexpialidocious and another Supercalifragilisticexpialidocious',
     value: 'verylarge',
+    wrap: true,
   },
   {
     iconProps: { path: IconName.mdiAccount },

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -79,7 +79,13 @@ import { Link } from './components/Link';
 
 import { List } from './components/List';
 
-import { Menu, MenuItemType, MenuVariant, MenuSize } from './components/Menu';
+import {
+  Menu,
+  MenuItemIconAlign,
+  MenuItemType,
+  MenuVariant,
+  MenuSize,
+} from './components/Menu';
 
 import { Modal, ModalSize } from './components/Modal';
 
@@ -264,6 +270,7 @@ export {
   LoaderSize,
   MatchScore,
   Menu,
+  MenuItemIconAlign,
   MenuItemType,
   MenuVariant,
   MenuSize,


### PR DESCRIPTION
## SUMMARY:
This is a part of ENG-45561

- Adds `alignIcon` prop in preparation for recursive dropdown menu support
- maps `IconSize` to `MenuSize`, omits size from `IconProps` via `MenuIconProps`
- Adds getIcon method to `MenuItemButton` and `MenuItemLink`
- Ensure `disabled` from props is read by `MenuItemLink`
- Adds `wrap` prop to `MenuItem` and RTL styles to enable menu item text wrapping
- Ensures `menuitem` `<li>` content is focusable and take the full width and height possible for greater click target
- Maps `MenuSize` and `IconSize` before the `iconProps` spread to ensure default size is the same as `Menu`
- Fixes `<li>` rendering bug
- Alphabetizes props
- Reduces the size of the `Dropdown` border radius by `4px` to better match systems design Figma
- Fixes `Dropdown` drift into position bug caused by unnecessary transition property on `.dropdown-wrapper`
- Add Jira identifier to TODO in `dropdown.module.scss`
- Adds `Menu` and `Dropdown` unit tests

Right aligned icon to enable sub menu visual cue:
![alignIcon](https://user-images.githubusercontent.com/99700808/224463338-4dd15f2b-91bf-4b68-929b-61f33777b862.png)

Preserved and improved UI:
https://user-images.githubusercontent.com/99700808/225406107-bdedeca1-6096-4af6-84e4-3f6b60718bc1.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-45561

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:
- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Dropdown`, `Menu` and `Select` stories behave as expected.