### PR TITLE
fix: slider: pixel push extremity labels to better match thumb label position

### DIFF
--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -40,13 +40,13 @@ const Slider_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         onChange={handleChangeA}
         value={transientSlidingAValue}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingAValue}</div>
       </Stack>
       <Row style={{ marginTop: 100 }}>
@@ -61,7 +61,7 @@ const Slider_Story: ComponentStory<typeof Slider> = (args) => {
           />
         </Col>
       </Row>
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingBValue}</div>
       </Stack>
     </Stack>
@@ -85,13 +85,13 @@ const Range_Slider_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         onChange={handleChangeA}
         value={transientSlidingAValues}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingAValues[0]}</div>
         <div>{transientSlidingAValues[1]}</div>
       </Stack>
@@ -109,7 +109,7 @@ const Range_Slider_Story: ComponentStory<typeof Slider> = (args) => {
           />
         </Col>
       </Row>
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingBValues[0]}</div>
         <div>{transientSlidingBValues[1]}</div>
       </Stack>
@@ -134,13 +134,13 @@ const Inline_Extemity_Labels_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         onChange={handleChangeA}
         value={transientSlidingAValue}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingAValue}</div>
       </Stack>
       <Slider
@@ -151,7 +151,7 @@ const Inline_Extemity_Labels_Story: ComponentStory<typeof Slider> = (args) => {
         style={{ marginTop: 100 }}
         value={transientSlidingBValues}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingBValues[0]}</div>
         <div>{transientSlidingBValues[1]}</div>
       </Stack>
@@ -175,7 +175,7 @@ const Custom_Markers_Included_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         onChange={handleChangeA}
@@ -258,13 +258,13 @@ const Dots_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         onChange={handleChangeA}
         value={transientSlidingAValue}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingAValue}</div>
       </Stack>
     </Stack>
@@ -289,17 +289,17 @@ const Toggle_Thumb_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         hideThumb={thumbHidden}
         onChange={handleChangeA}
         value={transientSlidingAValue}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingAValue}</div>
       </Stack>
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <PrimaryButton
           onClick={toggleThumbVisibility}
           text={thumbHidden ? 'Show thumb' : 'Hide thumb'}
