### PR TITLE
fix(avatar group): avatar group count, maxProps fixes

### DIFF
--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -101,4 +101,58 @@ describe('Avatar', () => {
     );
     expect(wrapper.children().length).toEqual(1);
   });
+
+  test('Should render a list group with max count', () => {
+    const imageProps = {
+      src: 'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg',
+      alt: 'random profile image',
+    };
+
+    interface User {
+      'data-test-id': string;
+      alt: string;
+      children: React.ReactNode;
+      classNames: string;
+      img: string;
+      key: string;
+      name: string;
+      randomiseTheme: boolean;
+    }
+
+    const sampleList: User[] = [
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    ].map((i) => ({
+      'data-test-id': `my-avatar-test-id-${i}`,
+      alt: i === 1 ? imageProps.alt : null,
+      children: `U${i}`,
+      classNames: `my-avatar-class-${i}`,
+      img: i === 1 ? imageProps.src : null,
+      key: `key-${i}`,
+      name: `User ${i}`,
+      randomiseTheme: true,
+    }));
+    const wrapper = mount(
+      <AvatarGroup
+        avatarListProps={{
+          items: sampleList,
+          renderItem: (item: User) => (
+            <Avatar
+              alt={item.alt}
+              classNames={item.classNames}
+              data-test-id={item['data-test-id']}
+              hashingFunction={() => 3}
+              randomiseTheme={item.randomiseTheme}
+              src={item.img}
+            >
+              {item.children}
+            </Avatar>
+          ),
+        }}
+        maxProps={{
+          count: 24,
+        }}
+      />
+    );
+    expect(wrapper.children().length).toEqual(1);
+  });
 });

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -72,7 +72,6 @@ const sampleList: User[] = [
 
 const Basic_Story: ComponentStory<typeof AvatarGroup> = (args) => (
   <AvatarGroup
-    {...args}
     animateOnHover
     maxProps={{
       count: 4,
@@ -86,6 +85,7 @@ const Basic_Story: ComponentStory<typeof AvatarGroup> = (args) => (
         theme: TooltipTheme.dark,
       },
     }}
+    {...args}
   >
     <Avatar
       alt={imageProps.alt}
@@ -202,9 +202,10 @@ export const Basic = Basic_Story.bind({});
 
 export const Basic_Spaced = Basic_Story.bind({});
 
+export const Basic_Max_Props_Exceed_Children = Basic_Story.bind({});
+
 const List_Story: ComponentStory<typeof AvatarGroup> = (args) => (
   <AvatarGroup
-    {...args}
     animateOnHover
     avatarListProps={{
       items: sampleList,
@@ -241,6 +242,7 @@ const List_Story: ComponentStory<typeof AvatarGroup> = (args) => (
         theme: TooltipTheme.dark,
       },
     }}
+    {...args}
   />
 );
 
@@ -248,11 +250,12 @@ export const List_Group = List_Story.bind({});
 
 export const List_Group_Spaced = List_Story.bind({});
 
+export const List_Group_Max_Props_Exceed_Children = List_Story.bind({});
+
 const avatarGroupArgs: Object = {
   classNames: 'my-avatar-group-class',
   'data-test-id': 'my-avatar-group-test-id',
   fontSize: '18px',
-  maxProps: {},
   size: '40px',
   style: {},
   type: 'round',
@@ -267,6 +270,13 @@ Basic_Spaced.args = {
   groupVariant: AvatarGroupVariant.Spaced,
 };
 
+Basic_Max_Props_Exceed_Children.args = {
+  ...avatarGroupArgs,
+  maxProps: {
+    count: 10,
+  },
+};
+
 List_Group.args = {
   ...avatarGroupArgs,
 };
@@ -274,4 +284,11 @@ List_Group.args = {
 List_Group_Spaced.args = {
   ...avatarGroupArgs,
   groupVariant: AvatarGroupVariant.Spaced,
+};
+
+List_Group_Max_Props_Exceed_Children.args = {
+  ...avatarGroupArgs,
+  maxProps: {
+    count: 30,
+  },
 };

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -81,7 +81,7 @@ const Basic_Story: ComponentStory<typeof AvatarGroup> = (args) => (
       onMouseLeave: action('maxcount-mouseleave'),
       tabIndex: 0,
       tooltipProps: {
-        content: 'User 7, User 8, User 9, User 10',
+        content: 'This is a tooltip.',
         theme: TooltipTheme.dark,
       },
     }}

--- a/src/components/Avatar/AvatarGroup.tsx
+++ b/src/components/Avatar/AvatarGroup.tsx
@@ -76,9 +76,7 @@ export const AvatarGroup: React.FC<AvatarGroupProps> = React.forwardRef(
         ])}
       >
         {!!maxProps?.value && maxProps?.value}
-        {!maxProps?.value && avatarListProps
-          ? `+${numChildren - maxCount}`
-          : `+${maxCount}`}
+        {!maxProps?.value && `+${numChildren - maxCount}`}
       </Avatar>
     );
 
