### PR TITLE
feat: pill: add align icon prop

### DIFF
--- a/src/components/Pills/Pill.test.tsx
+++ b/src/components/Pills/Pill.test.tsx
@@ -46,17 +46,17 @@ describe('Pill', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('Pill should render with icon to the right of its label', () => {
+  test('Pill should render with icon to the end of its label', () => {
     const { container } = render(
       <Pill
-        alignIcon={PillIconAlign.Right}
+        alignIcon={PillIconAlign.End}
         label="A pill with icon"
         iconProps={{
           path: IconName.mdiInformationOutline,
         }}
       />
     );
-    expect(container.getElementsByClassName('icon-right')).toHaveLength(1);
+    expect(container.getElementsByClassName('icon-end')).toHaveLength(1);
     expect(container).toMatchSnapshot();
   });
 

--- a/src/components/Pills/Pill.test.tsx
+++ b/src/components/Pills/Pill.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
-import { Pill, PillThemeName, PillType } from '.';
+import { Pill, PillIconAlign, PillThemeName, PillType } from '.';
 import { IconName } from '../Icon';
 import { render } from '@testing-library/react';
 
@@ -43,6 +43,20 @@ describe('Pill', () => {
       />
     );
     expect(container.getElementsByClassName('icon')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Pill should render with icon to the right of its label', () => {
+    const { container } = render(
+      <Pill
+        alignIcon={PillIconAlign.Right}
+        label="A pill with icon"
+        iconProps={{
+          path: IconName.mdiInformationOutline,
+        }}
+      />
+    );
+    expect(container.getElementsByClassName('icon-right')).toHaveLength(1);
     expect(container).toMatchSnapshot();
   });
 

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -11,7 +11,7 @@ import styles from './pills.module.scss';
 export const Pill: FC<PillProps> = React.forwardRef(
   (
     {
-      alignIcon = PillIconAlign.Left,
+      alignIcon = PillIconAlign.Start,
       classNames,
       color,
       configContextProps = {
@@ -57,8 +57,8 @@ export const Pill: FC<PillProps> = React.forwardRef(
 
     const iconClassNames: string = mergeClasses([
       styles.icon,
-      { [styles.iconLeft]: alignIcon === PillIconAlign.Left },
-      { [styles.iconRight]: alignIcon === PillIconAlign.Right },
+      { [styles.iconStart]: alignIcon === PillIconAlign.Start },
+      { [styles.iconEnd]: alignIcon === PillIconAlign.End },
     ]);
 
     const labelClassNames: string = mergeClasses([
@@ -97,14 +97,14 @@ export const Pill: FC<PillProps> = React.forwardRef(
         style={{ ...style, color }}
         ref={ref}
       >
-        {iconProps && alignIcon === PillIconAlign.Left && getIcon()}
+        {iconProps && alignIcon === PillIconAlign.Start && getIcon()}
         <span
           className={labelClassNames}
           style={lineClamp ? { WebkitLineClamp: lineClamp } : null}
         >
           {label}
         </span>
-        {iconProps && alignIcon === PillIconAlign.Right && getIcon()}
+        {iconProps && alignIcon === PillIconAlign.End && getIcon()}
         {type === PillType.withButton && (
           <DefaultButton
             {...pillButtonProps}

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -1,5 +1,5 @@
 import React, { FC, Ref, useContext } from 'react';
-import { PillProps, PillSize, PillType } from './Pills.types';
+import { PillIconAlign, PillProps, PillSize, PillType } from './Pills.types';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { ButtonSize, DefaultButton } from '../Button';
 import { Icon, IconName, IconSize } from '../Icon';
@@ -11,6 +11,7 @@ import styles from './pills.module.scss';
 export const Pill: FC<PillProps> = React.forwardRef(
   (
     {
+      alignIcon = PillIconAlign.Left,
       classNames,
       color,
       configContextProps = {
@@ -39,26 +40,36 @@ export const Pill: FC<PillProps> = React.forwardRef(
     const mergedDisabled: boolean = configContextProps.noDisabledContext
       ? disabled
       : contextuallyDisabled || disabled;
+
     const pillSizeToButtonSizeMap = new Map<PillSize, ButtonSize>([
       [PillSize.Large, ButtonSize.Medium],
       [PillSize.Medium, ButtonSize.Small],
       [PillSize.Small, ButtonSize.Small],
       [PillSize.XSmall, ButtonSize.Small],
     ]);
+
     const pillSizeToIconSizeMap = new Map<PillSize, IconSize>([
       [PillSize.Large, IconSize.Medium],
       [PillSize.Medium, IconSize.Small],
       [PillSize.Small, IconSize.XSmall],
       [PillSize.XSmall, IconSize.XSmall],
     ]);
-    const labelClassName: string = mergeClasses([
+
+    const iconClassNames: string = mergeClasses([
+      styles.icon,
+      { [styles.iconLeft]: alignIcon === PillIconAlign.Left },
+      { [styles.iconRight]: alignIcon === PillIconAlign.Right },
+    ]);
+
+    const labelClassNames: string = mergeClasses([
       styles.label,
       { [styles.medium]: size === PillSize.Medium },
       { [styles.small]: size === PillSize.Small },
       { [styles.xsmall]: size === PillSize.XSmall },
       { [styles.lineClamp]: lineClamp },
     ]);
-    const tagClassName: string = mergeClasses([
+
+    const tagClassNames: string = mergeClasses([
       styles.tagPills,
       classNames,
       (styles as any)[theme],
@@ -70,26 +81,30 @@ export const Pill: FC<PillProps> = React.forwardRef(
           type !== PillType.withButton && type !== PillType.closable,
       },
     ]);
+
+    const getIcon = (): JSX.Element => (
+      <Icon
+        {...iconProps}
+        size={pillSizeToIconSizeMap.get(size)}
+        classNames={iconClassNames}
+      />
+    );
+
     return (
       <div
         {...rest}
-        className={tagClassName}
+        className={tagClassNames}
         style={{ ...style, color }}
         ref={ref}
       >
-        {iconProps && (
-          <Icon
-            {...iconProps}
-            size={pillSizeToIconSizeMap.get(size)}
-            classNames={styles.icon}
-          />
-        )}
+        {iconProps && alignIcon === PillIconAlign.Left && getIcon()}
         <span
-          className={labelClassName}
+          className={labelClassNames}
           style={lineClamp ? { WebkitLineClamp: lineClamp } : null}
         >
           {label}
         </span>
+        {iconProps && alignIcon === PillIconAlign.Right && getIcon()}
         {type === PillType.withButton && (
           <DefaultButton
             {...pillButtonProps}

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -35,7 +35,7 @@ export default {
       action: 'close',
     },
     alignIcon: {
-      options: [PillIconAlign.Left, PillIconAlign.Right],
+      options: [PillIconAlign.Start, PillIconAlign.End],
       control: { type: 'radio' },
     },
     size: {
@@ -136,7 +136,7 @@ const With_Long_Text_Story: ComponentStory<typeof Pill> = (args) => (
 export const With_Long_Text = With_Long_Text_Story.bind({});
 
 const pillArgs: Object = {
-  alignIcon: PillIconAlign.Left,
+  alignIcon: PillIconAlign.Start,
   size: PillSize.Large,
   type: PillType.default,
   label: 'Pill label',

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Pill, PillSize, PillThemeName, PillType } from './';
+import { Pill, PillIconAlign, PillSize, PillThemeName, PillType } from './';
 import { IconName } from '../Icon';
 import { Stack } from '../Stack';
 
@@ -33,6 +33,10 @@ export default {
     },
     onClose: {
       action: 'close',
+    },
+    alignIcon: {
+      options: [PillIconAlign.Left, PillIconAlign.Right],
+      control: { type: 'radio' },
     },
     size: {
       options: [
@@ -67,7 +71,7 @@ const themes: PillThemeName[] = [
 ];
 
 const Default_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" gap="l">
+  <Stack direction="vertical" flexGap="l">
     {themes.map((theme) => (
       <Pill {...args} label={theme} theme={theme} key={theme} />
     ))}
@@ -77,7 +81,7 @@ const Default_Story: ComponentStory<typeof Pill> = (args) => (
 export const Default = Default_Story.bind({});
 
 const With_Icon_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" gap="l">
+  <Stack direction="vertical" flexGap="l">
     {themes.map((theme) => (
       <Pill {...args} label={theme} theme={theme} key={theme} />
     ))}
@@ -87,7 +91,7 @@ const With_Icon_Story: ComponentStory<typeof Pill> = (args) => (
 export const With_Icon = With_Icon_Story.bind({});
 
 const Closable_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" gap="l">
+  <Stack direction="vertical" flexGap="l">
     {themes.map((theme) => (
       <Pill {...args} label={theme} theme={theme} key={theme} />
     ))}
@@ -97,7 +101,7 @@ const Closable_Story: ComponentStory<typeof Pill> = (args) => (
 export const Closable = Closable_Story.bind({});
 
 const Custom_Closable_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" gap="l">
+  <Stack direction="vertical" flexGap="l">
     {themes.map((theme) => (
       <Pill {...args} label={theme} theme={theme} key={theme} />
     ))}
@@ -107,7 +111,7 @@ const Custom_Closable_Story: ComponentStory<typeof Pill> = (args) => (
 export const Custom_Closable = Custom_Closable_Story.bind({});
 
 const With_Button_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" gap="l">
+  <Stack direction="vertical" flexGap="l">
     {themes.map((theme) => (
       <Pill {...args} label={theme} theme={theme} key={theme} />
     ))}
@@ -117,7 +121,7 @@ const With_Button_Story: ComponentStory<typeof Pill> = (args) => (
 export const With_Button = With_Button_Story.bind({});
 
 const With_Long_Text_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" gap="l" style={{ width: 216 }}>
+  <Stack direction="vertical" flexGap="l" style={{ width: 216 }}>
     {themes.map((theme) => (
       <Pill
         {...args}
@@ -132,6 +136,7 @@ const With_Long_Text_Story: ComponentStory<typeof Pill> = (args) => (
 export const With_Long_Text = With_Long_Text_Story.bind({});
 
 const pillArgs: Object = {
+  alignIcon: PillIconAlign.Left,
   size: PillSize.Large,
   type: PillType.default,
   label: 'Pill label',

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -5,6 +5,11 @@ import { ButtonProps } from '../Button';
 import { OcBaseProps } from '../OcBase';
 import { ConfigContextProps } from '../ConfigProvider';
 
+export enum PillIconAlign {
+  Left = 'left',
+  Right = 'right',
+}
+
 export enum PillType {
   default = 'default',
   closable = 'closable',
@@ -50,6 +55,11 @@ export type PillThemeName =
   | 'white';
 
 export interface PillProps extends OcBaseProps<HTMLElement> {
+  /**
+   * The pill icon alignment.
+   * @default PillIconAlign.Left
+   */
+  alignIcon?: PillIconAlign;
   /**
    * Props for the close button,
    * if type is set to PillType.closable

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -6,8 +6,8 @@ import { OcBaseProps } from '../OcBase';
 import { ConfigContextProps } from '../ConfigProvider';
 
 export enum PillIconAlign {
-  Left = 'left',
-  Right = 'right',
+  Start = 'start',
+  End = 'end',
 }
 
 export enum PillType {

--- a/src/components/Pills/__snapshots__/Pill.test.tsx.snap
+++ b/src/components/Pills/__snapshots__/Pill.test.tsx.snap
@@ -135,3 +135,33 @@ exports[`Pill Pill should render with icon 1`] = `
   </div>
 </div>
 `;
+
+exports[`Pill Pill should render with icon to the right of its label 1`] = `
+<div>
+  <div
+    class="tag-pills blue read-only"
+  >
+    <span
+      class="label medium"
+    >
+      A pill with icon
+    </span>
+    <span
+      aria-hidden="false"
+      class="icon icon-right icon-wrapper"
+      role="presentation"
+    >
+      <svg
+        role="presentation"
+        style="width: 16px; height: 16px;"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
+          style="fill: currentColor;"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/Pills/__snapshots__/Pill.test.tsx.snap
+++ b/src/components/Pills/__snapshots__/Pill.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`Pill Pill should render with icon 1`] = `
   >
     <span
       aria-hidden="false"
-      class="icon icon-left icon-wrapper"
+      class="icon icon-start icon-wrapper"
       role="presentation"
     >
       <svg
@@ -136,7 +136,7 @@ exports[`Pill Pill should render with icon 1`] = `
 </div>
 `;
 
-exports[`Pill Pill should render with icon to the right of its label 1`] = `
+exports[`Pill Pill should render with icon to the end of its label 1`] = `
 <div>
   <div
     class="tag-pills blue read-only"
@@ -148,7 +148,7 @@ exports[`Pill Pill should render with icon to the right of its label 1`] = `
     </span>
     <span
       aria-hidden="false"
-      class="icon icon-right icon-wrapper"
+      class="icon icon-end icon-wrapper"
       role="presentation"
     >
       <svg

--- a/src/components/Pills/__snapshots__/Pill.test.tsx.snap
+++ b/src/components/Pills/__snapshots__/Pill.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`Pill Pill should render with icon 1`] = `
   >
     <span
       aria-hidden="false"
-      class="icon icon-wrapper"
+      class="icon icon-left icon-wrapper"
       role="presentation"
     >
       <svg

--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -158,7 +158,13 @@
   }
 
   .icon {
-    margin-right: $space-xxs;
+    &.icon-left {
+      margin-right: $space-xxs;
+    }
+
+    &.icon-right {
+      margin-left: $space-xxs;
+    }
   }
 
   &-disabled {
@@ -180,8 +186,15 @@
     }
 
     .icon {
-      margin-left: $space-xxs;
-      margin-right: unset;
+      &.icon-left {
+        margin-left: $space-xxs;
+        margin-right: unset;
+      }
+
+      &.icon-right {
+        margin-left: unset;
+        margin-right: $space-xxs;
+      }
     }
   }
 }

--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -158,11 +158,11 @@
   }
 
   .icon {
-    &.icon-left {
+    &.icon-start {
       margin-right: $space-xxs;
     }
 
-    &.icon-right {
+    &.icon-end {
       margin-left: $space-xxs;
     }
   }
@@ -186,12 +186,12 @@
     }
 
     .icon {
-      &.icon-left {
+      &.icon-start {
         margin-left: $space-xxs;
         margin-right: unset;
       }
 
-      &.icon-right {
+      &.icon-end {
         margin-left: unset;
         margin-right: $space-xxs;
       }

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -105,7 +105,13 @@ import {
 
 import { PersistentBar, PersistentBarType } from './components/PersistentBar';
 
-import { Pill, PillSize, PillThemeName, PillType } from './components/Pills';
+import {
+  Pill,
+  PillIconAlign,
+  PillSize,
+  PillThemeName,
+  PillType,
+} from './components/Pills';
 
 import {
   SearchBox,
@@ -305,6 +311,7 @@ export {
   PersistentBar,
   PersistentBarType,
   Pill,
+  PillIconAlign,
   PillSize,
   PillThemeName,
   PillType,


### PR DESCRIPTION
## SUMMARY:
Adds a prop to determine whether to align the `Pill` icon to the left or right of its label.


https://user-images.githubusercontent.com/99700808/231605921-2bd5d450-db3b-4b45-af16-d40db51eb10a.mp4


## JIRA TASK (Eightfold Employees Only):
ENG-49604

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Pill` icon story behaves as expected.