### PR TITLE
fix: dropdown: use id from clone element props if present

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -145,6 +145,7 @@ const Dropdown_Button_Story: ComponentStory<typeof Dropdown> = (args) => {
           path: IconName.mdiChevronDown,
           rotate: visible ? 180 : 0,
         }}
+        id="octuple-dropdown-button-id"
       />
     </Dropdown>
   );

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -78,6 +78,7 @@ const DropdownComponent = (): JSX.Element => {
           path: IconName.mdiChevronDown,
           rotate: visible ? 180 : 0,
         }}
+        id="test-button-id"
       />
     </Dropdown>
   );
@@ -124,5 +125,11 @@ describe('Dropdown', () => {
     expect(
       (container.querySelector('.dropdown-wrapper') as HTMLElement).style.color
     ).toContain('red');
+  });
+
+  test('Should support cloned element id from its props', async () => {
+    render(<DropdownComponent />);
+    const dropdownButton = screen.getByRole('button');
+    expect(dropdownButton.id).toBe('test-button-id');
   });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -74,8 +74,9 @@ export const Dropdown: FC<DropdownProps> = React.memo(
 
       const [closing, setClosing] = useState<boolean>(false);
       const dropdownId: string = uniqueId('dropdown-');
-      const dropdownReferenceId: React.MutableRefObject<string> =
-        useRef<string>(`${dropdownId}reference`);
+      const [dropdownReferenceId, setReferenceElementId] = useState<string>(
+        `${dropdownId}reference`
+      );
 
       let timeout: ReturnType<typeof setTimeout>;
       const { x, y, reference, floating, strategy, update, refs, context } =
@@ -111,9 +112,8 @@ export const Dropdown: FC<DropdownProps> = React.memo(
       useOnClickOutside(
         refs.floating,
         (e) => {
-          const referenceElement: HTMLElement = document.getElementById(
-            dropdownReferenceId?.current
-          );
+          const referenceElement: HTMLElement =
+            document.getElementById(dropdownReferenceId);
           if (closeOnOutsideClick && closeOnReferenceClick) {
             toggle(false)(e);
           }
@@ -239,11 +239,14 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           { [child.props.className]: child.props.className },
           { [styles.disabled]: disabled },
         ]);
+        if (child.props.id && dropdownReferenceId !== child.props.id) {
+          setReferenceElementId(child.props.id);
+        }
         return cloneElement(child, {
           ...{
             [TRIGGER_TO_HANDLER_MAP_ON_ENTER[trigger]]: toggle(true),
           },
-          id: dropdownReferenceId?.current,
+          id: dropdownReferenceId,
           onClick: handleReferenceClick,
           onKeyDown: handleReferenceKeyDown,
           className: referenceWrapperClassNames,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -4,7 +4,6 @@ import React, {
   SyntheticEvent,
   useEffect,
   useImperativeHandle,
-  useRef,
   useState,
 } from 'react';
 import {
@@ -239,6 +238,8 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           { [child.props.className]: child.props.className },
           { [styles.disabled]: disabled },
         ]);
+        // If there's an id and it does not yet match the state, update dropdownReferenceId.
+        // This compare ensures setState is only called when needed.
         if (child.props.id && dropdownReferenceId !== child.props.id) {
           setReferenceElementId(child.props.id);
         }

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Dropdown Should render a dropdown button 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       class="button button-default button-medium pill-shape icon-right"
-      id="dropdown-reference"
+      id="test-button-id"
       role="button"
       tabindex="0"
     >

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -156,6 +156,16 @@ describe('Select', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('Renders without stealing focus', () => {
+    const defaultValue = 'option2';
+    const { getByDisplayValue } = render(
+      <Select options={options} defaultValue={defaultValue} />
+    );
+    const select = getByDisplayValue('Option 2');
+    expect(select).toBeTruthy();
+    expect(document.activeElement === select).toBe(false);
+  });
+
   test('Updates the selected value', async () => {
     const defaultValue = 'option2';
     const handleChange = jest.fn();

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -175,6 +175,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
           hideOption: false,
           id: option.text + index,
           object: option.object,
+          role: 'option',
           ...option,
         }))
       );
@@ -226,7 +227,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
       // When dropdown not visible and select is filterable
       // reset the search query and visibility of the options.
-      if (!dropdownVisible && filterable) {
+      if (prevDropdownVisible && !dropdownVisible && filterable) {
         resetSelectOnDropdownHide();
       }
 
@@ -561,6 +562,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         ({ hideOption, ...opt }) => ({
           ...opt,
           classNames: mergeClasses([{ [styles.selectedOption]: opt.selected }]),
+          role: 'option',
         })
       );
       if (filteredOptions.length > 0) {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -140,7 +140,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       ? size
       : contextuallySized || size;
 
-    let timeout: ReturnType<typeof setTimeout>;
+    const firstRender: React.MutableRefObject<boolean> = useRef(true);
 
     const getSelectedOptionValues = (): SelectOption['value'][] => {
       return options
@@ -180,6 +180,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
     // Update options on change
     useEffect(() => {
       onOptionsChange?.(getSelectedOptionValues(), getSelectedOptions());
+
+      // Determine first render to help determine the Select interaction is intentional
+      if (firstRender.current) {
+        firstRender.current = false;
+        return;
+      }
       if (multiple) {
         inputRef.current?.focus();
       } else {
@@ -310,6 +316,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       const { target } = event;
       const value: string = target?.value || '';
       const valueLowerCase: string = value?.toLowerCase();
+      console.log(document.activeElement);
       setSearchQuery(value);
       if (loadOptions) {
         return loadOptions(value);

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -316,7 +316,6 @@ export const Select: FC<SelectProps> = React.forwardRef(
       const { target } = event;
       const value: string = target?.value || '';
       const valueLowerCase: string = value?.toLowerCase();
-      console.log(document.activeElement);
       setSearchQuery(value);
       if (loadOptions) {
         return loadOptions(value);

--- a/src/hooks/usePreviousState.test.tsx
+++ b/src/hooks/usePreviousState.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { usePreviousState } from './usePreviousState';
+
+describe('usePreviousState', () => {
+  it('should return the previous value after a re-render', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => usePreviousState(value),
+      {
+        initialProps: { value: 0 },
+      }
+    );
+
+    // initial render, the previous value should be undefined
+    expect(result.current).toBeUndefined();
+
+    // update the value and rerender the hook
+    act(() => {
+      rerender({ value: 1 });
+    });
+
+    // the previous value should be the previous value, which is 0
+    expect(result.current).toEqual(0);
+
+    // update the value again and rerender the hook
+    act(() => {
+      rerender({ value: 2 });
+    });
+
+    // the previous value should be the previous value, which is 1
+    expect(result.current).toEqual(1);
+  });
+});

--- a/src/hooks/usePreviousState.ts
+++ b/src/hooks/usePreviousState.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react';
+
+export const usePreviousState = (value: any) => {
+  const ref: React.MutableRefObject<any> = useRef();
+
+  // useEffect when the value of 'value' changes
+  useEffect(() => {
+    // Assign the value of ref to the argument
+    ref.current = value;
+  }, [value]);
+
+  // return the current ref value.
+  return ref.current;
+};


### PR DESCRIPTION
## SUMMARY:

- Fixes `Select` focus steal on init by checking `firstRender` in the options change `useEffect`
- Fixes bug in `Dropdown` where the inherited id of the locally cloned element was being overridden by the component
- Fixes bug in smartApply where re-render caused the `defaultValue` to be `''`
- Fixes bug in smartApply where the option `role` was being overridden by `menuitem` default

## JIRA TASK (Eightfold Employees Only):
ENG-51660

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn`, `yarn test` and `yarn storybook`. Verify all tests pass and the `Dropdown`, `Menu` and `Select` stories behave as expected.