### PR TITLE
fix: button: move three more button palettes to global css vars

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -756,10 +756,12 @@
 
   &:hover:not([disabled]) {
     --bg: var(--button-neutral-hover-background-color);
+    --color: var(--button-neutral-hover-text-color);
   }
 
   &:active:not([disabled]) {
     --bg: var(--button-neutral-active-background-color);
+    --color: var(--button-neutral-active-text-color);
   }
 }
 
@@ -802,10 +804,12 @@
 
   &:not(.transparent):not([disabled]):hover {
     --bg: var(--button-system-ui-hover-background-color);
+    --color: var(--button-system-ui-hover-text-color);
   }
 
   &:not(.transparent):not([disabled]):active {
     --bg: var(--button-system-ui-active-background-color);
+    --color: var(--button-system-ui-active-text-color);
   }
 }
 
@@ -913,22 +917,22 @@
 
 .two-state-button {
   --button-counter-default-background-color: var(
-    --button-two-state-counter-default-background-color
+    --button-two-state-default-counter-background-color
   );
   --button-counter-hover-background-color: var(
-    --button-two-state-counter-hover-background-color
+    --button-two-state-hover-counter-background-color
   );
   --button-counter-checked-background-color: var(
-    --button-two-state-counter-checked-background-color
+    --button-two-state-checked-counter-background-color
   );
   --button-counter-focus-background-color: var(
-    --button-two-state-counter-focus-background-color
+    --button-two-state-focus-counter-background-color
   );
   --button-counter-active-background-color: var(
-    --button-two-state-counter-active-background-color
+    --button-two-state-active-counter-background-color
   );
   --button-counter-default-text-color: var(
-    --button-two-state-counter-default-text-color
+    --button-two-state-default-counter-text-color
   );
 
   --bg: var(--button-two-state-background-color);

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -745,27 +745,31 @@
 }
 
 .button-neutral {
-  --button-counter-default-text-color: var(--grey-color-80);
+  --button-counter-default-text-color: var(
+    --button-neutral-counter-default-text-color
+  );
 
-  --bg: var(--grey-color-10);
-  --color: var(--text-secondary-color);
+  --bg: var(--button-neutral-background-color);
+  --color: var(--button-neutral-text-color);
   color: var(--color);
   background-color: var(--bg);
 
   &:hover:not([disabled]) {
-    --bg: var(--background-color);
+    --bg: var(--button-neutral-hover-background-color);
   }
 
   &:active:not([disabled]) {
-    --bg: var(--grey-color-20);
+    --bg: var(--button-neutral-active-background-color);
   }
 }
 
 .button-system-ui {
-  --button-counter-default-text-color: var(--grey-color-80);
+  --button-counter-default-text-color: var(
+    --button-system-ui-counter-default-text-color
+  );
 
-  --bg: var(--background-color);
-  --color: var(--grey-color-60);
+  --bg: var(--button-system-ui-background-color);
+  --color: var(--button-system-ui-text-color);
   color: var(--color);
 
   .inner-nudge {
@@ -797,11 +801,11 @@
   }
 
   &:not(.transparent):not([disabled]):hover {
-    --bg: var(--grey-color-10);
+    --bg: var(--button-system-ui-hover-background-color);
   }
 
   &:not(.transparent):not([disabled]):active {
-    --bg: var(--grey-color-20);
+    --bg: var(--button-system-ui-active-background-color);
   }
 }
 
@@ -856,35 +860,35 @@
     width: 1px;
 
     &.split-divider-primary {
-      background-color: var(--primary-color-80);
+      background-color: var(--button-primary-split-divider-color);
     }
 
     &.split-divider-secondary {
-      background-color: var(--primary-color-70);
+      background-color: var(--button-secondary-split-divider-color);
     }
 
     &.split-divider-system-ui {
-      background-color: var(--grey-color-70);
+      background-color: var(--button-system-ui-split-divider-color);
     }
 
     &.split-divider-primary-disruptive {
-      background-color: var(--disruptive-color-80);
+      background-color: var(--button-primary-disruptive-split-divider-color);
     }
 
     &.split-divider-secondary-disruptive {
-      background-color: var(--disruptive-color-70);
+      background-color: var(--button-secondary-disruptive-split-divider-color);
     }
 
     &.split-divider-default {
-      background-color: var(--primary-color-70);
+      background-color: var(--button-default-split-divider-color);
     }
 
     &.split-divider-disruptive {
-      background-color: var(--disruptive-color-70);
+      background-color: var(--button-default-disruptive-split-divider-color);
     }
 
     &.split-divider-neutral {
-      background-color: var(--grey-color-70);
+      background-color: var(--button-neutral-split-divider-color);
     }
   }
 
