### PR TITLE
fix: popup: fixes pseudo element so it doesn't block cursor

### DIFF
--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -107,10 +107,9 @@ Popups.args = {
             height: 172,
             margin: 4,
             width: 'calc(100% - 8px)',
-            zIndex: 0,
           }}
         />
-        <div className="octuple" style={{ zIndex: 1 }}>
+        <div className="octuple">
           <div className="octuple-content" style={{ padding: '16px' }}>
             <h5>Header 5</h5>
             <p className="octuple-content__small">

--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -50,6 +50,7 @@ $tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
         content: '';
         left: -$space-xs;
         padding: $space-xs;
+        pointer-events: none;
         position: absolute;
         right: -$space-xs;
         top: -$space-xs;


### PR DESCRIPTION
## SUMMARY:
Ensures CSS pseudo selector doesn't block cursor when over Popup


https://user-images.githubusercontent.com/99700808/230682142-54431dca-118e-4761-b228-2c0c666bffa5.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-48127

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Popup` story behaves as expected.