### PR TITLE
fix: upload: adds button type props to show list item interface

### DIFF
--- a/src/components/Upload/Tests/__snapshots__/uploadlist.test.tsx.snap
+++ b/src/components/Upload/Tests/__snapshots__/uploadlist.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`Upload List should be uploading when upload a file 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -253,6 +254,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -316,6 +318,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -390,6 +393,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -464,6 +468,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -527,6 +532,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -590,6 +596,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -653,6 +660,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -716,6 +724,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -779,6 +788,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -842,6 +852,7 @@ exports[`Upload List should non-image format file preview 1`] = `
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -953,6 +964,7 @@ exports[`Upload List should support removeIcon, replaceIcon, and downloadIcon 1`
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -1016,6 +1028,7 @@ exports[`Upload List should support removeIcon, replaceIcon, and downloadIcon 1`
                 aria-disabled="false"
                 aria-label="Download file"
                 class="icon-download button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -1038,6 +1051,7 @@ exports[`Upload List should support removeIcon, replaceIcon, and downloadIcon 1`
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -1149,6 +1163,7 @@ exports[`Upload List should support removeIcon, replaceIcon, and downloadIcon 2`
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -1212,6 +1227,7 @@ exports[`Upload List should support removeIcon, replaceIcon, and downloadIcon 2`
                 aria-disabled="false"
                 aria-label="Download file"
                 class="icon-download button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"
@@ -1234,6 +1250,7 @@ exports[`Upload List should support removeIcon, replaceIcon, and downloadIcon 2`
                 aria-disabled="false"
                 aria-label="Remove file"
                 class="icon-delete button button-default button-medium round-shape icon-left"
+                type="button"
               >
                 <span
                   aria-hidden="false"

--- a/src/components/Upload/Tests/type.test.tsx
+++ b/src/components/Upload/Tests/type.test.tsx
@@ -73,6 +73,9 @@ describe('Upload.typescript', () => {
     const upload = (
       <Upload
         showUploadList={{
+          downloadIconButtonType: 'button',
+          removeIconButtonType: 'button',
+          replaceButtonType: 'button',
           showPreviewIconButton: true,
           showRemoveIconButton: true,
           showReplaceButton: true,

--- a/src/components/Upload/Upload.stories.tsx
+++ b/src/components/Upload/Upload.stories.tsx
@@ -121,6 +121,10 @@ const Basic_With_Upload_List_Story: ComponentStory<typeof Upload> = () => {
         });
       }
     },
+    showUploadList: {
+      downloadIconButtonType: 'button',
+      removeIconButtonType: 'button',
+    },
   };
   return (
     <>
@@ -163,6 +167,10 @@ const Drag_and_Drop_Single_Small_Story: ComponentStory<typeof Upload> = () => {
       console.log('Dropped files', e.dataTransfer.files);
     },
     size: UploadSize.Small,
+    showUploadList: {
+      replaceButtonType: 'button',
+      showReplaceButton: true,
+    },
   };
   return (
     <>
@@ -199,6 +207,10 @@ const Drag_and_Drop_Multiple_Small_Story: ComponentStory<
     },
     onDrop(e) {
       console.log('Dropped files', e.dataTransfer.files);
+    },
+    showUploadList: {
+      downloadIconButtonType: 'button',
+      removeIconButtonType: 'button',
     },
     size: UploadSize.Small,
   };
@@ -275,6 +287,10 @@ const Drag_and_Drop_Multiple_Medium_Story: ComponentStory<
     onDrop(e) {
       console.log('Dropped files', e.dataTransfer.files);
     },
+    showUploadList: {
+      downloadIconButtonType: 'button',
+      removeIconButtonType: 'button',
+    },
   };
   return (
     <>
@@ -349,6 +365,10 @@ const Drag_and_Drop_Multiple_Large_Story: ComponentStory<
     },
     onDrop(e) {
       console.log('Dropped files', e.dataTransfer.files);
+    },
+    showUploadList: {
+      downloadIconButtonType: 'button',
+      removeIconButtonType: 'button',
     },
     size: UploadSize.Large,
   };

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -478,8 +478,11 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (
         {(_contextLocale: UploadLocale) => {
           const {
             downloadIcon,
+            downloadIconButtonType: downloadIconButtonType,
             previewIcon,
             removeIcon,
+            removeIconButtonType: removeIconButtonType,
+            replaceButtonType: replaceButtonType,
             replaceIcon,
             showDownloadIconButton: showDownloadIconButton,
             showPreviewIconButton: showPreviewIconButton,
@@ -494,6 +497,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (
               appendActionVisible={buttonVisible}
               downloadFileText={downloadFileText}
               downloadIcon={downloadIcon}
+              downloadIconButtonType={downloadIconButtonType}
               iconRender={iconRender}
               isImageUrl={isImageUrl}
               itemRender={itemRender}
@@ -510,6 +514,8 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (
               progress={progress}
               removeFileText={removeFileText}
               removeIcon={removeIcon}
+              removeIconButtonType={removeIconButtonType}
+              replaceButtonType={replaceButtonType}
               replaceFileText={replaceFileText}
               replaceIcon={replaceIcon}
               showDownloadIconButton={showDownloadIconButton}

--- a/src/components/Upload/Upload.types.tsx
+++ b/src/components/Upload/Upload.types.tsx
@@ -11,6 +11,8 @@ import { ConfigContextProps } from '../ConfigProvider';
 import { ButtonProps } from '../Button';
 import { IconName } from '../Icon';
 
+type UploadButtonHtmlType = 'button' | 'submit' | 'reset';
+
 type Locale = {
   /**
    * The Upload locale.
@@ -243,6 +245,11 @@ export interface ShowUploadListInterface {
    */
   downloadIcon?: IconName | ((file: UploadFile) => IconName);
   /**
+   * The download icon button type
+   * @default 'button'
+   */
+  downloadIconButtonType?: UploadButtonHtmlType;
+  /**
    * Customize the preview icon button svg path.
    */
   previewIcon?: IconName | ((file: UploadFile) => IconName);
@@ -250,6 +257,16 @@ export interface ShowUploadListInterface {
    * Customize the remove icon button svg path.
    */
   removeIcon?: IconName | ((file: UploadFile) => IconName);
+  /**
+   * The remove icon button type
+   * @default 'button'
+   */
+  removeIconButtonType?: UploadButtonHtmlType;
+  /**
+   * The replace button type
+   * @default 'button'
+   */
+  replaceButtonType?: UploadButtonHtmlType;
   /**
    * Customize the replace button icon svg path.
    */
@@ -268,6 +285,7 @@ export interface ShowUploadListInterface {
   showRemoveIconButton?: boolean;
   /**
    * Whether to show the replace button.
+   * Use when maxCount is 1
    */
   showReplaceButton?: boolean;
 }
@@ -495,7 +513,8 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
   selectMultipleFilesText?: string;
   /**
    * Whether to show default upload list,
-   * could be an object to specify each 'showPreviewIconButton', 'showRemoveIconButton',
+   * could be an object to specify each 'downloadIconButtonType', 'removeIconButtonType',
+   * 'replaceButtonType', 'showPreviewIconButton', 'showRemoveIconButton',
    * 'showDownloadIconButton', 'showReplaceButton', 'removeIcon', 'replaceIcon', and 'downloadIcon'.
    * @default true
    */
@@ -566,6 +585,11 @@ export interface UploadListProps<T = any> {
    * Customize the download icon button svg path.
    */
   downloadIcon?: IconName | ((file: UploadFile) => IconName);
+  /**
+   * The download icon button type
+   * @default 'button'
+   */
+  downloadIconButtonType?: UploadButtonHtmlType;
   /**
    * The custom icon.
    */
@@ -645,6 +669,16 @@ export interface UploadListProps<T = any> {
    */
   removeIcon?: IconName | ((file: UploadFile) => IconName);
   /**
+   * The remove icon button type
+   * @default 'button'
+   */
+  removeIconButtonType?: UploadButtonHtmlType;
+  /**
+   * The replace button type
+   * @default 'button'
+   */
+  replaceButtonType?: UploadButtonHtmlType;
+  /**
    * The replace string.
    * @default 'Replace'
    */
@@ -667,6 +701,7 @@ export interface UploadListProps<T = any> {
   showRemoveIconButton?: boolean;
   /**
    * Whether to show the replace button.
+   * Use when maxCount is 1
    */
   showReplaceButton?: boolean;
   /**
@@ -707,6 +742,11 @@ export interface ListItemProps {
    * Customize the download icon path.
    */
   downloadIcon?: IconName | ((file: UploadFile) => IconName);
+  /**
+   * The download icon button type
+   * @default 'button'
+   */
+  downloadIconButtonType?: UploadButtonHtmlType;
   /**
    * The Upload list item file.
    */
@@ -783,6 +823,16 @@ export interface ListItemProps {
    */
   removeIcon?: IconName | ((file: UploadFile) => IconName);
   /**
+   * The remove icon button type
+   * @default 'button'
+   */
+  removeIconButtonType?: UploadButtonHtmlType;
+  /**
+   * The replace button type
+   * @default 'button'
+   */
+  replaceButtonType?: UploadButtonHtmlType;
+  /**
    * The replace string.
    * @default 'Replace'
    */
@@ -805,6 +855,7 @@ export interface ListItemProps {
   showRemoveIconButton?: boolean;
   /**
    * Whether to show the replace button.
+   * Use when maxCount is 1
    */
   showReplaceButton?: boolean;
   /**

--- a/src/components/Upload/UploadList/ListItem.tsx
+++ b/src/components/Upload/UploadList/ListItem.tsx
@@ -16,6 +16,7 @@ const ListItem = React.forwardRef(
       classNames,
       downloadFileText,
       downloadIcon: customDownloadIcon,
+      downloadIconButtonType: downloadIconButtonType,
       file,
       iconRender,
       isImgUrl,
@@ -32,6 +33,8 @@ const ListItem = React.forwardRef(
       previewIcon: customPreviewIcon,
       progress: progressProps,
       removeFileText,
+      removeIconButtonType: removeIconButtonType,
+      replaceButtonType: replaceButtonType,
       replaceFileText,
       removeIcon: customRemoveIcon,
       replaceIcon: customReplaceIcon,
@@ -131,6 +134,7 @@ const ListItem = React.forwardRef(
             ariaLabel: removeFileText,
             classNames: mergeClasses([styles.iconDelete]),
             disruptive: mergedStatus === 'error',
+            htmlType: removeIconButtonType,
             iconProps: {
               path:
                 typeof customRemoveIcon === 'function'
@@ -151,6 +155,7 @@ const ListItem = React.forwardRef(
           {
             classNames: mergeClasses([styles.iconReplace]),
             disruptive: mergedStatus === 'error',
+            htmlType: replaceButtonType,
             iconProps: {
               path:
                 typeof customReplaceIcon === 'function'
@@ -171,6 +176,7 @@ const ListItem = React.forwardRef(
             {
               ariaLabel: downloadFileText,
               classNames: mergeClasses([styles.iconDownload]),
+              htmlType: downloadIconButtonType,
               iconProps: {
                 path:
                   typeof customDownloadIcon === 'function'
@@ -253,7 +259,7 @@ const ListItem = React.forwardRef(
       mergedStatus !== 'uploading' && (
         <span className={styles.uploadListItemActions}>
           {previewIconButton}
-          {mergedStatus === 'done' && downloadIconButton}
+          {downloadIconButton}
           {!maxCount && removeIconButton}
           {maxCount === 1 && replaceButton}
         </span>

--- a/src/components/Upload/UploadList/index.tsx
+++ b/src/components/Upload/UploadList/index.tsx
@@ -39,6 +39,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<
     appendActionVisible = true,
     downloadFileText,
     downloadIcon,
+    downloadIconButtonType = 'button',
     iconRender,
     isImageUrl: isImgUrl = isImageUrl,
     itemRender,
@@ -55,6 +56,8 @@ const InternalUploadList: React.ForwardRefRenderFunction<
     progress = { strokeWidth: 2, showLabels: false },
     removeFileText,
     removeIcon,
+    removeIconButtonType = 'button',
+    replaceButtonType = 'button',
     replaceFileText,
     replaceIcon,
     showDownloadIconButton: showDownloadIconButton = false,
@@ -196,6 +199,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<
         styles.uploadListItemCardActionsButton,
         styles.iconDownload,
       ]),
+      htmlType: downloadIconButtonType,
       iconProps: {
         path: IconName.mdiArrowDownThin,
       },
@@ -257,6 +261,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<
             classNames={motionClassNames}
             downloadFileText={downloadFileText}
             downloadIcon={downloadIcon}
+            downloadIconButtonType={downloadIconButtonType}
             file={file}
             iconRender={internalIconRender}
             isImgUrl={isImgUrl}
@@ -274,6 +279,8 @@ const InternalUploadList: React.ForwardRefRenderFunction<
             progress={progress}
             removeFileText={removeFileText}
             removeIcon={removeIcon}
+            removeIconButtonType={removeIconButtonType}
+            replaceButtonType={replaceButtonType}
             replaceFileText={replaceFileText}
             replaceIcon={replaceIcon}
             showDownloadIconButton={showDownloadIconButton}


### PR DESCRIPTION
## SUMMARY:
Adds `<button>` `type` props to `Upload` `showUploadList` interface and defaults them to `'button'` to prevent unintended `Form` submit

![uploadButtonType](https://user-images.githubusercontent.com/99700808/231892200-95ca1a90-7a31-4eb4-a981-19fbe396bff8.png)


## JIRA TASK (Eightfold Employees Only):
ENG-49788

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Upload` stories behave as expected.