### PR TITLE
fix: dropdown: handle event propagation and disabled

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -63,6 +63,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         placement = 'bottom-start',
         portal = false,
         positionStrategy = 'absolute',
+        referenceOnClick,
         role = 'listbox',
         showDropdown,
         style,
@@ -168,6 +169,15 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         height: height ?? '',
       };
 
+      const handleReferenceClick = (event: React.MouseEvent): void => {
+        event.stopPropagation();
+        if (disabled) {
+          return;
+        }
+        toggle(!mergedVisible)(event);
+        referenceOnClick?.(event);
+      };
+
       const getReference = (): JSX.Element => {
         const child = React.Children.only(children) as React.ReactElement<any>;
         const referenceWrapperClasses: string = mergeClasses([
@@ -180,7 +190,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           ...{
             [TRIGGER_TO_HANDLER_MAP_ON_ENTER[trigger]]: toggle(true),
           },
-          onClick: toggle(!mergedVisible),
+          onClick: handleReferenceClick,
           className: referenceWrapperClasses,
           'aria-controls': dropdownId,
           'aria-expanded': mergedVisible,

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -67,6 +67,12 @@ export interface DropdownProps {
    */
   positionStrategy?: Strategy;
   /**
+   * Callback executed on reference element click.
+   * @param event
+   * @returns (event: React.MouseEvent) => void
+   */
+  referenceOnClick?: (event: React.MouseEvent) => void;
+  /**
    * The dropdown aria role.
    * @default 'listbox'
    */

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -13,6 +13,9 @@ export const Popup: FC<PopupProps> = React.forwardRef<PopupRef, PopupProps>(
       closeOnPopupClick = false,
       closeOnReferenceClick = true,
       id,
+      popupOnKeydown,
+      referenceOnClick,
+      referenceOnKeydown,
       showPopup,
       size = PopupSize.Medium,
       tabIndex = 0,
@@ -47,9 +50,12 @@ export const Popup: FC<PopupProps> = React.forwardRef<PopupRef, PopupProps>(
         closeOnReferenceClick={closeOnReferenceClick}
         id={popupId}
         ref={ref}
+        referenceOnClick={referenceOnClick}
+        referenceOnKeydown={referenceOnKeydown}
         showTooltip={showPopup}
         size={popupSizeToTooltipSizeMap.get(size)}
         tabIndex={tabIndex}
+        tooltipOnKeydown={popupOnKeydown}
         tooltipStyle={popupStyle}
         trigger={trigger}
         type={TooltipType.Popup}

--- a/src/components/Popup/Popup.types.ts
+++ b/src/components/Popup/Popup.types.ts
@@ -14,13 +14,24 @@ export enum PopupTheme {
 export interface PopupProps
   extends Omit<
     TooltipProps,
-    'closeOnTooltipClick' | 'showTooltip' | 'size' | 'tooltipStyle' | 'type'
+    | 'closeOnTooltipClick'
+    | 'showTooltip'
+    | 'size'
+    | 'tooltipOnKeydown'
+    | 'tooltipStyle'
+    | 'type'
   > {
   /**
    * Should close Popup on body click.
    * @default false
    */
   closeOnPopupClick?: boolean;
+  /**
+   * Callback executed on popup element keydown.
+   * @param event
+   * @returns (event: React.KeyboardEvent) => void
+   */
+  popupOnKeydown?: (event: React.KeyboardEvent) => void;
   /**
    * The Popup style.
    */

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -65,10 +65,13 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         portalId,
         portalRoot,
         positionStrategy = 'absolute',
+        referenceOnClick,
+        referenceOnKeydown,
         showTooltip,
         size = TooltipSize.Small,
         tabIndex = 0,
         theme,
+        tooltipOnKeydown,
         tooltipStyle,
         trigger = 'hover',
         triggerAbove = false,
@@ -181,6 +184,10 @@ export const Tooltip: FC<TooltipProps> = React.memo(
       );
 
       const handleReferenceClick = (event: React.MouseEvent): void => {
+        event.stopPropagation();
+        if (disabled) {
+          return;
+        }
         timeout && clearTimeout(timeout);
         timeout = setTimeout(() => {
           if (mergedVisible && closeOnReferenceClick) {
@@ -189,9 +196,14 @@ export const Tooltip: FC<TooltipProps> = React.memo(
             toggle(true)(event);
           }
         }, hideAfter);
+        referenceOnClick?.(event);
       };
 
       const handleReferenceKeyDown = (event: React.KeyboardEvent): void => {
+        event.stopPropagation();
+        if (disabled) {
+          return;
+        }
         if (
           event?.key === eventKeys.ENTER &&
           document.activeElement === event.target
@@ -211,9 +223,11 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         ) {
           toggle(false)(event);
         }
+        referenceOnKeydown?.(event);
       };
 
       const handleFloatingKeyDown = (event: React.KeyboardEvent): void => {
+        event.stopPropagation();
         if (event?.key === eventKeys.ESCAPE) {
           toggle(false)(event);
         }
@@ -233,6 +247,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
             }
           }, NO_ANIMATION_DURATION);
         }
+        tooltipOnKeydown?.(event);
       };
 
       // The placement type contains both `Side` and `Alignment`, joined by `-`.

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -120,6 +120,18 @@ export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
    */
   ref?: Ref<TooltipRef>;
   /**
+   * Callback executed on reference element click.
+   * @param event
+   * @returns (event: React.MouseEvent) => void
+   */
+  referenceOnClick?: (event: React.MouseEvent) => void;
+  /**
+   * Callback executed on reference element keydown.
+   * @param event
+   * @returns (event: React.KeyboardEvent) => void
+   */
+  referenceOnKeydown?: (event: React.KeyboardEvent) => void;
+  /**
    * Callback to control the show/hide behavior of the Tooltip.
    * triggered before the visible change
    * @param show {boolean}
@@ -141,6 +153,12 @@ export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
    * @default light
    */
   theme?: TooltipTheme;
+  /**
+   * Callback executed on tooltip element keydown.
+   * @param event
+   * @returns (event: React.KeyboardEvent) => void
+   */
+  tooltipOnKeydown?: (event: React.KeyboardEvent) => void;
   /**
    * The Tooltip style.
    */


### PR DESCRIPTION
## SUMMARY:
Handle event propagation, disabled state and provide callbacks in `clonedElement` events.

## JIRA TASK (Eightfold Employees Only):
N/A

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST PLAN:
Pull the PR branch and run `yarn`, `yarn storybook`. Verify `Dropdown`, `Tooltip`, `Popup`, `Menu`, and `Select` components behave as expected.