### PR TITLE
fix: select: options change not reacting properly when value is an object

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -84,7 +84,19 @@ describe('Select', () => {
     await sleep(ANIMATION_DURATION);
     const option = getByText('Option 1');
     fireEvent.click(option);
-    expect(handleChange).toHaveBeenCalledWith(['option1']);
+    expect(handleChange).toHaveBeenCalledWith(
+      ['option1'],
+      [
+        {
+          hideOption: false,
+          id: 'Option 1-0',
+          object: undefined,
+          selected: true,
+          text: 'Option 1',
+          value: 'option1',
+        },
+      ]
+    );
   });
 
   test('Selects multiple options', async () => {
@@ -99,7 +111,27 @@ describe('Select', () => {
     fireEvent.click(option1);
     const option2 = getByText('Option 2');
     fireEvent.click(option2);
-    expect(handleChange).toHaveBeenCalledWith(['option1', 'option2']);
+    expect(handleChange).toHaveBeenCalledWith(
+      ['option1', 'option2'],
+      [
+        {
+          hideOption: false,
+          id: 'Option 1-0',
+          object: undefined,
+          selected: true,
+          text: 'Option 1',
+          value: 'option1',
+        },
+        {
+          hideOption: false,
+          id: 'Option 2-1',
+          object: undefined,
+          selected: true,
+          text: 'Option 2',
+          value: 'option2',
+        },
+      ]
+    );
   });
 
   test('Renders with default value', () => {
@@ -128,7 +160,33 @@ describe('Select', () => {
     await sleep(ANIMATION_DURATION);
     const option1 = getByText('Option 1');
     fireEvent.click(option1);
-    expect(handleChange).toHaveBeenCalledWith(['option1']);
+    expect(handleChange).toHaveBeenCalledWith([], []);
+    expect(handleChange).toHaveBeenCalledWith(
+      ['option2'],
+      [
+        {
+          hideOption: false,
+          id: 'Option 2-1',
+          object: undefined,
+          selected: true,
+          text: 'Option 2',
+          value: 'option2',
+        },
+      ]
+    );
+    expect(handleChange).toHaveBeenCalledWith(
+      ['option1'],
+      [
+        {
+          hideOption: false,
+          id: 'Option 1-0',
+          object: undefined,
+          selected: true,
+          text: 'Option 1',
+          value: 'option1',
+        },
+      ]
+    );
   });
 
   test('Renders with default values when multiple', () => {
@@ -160,11 +218,35 @@ describe('Select', () => {
     await sleep(ANIMATION_DURATION);
     const option1 = getByText('Option 1');
     fireEvent.click(option1);
-    expect(handleChange).toHaveBeenCalledWith([
-      'option1',
-      'option2',
-      'option3',
-    ]);
+    expect(handleChange).toHaveBeenCalledWith(
+      ['option1', 'option2', 'option3'],
+      [
+        {
+          hideOption: false,
+          id: 'Option 1-0',
+          object: undefined,
+          selected: true,
+          text: 'Option 1',
+          value: 'option1',
+        },
+        {
+          hideOption: false,
+          id: 'Option 2-1',
+          object: undefined,
+          selected: true,
+          text: 'Option 2',
+          value: 'option2',
+        },
+        {
+          hideOption: false,
+          id: 'Option 3-2',
+          object: undefined,
+          selected: true,
+          text: 'Option 3',
+          value: 'option3',
+        },
+      ]
+    );
   });
 
   test('Renders with clear button', () => {
@@ -192,7 +274,21 @@ describe('Select', () => {
     await sleep(ANIMATION_DURATION);
     const clearButton = container.querySelector('.clear-icon-button');
     fireEvent.click(clearButton);
-    expect(handleChange).toHaveBeenCalledWith([]);
+    expect(handleChange).toHaveBeenCalledWith([], []);
+    expect(handleChange).toHaveBeenCalledWith(
+      ['option2'],
+      [
+        {
+          hideOption: false,
+          id: 'Option 2-1',
+          object: undefined,
+          selected: true,
+          text: 'Option 2',
+          value: 'option2',
+        },
+      ]
+    );
+    expect(handleChange).toHaveBeenCalledWith([], []);
   });
 
   test('Select clearable input value is cleared and clear button is no longer visible', async () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -105,6 +105,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         selected: false,
         hideOption: false,
         id: option.text + '-' + index,
+        object: option.object,
         ...option,
       }))
     );
@@ -128,10 +129,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
       ? size
       : contextuallySized || size;
 
-    const getSelectedOptions = (): SelectOption['value'][] => {
+    const getSelectedOptionValues = (): SelectOption['value'][] => {
       return options
         .filter((option: SelectOption) => option.selected)
         .map((option: SelectOption) => option.value);
+    };
+
+    const getSelectedOptions = (): SelectOption['value'][] => {
+      return options.filter((option: SelectOption) => option.selected);
     };
 
     const { count, filled, width } = useMaxVisibleSections(
@@ -140,7 +145,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       168,
       8,
       1,
-      getSelectedOptions().length
+      getSelectedOptionValues().length
     );
 
     useEffect(() => {
@@ -152,14 +157,15 @@ export const Select: FC<SelectProps> = React.forwardRef(
           selected: !!selected.find((opt) => opt.value === option.value),
           hideOption: false,
           id: option.text + index,
+          object: option.object,
           ...option,
         }))
       );
     }, [_options, isLoading]);
 
     useEffect(() => {
-      onOptionsChange?.(getSelectedOptions());
-    }, [getSelectedOptions().join('')]);
+      onOptionsChange?.(getSelectedOptionValues(), getSelectedOptions());
+    }, [getSelectedOptionValues().join('')]);
 
     useEffect(() => {
       const updatedOptions = options.map((opt) => ({

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -26,9 +26,13 @@ export interface SelectOption extends MenuItemButtonProps {
    */
   hideOption?: boolean;
   /**
-   * The select option id.
+   * The select option element id.
    */
   id?: string;
+  /**
+   * The optional select JSON object.
+   */
+  object?: object;
   /**
    * The select option selected state.
    */
@@ -128,9 +132,10 @@ export interface SelectProps
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
   /**
    * Callback called when options are selected/unselected.
-   * @param options {SelectOption[]}
+   * @param values {SelectOption['value'].value[]}
+   * @param options {SelectOption['value'][]}
    */
-  onOptionsChange?: (options: SelectOption[]) => void;
+  onOptionsChange?: (values: SelectOption[], options?: SelectOption[]) => void;
   /**
    * The select options.
    * @default []


### PR DESCRIPTION
## SUMMARY:

- Adds `object` prop to `SelectOption`
- Updates `onOptionsChange` callback to return `values` `string` array and its `options` `object` array
- Updates unit tests to account for the newly added `options` argument returned by the `onOptionsChange` callback

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/562

## JIRA TASK (Eightfold Employees Only):
ENG-46082

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Select` stories behave as expected.