@@ -111,21 +109,25 @@ export const AvatarGroup: React.FC<AvatarGroupProps> = React.forwardRef(
       </ConditionalWrapper>
     );
 
-    if (avatarListProps && maxCount && maxCount < numChildren) {
+    if (avatarListProps) {
+      const inlineCount = maxCount
+        ? Math.min(maxCount, numChildren)
+        : numChildren;
+      const showCountAvatar = maxCount && maxCount < numChildren;
       const childrenShown: React.ReactNode[] = avatarListProps?.items.slice(
         0,
-        maxCount
+        inlineCount
       );
       return (
         <List
           layout={'horizontal'}
           {...rest}
           ref={ref}
-          additionalItem={maxCountAvatar}
+          additionalItem={showCountAvatar ? maxCountAvatar : null}
           classNames={avatarGroupClassNames}
           items={childrenShown}
           renderItem={avatarListProps?.renderItem}
-          renderAdditionalItem={maxCountItem}
+          renderAdditionalItem={showCountAvatar ? maxCountItem : () => null}
           style={style}
           tabIndex={-1}
         />

--- a/src/components/Avatar/AvatarGroup.tsx
+++ b/src/components/Avatar/AvatarGroup.tsx
@@ -109,11 +109,12 @@ export const AvatarGroup: React.FC<AvatarGroupProps> = React.forwardRef(
       </ConditionalWrapper>
     );
 
+    const inlineCount = maxCount
+      ? Math.min(maxCount, numChildren)
+      : numChildren;
+    const showCountAvatar = maxCount && maxCount < numChildren;
+
     if (avatarListProps) {
-      const inlineCount = maxCount
-        ? Math.min(maxCount, numChildren)
-        : numChildren;
-      const showCountAvatar = maxCount && maxCount < numChildren;
       const childrenShown: React.ReactNode[] = avatarListProps?.items.slice(
         0,
         inlineCount
@@ -134,27 +135,18 @@ export const AvatarGroup: React.FC<AvatarGroupProps> = React.forwardRef(
       );
     }
 
-    if (!avatarListProps && maxCount && maxCount < numChildren) {
-      const childrenShow: React.ReactElement<
-        any,
-        string | React.JSXElementConstructor<any>
-      >[] = childrenWithProps?.slice(0, maxCount);
+    const childrenShow: React.ReactElement<
+      any,
+      string | React.JSXElementConstructor<any>
+    >[] = childrenWithProps?.slice(0, inlineCount);
+
+    if (showCountAvatar) {
       childrenShow?.push(maxCountItem());
-      return (
-        <div
-          {...rest}
-          ref={ref}
-          className={avatarGroupClassNames}
-          style={style}
-        >
-          {childrenShow}
-        </div>
-      );
     }
 
     return (
       <div {...rest} ref={ref} className={avatarGroupClassNames} style={style}>
-        {childrenWithProps}
+        {childrenShow}
       </div>
     );
   }

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -9,6 +9,7 @@ import {
   Avatar,
   AvatarGroup,
   AvatarGroupVariant,
+  AvatarPopupProps,
   StatusItemIconAlign,
   StatusItemsPosition,
 } from './components/Avatar';
@@ -234,6 +235,7 @@ export {
   Avatar,
   AvatarGroup,
   AvatarGroupVariant,
+  AvatarPopupProps,
   Badge,
   ButtonIconAlign,
   ButtonShape,


### PR DESCRIPTION
## SUMMARY:
fix(avatar group): avatar group count, maxProps fixes.
The maxProps count is not being properly considered to show the correct count.
Having wrong counts shown when sent as children or avatarListProps -> fixed.
Avatar Group completely null rendered or moot when the numChildren available less then maxProps set -> fixed.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-50821

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
1.) Check the below stories of Avatar Group, the earlier wrongly shown counts are properly shown and in case of the octuple stories of Exceed MaxCount than children all avatars must render inline.


<img width="1792" alt="Screenshot 2023-04-25 at 1 01 40 AM" src="https://user-images.githubusercontent.com/66293858/234097182-5f801f14-448c-4e4f-8a19-62fb671ecf53.png">
