### PR TITLE
fix: tooltip: fixes pixel position rounding error

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -260,7 +260,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
                 [TRIGGER_TO_HANDLER_MAP_ON_ENTER[trigger]]: toggle(true),
               },
               onClick: toggle(!mergedVisible),
-              classNames: referenceWrapperClassNames,
+              className: referenceWrapperClassNames,
               'aria-controls': tooltipId?.current,
               'aria-expanded': mergedVisible,
               'aria-haspopup': true,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -216,8 +216,8 @@ export const Tooltip: FC<TooltipProps> = React.memo(
 
       const tooltipStyles: object = {
         position: strategy,
-        top: y ?? '',
-        left: x ?? '',
+        top: Math.floor(y) ?? '',
+        left: Math.floor(x) ?? '',
         width: width ?? '',
         height: height ?? '',
         ...tooltipStyle,


### PR DESCRIPTION
## SUMMARY:

- Fixes rounding error by rounding down to nearest number, previously  the calculated `left`, `top` `style` positions that were floats would be auto-corrected by the browser resulting in a noticeable 1 pixel shift at run time.
- Fixes class prop typo of cloned `Tooltip` element.

## JIRA TASK (Eightfold Employees Only):
ENG-46933

Before fix:

https://user-images.githubusercontent.com/99700808/226689782-8e5132d6-4b11-4e85-9258-70f97f88e322.mp4


After fix:

https://user-images.githubusercontent.com/99700808/226689860-c2929d8c-4874-4802-9bfc-83ec32960fb5.mp4


## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch, run `yarn` and `yarn storybook`. Verify the `Tooltip` behaves as expected in the `Avatar` story suite.