### PR TITLE
feat: adding style option for Empty description

### DIFF
--- a/src/components/Empty/Empty.stories.tsx
+++ b/src/components/Empty/Empty.stories.tsx
@@ -51,6 +51,7 @@ const emptyArgs: Object = {
   mode: EmptyMode.data,
   style: {},
   title: 'Short Message Here',
+  descriptionClassNames: 'my-description-class',
 };
 
 No_Data.args = {

--- a/src/components/Empty/Empty.test.tsx
+++ b/src/components/Empty/Empty.test.tsx
@@ -13,4 +13,13 @@ describe('Empty', () => {
     const wrapper = mount(<Empty description="Test" />);
     expect(wrapper.containsMatchingElement(<Empty />)).toEqual(true);
   });
+
+  test('empty includes the description class name', () => {
+    const wrapper = mount(
+      <Empty description="Test" descriptionClassNames="description-class" />
+    );
+    expect(
+      wrapper.getDOMNode().querySelector('.description-class')
+    ).toBeTruthy();
+  });
 });

--- a/src/components/Empty/Empty.tsx
+++ b/src/components/Empty/Empty.tsx
@@ -79,7 +79,10 @@ export const Empty: FC<EmptyProps> = React.forwardRef(
         {title && <div className={styles.emptyTitle}>{title}</div>}
         {description && (
           <div
-            className={`${styles.emptyDescription} ${descriptionClassNames}`}
+            className={mergeClasses([
+              styles.emptyDescription,
+              descriptionClassNames,
+            ])}
           >
             {description}
           </div>

--- a/src/components/Empty/Empty.tsx
+++ b/src/components/Empty/Empty.tsx
@@ -22,6 +22,7 @@ export const Empty: FC<EmptyProps> = React.forwardRef(
       children,
       classNames,
       description,
+      descriptionClassNames = '',
       image,
       imageStyle,
       mode = EmptyMode.data,
@@ -77,7 +78,11 @@ export const Empty: FC<EmptyProps> = React.forwardRef(
         </div>
         {title && <div className={styles.emptyTitle}>{title}</div>}
         {description && (
-          <div className={styles.emptyDescription}>{description}</div>
+          <div
+            className={`${styles.emptyDescription} ${descriptionClassNames}`}
+          >
+            {description}
+          </div>
         )}
         {children && <div className={styles.emptyFooter}>{children}</div>}
       </div>

--- a/src/components/Empty/Empty.types.ts
+++ b/src/components/Empty/Empty.types.ts
@@ -18,6 +18,10 @@ export interface EmptyProps extends OcBaseProps<HTMLDivElement> {
    */
   description?: string;
   /**
+   * The empty component description class names.
+   */
+  descriptionClassNames?: string;
+  /**
    * The empty component mode
    */
   mode?: EmptyMode;


### PR DESCRIPTION

## SUMMARY:
Add descriptionClassNames property on Empty component

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-51296

## CHANGE TYPE:
https://eightfoldai.atlassian.net/browse/ENG-51296

- [ ] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
I need to include additional styling on the Empty component description text. The test case I've added should be sufficient to verify that this behaves as expected.
