### PR TITLE
fix: usescrolllock: adds getscrollbarwidth and padding by direction to avoid shake

### DIFF
--- a/src/components/Dialog/BaseDialog/BaseDialog.tsx
+++ b/src/components/Dialog/BaseDialog/BaseDialog.tsx
@@ -58,7 +58,7 @@ export const BaseDialog: FC<BaseDialogProps> = React.forwardRef(
     const labelId = uniqueId('dialog-label-');
     const bodyRef = useRef<HTMLDivElement>(null);
 
-    useScrollLock(parent, visible);
+    useScrollLock(parent, visible, htmlDir);
     const { showBottomShadow, showTopShadow, scrollRef } =
       useScrollShadow(bodyRef);
 

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -79,7 +79,7 @@ export const Panel = React.forwardRef<PanelRef, PanelProps>(
     const parentPanel = useContext<PanelRef>(PanelContext);
     const [internalPush, setPush] = useState<boolean>(false);
 
-    useScrollLock(parent, !scrollLock ? false : visible);
+    useScrollLock(parent, !scrollLock ? false : visible, htmlDir);
 
     // ============================ Strings ===========================
     const [panelLocale] = useLocaleReceiver('Panel');

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -7,23 +7,65 @@ import React, { useCallback, useEffect, useRef } from 'react';
  */
 export const useScrollLock = (
   element: HTMLElement,
-  shouldLock: boolean
+  shouldLock: boolean,
+  direction?: string
 ): void => {
   let originalOverflow: React.MutableRefObject<string> = useRef<string>('');
+  let originalPaddingLeft: React.MutableRefObject<string> = useRef<string>('');
+  let originalPaddingRight: React.MutableRefObject<string> = useRef<string>('');
+
+  const getScrollbarWidth = (): number => {
+    const outer: HTMLDivElement = document.createElement('div');
+    outer.style.visibility = 'hidden';
+    outer.style.width = '100px';
+
+    document.body.appendChild(outer);
+
+    const widthNoScroll: number = outer.offsetWidth;
+    outer.style.overflow = 'scroll';
+
+    const inner: HTMLDivElement = document.createElement('div');
+    inner.style.width = '100%';
+    outer.appendChild(inner);
+
+    const widthWithScroll: number = inner.offsetWidth;
+
+    outer.parentNode.removeChild(outer);
+
+    return widthNoScroll - widthWithScroll;
+  };
 
   const lockScroll = useCallback(() => {
     originalOverflow.current = element.style.overflow;
     element.style.overflow = 'hidden';
-  }, []);
+
+    if (direction) {
+      if (direction === 'rtl') {
+        originalPaddingLeft.current = element.style.paddingLeft;
+        element.style.paddingLeft = `${getScrollbarWidth()}px`;
+      } else {
+        originalPaddingRight.current = element.style.paddingRight;
+        element.style.paddingRight = `${getScrollbarWidth()}px`;
+      }
+    }
+  }, [direction]);
 
   const unlockScroll = useCallback(() => {
     element.style.overflow = originalOverflow.current;
-  }, []);
+
+    if (direction) {
+      if (direction === 'rtl') {
+        element.style.paddingLeft = originalPaddingLeft.current;
+      } else {
+        element.style.paddingRight = originalPaddingRight.current;
+      }
+    }
+  }, [direction]);
 
   useEffect(() => {
     if (shouldLock) {
       lockScroll();
     }
     return unlockScroll;
-  }, [element, shouldLock]);
+  }, [element, shouldLock, direction]);
 };


### PR DESCRIPTION
## SUMMARY:
When `useScrollLock` is active, it sets the container element `overflow` to `overflow: hidden`. This causes a pixel shift equal to the width of the container scrollbar if it is present.

This change accounts for the `scrollbar` `width` and adds left/right `padding` depending on canvas direction to the container element when `useScrollLock` is active.

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/480

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Panel` and `Modal` stories behave as expected.