### PR TITLE
fix: tooltip: remove pointer events property of disabled styling

### DIFF
--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -15,7 +15,6 @@ $tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
 
   &.disabled {
     cursor: auto;
-    pointer-events: none;
   }
 
   // Hides the browser default keyboard focus-visible styles.


### PR DESCRIPTION
## SUMMARY:
The reference element of `Tooltip` and `Popup` were inheriting the `pointer-events: none` property and value of the reference wrapper. As the reference and base Tooltip styling concerns are separated in this regard, this is not needed. Removing this line should fix the issue where disabling Tooltips cause inputs to ignore pointer events.

## JIRA TASK (Eightfold Employees Only):
ENG-50127

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify `Tooltip` and `Popup` stories behave as expected when `disabled` is `true `or `false`.