@@ -908,15 +912,27 @@
 }
 
 .two-state-button {
-  --button-counter-default-background-color: var(--green-color-20);
-  --button-counter-hover-background-color: var(--green-color-20);
-  --button-counter-checked-background-color: var(--green-color-10);
-  --button-counter-focus-background-color: var(--green-color-20);
-  --button-counter-active-background-color: var(--green-color-10);
-  --button-counter-default-text-color: var(--grey-color-80);
+  --button-counter-default-background-color: var(
+    --button-two-state-counter-default-background-color
+  );
+  --button-counter-hover-background-color: var(
+    --button-two-state-counter-hover-background-color
+  );
+  --button-counter-checked-background-color: var(
+    --button-two-state-counter-checked-background-color
+  );
+  --button-counter-focus-background-color: var(
+    --button-two-state-counter-focus-background-color
+  );
+  --button-counter-active-background-color: var(
+    --button-two-state-counter-active-background-color
+  );
+  --button-counter-default-text-color: var(
+    --button-two-state-counter-default-text-color
+  );
 
-  --bg: var(--grey-color-10);
-  --color: var(--grey-color-70);
+  --bg: var(--button-two-state-background-color);
+  --color: var(--button-two-state-text-color);
   background-color: var(--bg);
   color: var(--color);
 
@@ -964,8 +980,8 @@
   }
 
   &:hover:not([disabled]) {
-    --bg: var(--green-color-10);
-    --color: var(--accent-color-70);
+    --bg: var(--button-two-state-hover-background-color);
+    --color: var(--button-two-state-hover-text-color);
 
     .counter {
       background-color: var(--button-counter-hover-background-color);
@@ -973,8 +989,8 @@
   }
 
   &:active:not([disabled]) {
-    --bg: var(--green-color-20);
-    --color: var(--accent-color);
+    --bg: var(--button-two-state-active-background-color);
+    --color: var(--button-two-state-active-text-color);
 
     .counter {
       background-color: var(--button-counter-active-background-color);
@@ -982,8 +998,8 @@
   }
 
   &.checked {
-    --bg: var(--green-color-20);
-    --color: var(--accent-color-80);
+    --bg: var(--button-two-state-checked-background-color);
+    --color: var(--button-two-state-checked-text-color);
 
     .counter {
       background-color: var(--button-counter-checked-background-color);
@@ -1284,7 +1300,7 @@
     &.button-neutral {
       &.focus-visible,
       &:focus-visible {
-        background-color: var(--grey-color-10);
+        background-color: var(--button-neutral-focus-visible-background-color);
 
         &.drop-shadow {
           box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;
@@ -1295,7 +1311,9 @@
     &.button-system-ui {
       &.focus-visible,
       &:focus-visible {
-        background-color: var(--background-color);
+        background-color: var(
+          --button-system-ui-focus-visible-background-color
+        );
 
         &.drop-shadow {
           box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -442,6 +442,7 @@
   --button-default-active-border-color: var(
     --button-default-active-background-color
   );
+  --button-default-split-divider-color: var(--primary-color-70);
   // ------ Default Button theme ------
 
   // ------ Default Disruptive Button theme ------
@@ -476,7 +477,18 @@
   --button-default-disruptive-active-border-color: var(
     --button-default-disruptive-active-background-color
   );
+  --button-default-disruptive-split-divider-color: var(--disruptive-color-70);
   // ------ Default Disruptive Button theme ------
+
+  // ------ Neutral Button theme ------
+  --button-neutral-text-color: var(--text-secondary-color);
+  --button-neutral-background-color: var(--grey-color-10);
+  --button-neutral-counter-default-text-color: var(--grey-color-80);
+  --button-neutral-hover-background-color: var(--background-color);
+  --button-neutral-focus-visible-background-color: var(--grey-color-10);
+  --button-neutral-active-background-color: var(--grey-color-20);
+  --button-neutral-split-divider-color: var(--grey-color-70);
+  // ------ Neutral Button theme ------
 
   // ------ Primary Button theme ------
   --button-primary-text-color: var(--primary-color-80);
@@ -498,6 +510,7 @@
   --button-primary-active-border-color: var(
     --button-primary-active-background-color
   );
+  --button-primary-split-divider-color: var(--primary-color-80);
   // ------ Primary Button theme ------
 
   // ------ Primary Disruptive Button theme ------
@@ -538,6 +551,7 @@
   --button-primary-disruptive-active-border-color: var(
     --button-primary-disruptive-active-background-color
   );
+  --button-primary-disruptive-split-divider-color: var(--disruptive-color-80);
   // ------ Primary Disruptive Button theme ------
 
   // ------ Secondary Button theme ------
@@ -556,6 +570,7 @@
   --button-secondary-active-border-width: var(--button-secondary-border-width);
   --button-secondary-active-border-style: var(--button-secondary-border-style);
   --button-secondary-active-border-color: var(--button-secondary-border-color);
+  --button-secondary-split-divider-color: var(--primary-color-70);
   // ------ Secondary Button theme ------
 
   // ------ Secondary Disruptive Button theme ------
@@ -594,7 +609,36 @@
   --button-secondary-disruptive-active-border-color: var(
     --button-secondary-disruptive-active-background-color
   );
+  --button-secondary-disruptive-split-divider-color: var(--disruptive-color-70);
   // ------ Secondary Disruptive Button theme ------
+
+  // ------ System UI Button theme ------
+  --button-system-ui-text-color: var(--grey-color-60);
+  --button-system-ui-background-color: var(--background-color);
+  --button-system-ui-counter-default-text-color: var(--grey-color-80);
+  --button-system-ui-hover-background-color: var(--grey-color-10);
+  --button-system-ui-focus-visible-background-color: var(--background-color);
+  --button-system-ui-active-background-color: var(--grey-color-20);
+  --button-system-ui-split-divider-color: var(--grey-color-70);
+  // ------ System UI Button theme ------
+
+  // ------ Two State Button theme ------
+  --button-two-state-text-color: var(--grey-color-70);
+  --button-two-state-background-color: var(--grey-color-10);
+  --button-two-state-border-color: var(--button-two-state-background-color);
+  --button-two-state-counter-default-background-color: var(--green-color-20);
+  --button-two-state-counter-hover-background-color: var(--green-color-20);
+  --button-two-state-counter-checked-background-color: var(--green-color-10);
+  --button-two-state-counter-focus-background-color: var(--green-color-20);
+  --button-two-state-counter-active-background-color: var(--green-color-10);
+  --button-two-state-counter-default-text-color: var(--grey-color-80);
+  --button-two-state-hover-text-color: var(--accent-color-70);
+  --button-two-state-hover-background-color: var(--green-color-10);
+  --button-two-state-active-text-color: var(--accent-color);
+  --button-two-state-active-background-color: var(--green-color-20);
+  --button-two-state-checked-text-color: var(--accent-color-80);
+  --button-two-state-checked-background-color: var(--green-color-20);
+  // ------ Two State Button theme ------
 
   // ------ Button Counter theme ------
   --button-counter-default-background-color: var(--grey-color-20);

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -484,8 +484,10 @@
   --button-neutral-text-color: var(--text-secondary-color);
   --button-neutral-background-color: var(--grey-color-10);
   --button-neutral-counter-default-text-color: var(--grey-color-80);
+  --button-neutral-hover-text-color: var(--button-neutral-text-color);
   --button-neutral-hover-background-color: var(--background-color);
   --button-neutral-focus-visible-background-color: var(--grey-color-10);
+  --button-neutral-active-text-color: var(--button-neutral-text-color);
   --button-neutral-active-background-color: var(--grey-color-20);
   --button-neutral-split-divider-color: var(--grey-color-70);
   // ------ Neutral Button theme ------
@@ -616,8 +618,10 @@
   --button-system-ui-text-color: var(--grey-color-60);
   --button-system-ui-background-color: var(--background-color);
   --button-system-ui-counter-default-text-color: var(--grey-color-80);
+  --button-system-ui-hover-text-color: var(--button-system-ui-text-color);
   --button-system-ui-hover-background-color: var(--grey-color-10);
   --button-system-ui-focus-visible-background-color: var(--background-color);
+  --button-system-ui-active-text-color: var(--button-system-ui-text-color);
   --button-system-ui-active-background-color: var(--grey-color-20);
   --button-system-ui-split-divider-color: var(--grey-color-70);
   // ------ System UI Button theme ------
@@ -626,12 +630,12 @@
   --button-two-state-text-color: var(--grey-color-70);
   --button-two-state-background-color: var(--grey-color-10);
   --button-two-state-border-color: var(--button-two-state-background-color);
-  --button-two-state-counter-default-background-color: var(--green-color-20);
-  --button-two-state-counter-hover-background-color: var(--green-color-20);
-  --button-two-state-counter-checked-background-color: var(--green-color-10);
-  --button-two-state-counter-focus-background-color: var(--green-color-20);
-  --button-two-state-counter-active-background-color: var(--green-color-10);
-  --button-two-state-counter-default-text-color: var(--grey-color-80);
+  --button-two-state-default-counter-background-color: var(--green-color-20);
+  --button-two-state-hover-counter-background-color: var(--green-color-20);
+  --button-two-state-checked-counter-background-color: var(--green-color-10);
+  --button-two-state-focus-counter-background-color: var(--green-color-20);
+  --button-two-state-active-counter-background-color: var(--green-color-10);
+  --button-two-state-default-counter-text-color: var(--grey-color-80);
   --button-two-state-hover-text-color: var(--accent-color-70);
   --button-two-state-hover-background-color: var(--green-color-10);
   --button-two-state-active-text-color: var(--accent-color);


### PR DESCRIPTION
## SUMMARY:

- Moves `NeutralButton`, `SystemUIButton` and `TwoStateButton` color palettes to global CSS variables
- Moves split divider colors to global CSS variables


https://user-images.githubusercontent.com/99700808/231304214-996c0226-90f6-4ace-a0d6-451c427473fe.mp4



## JIRA TASK (Eightfold Employees Only):
ENG-49421

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Button` stories behave as expected.