@@ -816,7 +816,7 @@ const With_Benchmark_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         dotStyle={{
@@ -825,7 +825,7 @@ const With_Benchmark_Story: ComponentStory<typeof Slider> = (args) => {
         onChange={handleChange}
         value={transientSlidingValue}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingValue}</div>
       </Stack>
     </Stack>
@@ -842,7 +842,7 @@ const Data_Inactive_Story: ComponentStory<typeof Slider> = (args) => {
   };
 
   return (
-    <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+    <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
       <Slider
         {...args}
         dotStyle={{
@@ -851,7 +851,7 @@ const Data_Inactive_Story: ComponentStory<typeof Slider> = (args) => {
         onChange={handleChangeB}
         value={transientSlidingBValues}
       />
-      <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+      <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
         <div>{transientSlidingBValues[0]}</div>
         <div>{transientSlidingBValues[1]}</div>
       </Stack>
@@ -954,7 +954,7 @@ const Data_Active_Story: ComponentStory<typeof Slider> = (args) => {
         name: 'blue',
       }}
     >
-      <Stack align="stretch" direction="vertical" fullWidth gap="xl">
+      <Stack align="stretch" direction="vertical" fullWidth flexGap="xl">
         <div>
           <Slider {...args} ref={sliderRef} onChange={handleChangeRange} />
           <Slider
@@ -972,11 +972,11 @@ const Data_Active_Story: ComponentStory<typeof Slider> = (args) => {
             value={targetSlidingValue}
           />
         </div>
-        <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+        <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
           <div>{transientSlidingValues[0]}</div>
           <div>{transientSlidingValues[1]}</div>
         </Stack>
-        <Stack direction="horizontal" gap="xl" justify="center" fullWidth>
+        <Stack direction="horizontal" flexGap="xl" justify="center" fullWidth>
           <PrimaryButton
             iconProps={{
               icomoonIconName: 'employee',

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -282,10 +282,10 @@ export const Slider: FC<SliderProps> = React.forwardRef(
       thumbRadius: number
     ): number => {
       const inputWidth = sliderRef.current?.offsetWidth || 0;
-      return (
+      return Math.floor(
         ((val - mergedMin) / (mergedMax - mergedMin)) *
           (inputWidth - thumbDiameter) +
-        thumbRadius
+          thumbRadius
       );
     };
 
@@ -351,27 +351,28 @@ export const Slider: FC<SliderProps> = React.forwardRef(
       }
 
       if (!isRange) {
-        const lowerLabelOffset: number =
-          lowerLabelRef.current?.offsetWidth / 2 -
-          sliderRef.current?.offsetLeft;
+        const lowerLabelOffset: number = Math.floor(
+          lowerLabelRef.current?.offsetWidth / 2 - sliderRef.current?.offsetLeft
+        );
         const showMarkerOffest: number =
           showMarkers === true ? thumbGeometry().showMarkerOffset : 0;
 
         if (htmlDir === 'rtl') {
-          lowerLabelRef.current.style.right = `${
+          lowerLabelRef.current.style.right = `${Math.floor(
             lowerThumbOffset - lowerLabelOffset - showMarkerOffest
-          }px`;
+          )}px`;
           lowerLabelRef.current.style.left = 'unset';
         } else {
-          lowerLabelRef.current.style.left = `${
+          lowerLabelRef.current.style.left = `${Math.floor(
             lowerThumbOffset - lowerLabelOffset - showMarkerOffest
-          }px`;
+          )}px`;
           lowerLabelRef.current.style.right = 'unset';
         }
       } else {
         if (labelPosition === 'inline') {
-          const sliderLabelsOffset: number =
-            sliderLabelsRef.current.offsetWidth / 2;
+          const sliderLabelsOffset: number = Math.floor(
+            sliderLabelsRef.current.offsetWidth / 2
+          );
 
           if (htmlDir === 'rtl') {
             sliderLabelsRef.current.style.marginRight = `-${sliderLabelsOffset}px`;
@@ -439,7 +440,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
           ? `${lowerThumbOffset}px`
           : `${thumbRadius}px`;
       }
-      trackRef.current.style.width = `${rangeWidth}px`;
+      trackRef.current.style.width = `${Math.floor(rangeWidth)}px`;
     };
 
     const [formatValue] = useOffset(mergedMin, mergedMax, mergedStep, markers);

--- a/src/components/Slider/slider.module.scss
+++ b/src/components/Slider/slider.module.scss
@@ -9,6 +9,10 @@ $large-track-height: 6px;
 $large-vertical-center: calc($large-slider-height / 2);
 $large-rail-top: $large-vertical-center - calc($large-track-height / 2);
 $large-marker-top: 0;
+$large-max-label-offset: 18px;
+$large-max-label-offset-with-steps: 22px;
+$large-min-label-offset: 10px;
+$large-min-label-offset-with-steps: 6px;
 
 $medium-slider-height: 22px;
 $medium-slider-inline-margin: $space-xs;
@@ -18,6 +22,10 @@ $medium-track-height: 4px;
 $medium-vertical-center: calc($medium-slider-height / 2);
 $medium-rail-top: $medium-vertical-center - calc($medium-track-height / 2);
 $medium-marker-top: 0;
+$medium-max-label-offset: 13px;
+$medium-max-label-offset-with-steps: 17px;
+$medium-min-label-offset: 8px;
+$medium-min-label-offset-with-steps: 4px;
 
 $small-slider-height: 16px;
 $small-slider-inline-margin: $space-xs;
@@ -26,6 +34,10 @@ $small-track-height: 4px;
 $small-vertical-center: calc($small-slider-height / 2);
 $small-rail-top: $small-vertical-center - calc($small-track-height / 2);
 $small-marker-top: 0;
+$small-max-label-offset: 9px;
+$small-max-label-offset-with-steps: 11px;
+$small-min-label-offset: 5px;
+$small-min-label-offset-with-steps: 3px;
 
 // Export values for typescript consumption.
 :export {
@@ -263,11 +275,13 @@ $small-marker-top: 0;
     opacity: 0;
 
     &.max-label {
-      right: calc($medium-slider-height / 2);
+      right: $medium-max-label-offset;
+      width: $space-xs;
     }
 
     &.min-label {
-      left: calc($medium-slider-height / 2);
+      left: $medium-min-label-offset;
+      width: $space-xs;
     }
 
     &-inline {
@@ -392,6 +406,16 @@ $small-marker-top: 0;
       }
     }
 
+    .extremity-label {
+      &.max-label {
+        right: $medium-max-label-offset-with-steps;
+      }
+
+      &.min-label {
+        left: $medium-min-label-offset-with-steps;
+      }
+    }
+
     .thumb {
       margin-left: -$medium-thumb-offset;
     }
@@ -405,6 +429,16 @@ $small-marker-top: 0;
 
     .slider {
       flex: 1;
+    }
+
+    .extremity-label {
+      &.max-label {
+        width: auto;
+      }
+
+      &.min-label {
+        width: auto;
+      }
     }
 
     .slider-range-labels {
@@ -479,11 +513,11 @@ $small-marker-top: 0;
       font-size: $text-font-size-3;
 
       &.max-label {
-        right: calc($large-slider-height / 2);
+        right: $large-max-label-offset;
       }
 
       &.min-label {
-        left: calc($large-slider-height / 2);
+        left: $large-min-label-offset;
       }
 
       &-inline {
@@ -549,6 +583,16 @@ $small-marker-top: 0;
 
         &-mark-text {
           margin-left: -$space-xxs;
+        }
+      }
+
+      .extremity-label {
+        &.max-label {
+          right: $large-max-label-offset-with-steps;
+        }
+
+        &.min-label {
+          left: $large-min-label-offset-with-steps;
         }
       }
 
@@ -624,11 +668,11 @@ $small-marker-top: 0;
       font-size: $text-font-size-2;
 
       &.max-label {
-        right: calc($medium-slider-height / 2);
+        right: $medium-max-label-offset;
       }
 
       &.min-label {
-        left: calc($medium-slider-height / 2);
+        left: $medium-min-label-offset;
       }
 
       &-inline {
@@ -694,6 +738,16 @@ $small-marker-top: 0;
 
         &-mark-text {
           margin-left: -$space-xxs;
+        }
+      }
+
+      .extremity-label {
+        &.max-label {
+          right: $medium-max-label-offset-with-steps;
+        }
+
+        &.min-label {
+          left: $medium-min-label-offset-with-steps;
         }
       }
 
@@ -772,11 +826,11 @@ $small-marker-top: 0;
       font-size: $text-font-size-1;
 
       &.max-label {
-        right: calc($small-slider-height / 2);
+        right: $small-max-label-offset;
       }
 
       &.min-label {
-        left: calc($small-slider-height / 2);
+        left: $small-min-label-offset;
       }
 
       &-inline {
@@ -847,6 +901,16 @@ $small-marker-top: 0;
         }
       }
 
+      .extremity-label {
+        &.max-label {
+          right: $small-max-label-offset-with-steps;
+        }
+
+        &.min-label {
+          left: $small-min-label-offset-with-steps;
+        }
+      }
+
       .thumb {
         margin-left: -$space-xxxs;
       }
@@ -887,12 +951,12 @@ $small-marker-top: 0;
     .extremity-label {
       &.max-label {
         right: unset;
-        left: calc($medium-slider-height / 2);
+        left: $medium-max-label-offset;
       }
 
       &.min-label {
         left: unset;
-        right: calc($medium-slider-height / 2);
+        right: $medium-min-label-offset;
       }
 
       &-inline {
@@ -920,6 +984,18 @@ $small-marker-top: 0;
         &-mark-text {
           margin-left: unset;
           margin-right: -$space-xxs;
+        }
+      }
+
+      .extremity-label {
+        &.max-label {
+          right: unset;
+          left: $medium-max-label-offset-with-steps;
+        }
+
+        &.min-label {
+          left: unset;
+          right: $medium-min-label-offset-with-steps;
         }
       }
 
@@ -963,12 +1039,12 @@ $small-marker-top: 0;
       .extremity-label {
         &.max-label {
           right: unset;
-          left: calc($large-slider-height / 2);
+          left: $large-max-label-offset;
         }
 
         &.min-label {
           left: unset;
-          right: calc($large-slider-height / 2);
+          right: $large-min-label-offset;
         }
 
         &-inline {
@@ -996,6 +1072,18 @@ $small-marker-top: 0;
           &-mark-text {
             margin-left: unset;
             margin-right: -$space-xxs;
+          }
+        }
+
+        .extremity-label {
+          &.max-label {
+            left: $large-max-label-offset-with-steps;
+            right: unset;
+          }
+
+          &.min-label {
+            left: unset;
+            right: $large-min-label-offset-with-steps;
           }
         }
 
@@ -1033,12 +1121,12 @@ $small-marker-top: 0;
       .extremity-label {
         &.max-label {
           right: unset;
-          left: calc($medium-slider-height / 2);
+          left: $medium-max-label-offset;
         }
 
         &.min-label {
           left: unset;
-          right: calc($medium-slider-height / 2);
+          right: $medium-min-label-offset;
         }
 
         &-inline {
@@ -1066,6 +1154,18 @@ $small-marker-top: 0;
           &-mark-text {
             margin-left: unset;
             margin-right: -$space-xxs;
+          }
+        }
+
+        .extremity-label {
+          &.max-label {
+            left: $medium-max-label-offset-with-steps;
+            right: unset;
+          }
+
+          &.min-label {
+            left: unset;
+            right: $medium-min-label-offset-with-steps;
           }
         }
 
@@ -1103,12 +1203,12 @@ $small-marker-top: 0;
       .extremity-label {
         &.max-label {
           right: unset;
-          left: calc($small-slider-height / 2);
+          left: $small-max-label-offset;
         }
 
         &.min-label {
           left: unset;
-          right: calc($small-slider-height / 2);
+          right: $small-min-label-offset;
         }
 
         &-inline {
@@ -1136,6 +1236,18 @@ $small-marker-top: 0;
           &-mark-text {
             margin-left: unset;
             margin-right: -$space-xxxs;
+          }
+        }
+
+        .extremity-label {
+          &.max-label {
+            left: $small-max-label-offset-with-steps;
+            right: unset;
+          }
+
+          &.min-label {
+            left: unset;
+            right: $small-min-label-offset-with-steps;
           }
         }
 


### PR DESCRIPTION
## SUMMARY:
- Rounds down calculated pixels
- Replaces inaccurate `calc()` offset in CSS with `px` variables by `Slider` `size` of non-inline extremity labels


https://user-images.githubusercontent.com/99700808/228373726-792b8286-e15a-4f8f-9009-38a4fdaeb914.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-47094

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Slider` stories behave as expected.