### PR TITLE
fix: dropdown: fix visible prop

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import {
@@ -10,6 +10,7 @@ import {
 import { Icon, IconName } from '../Icon';
 import { Dropdown } from './';
 import { List } from '../List';
+import { Stack } from '../Stack';
 
 export default {
   title: 'Dropdown',
@@ -192,6 +193,37 @@ const Dropdown_Div_Story: ComponentStory<typeof Dropdown> = (args) => {
 
 export const Dropdown_Div = Dropdown_Div_Story.bind({});
 
+const Dropdown_External_Story: ComponentStory<typeof Dropdown> = (args) => {
+  const [visible, setVisibility] = useState(false);
+  return (
+    <Stack direction="horizontal" flexGap="xxl">
+      <DefaultButton
+        alignIcon={ButtonIconAlign.Right}
+        checked={visible}
+        onClick={() => setVisibility(!visible)}
+        text={'External Control'}
+        toggle
+      />
+      <Dropdown
+        {...args}
+        visible={visible}
+        onVisibleChange={(isVisible) => setVisibility(isVisible)}
+      >
+        <DefaultButton
+          alignIcon={ButtonIconAlign.Right}
+          text={'Click button start'}
+          iconProps={{
+            path: IconName.mdiChevronDown,
+            rotate: visible ? 180 : 0,
+          }}
+        />
+      </Dropdown>
+    </Stack>
+  );
+};
+
+export const Dropdown_External = Dropdown_External_Story.bind({});
+
 const dropdownArgs: Object = {
   trigger: 'click',
   classNames: 'my-dropdown-class',
@@ -216,5 +248,9 @@ Dropdown_Div.args = {
 };
 
 Dropdown_IconButton.args = {
+  ...dropdownArgs,
+};
+
+Dropdown_External.args = {
   ...dropdownArgs,
 };

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -116,6 +116,38 @@ const ComplexDropdownComponent = (): JSX.Element => {
   );
 };
 
+const ExternalElementDropdownComponent = (): JSX.Element => {
+  const [visible, setVisibility] = useState(false);
+
+  return (
+    <Stack direction="horizontal" flexGap="xxl">
+      <DefaultButton
+        alignIcon={ButtonIconAlign.Right}
+        checked={visible}
+        data-testid="test-external-button-id"
+        onClick={() => setVisibility(!visible)}
+        text={'External Control'}
+        toggle
+      />
+      <Dropdown
+        {...dropdownProps}
+        visible={visible}
+        onVisibleChange={(isVisible) => setVisibility(isVisible)}
+      >
+        <DefaultButton
+          alignIcon={ButtonIconAlign.Right}
+          text={'Dropdown menu test'}
+          iconProps={{
+            path: IconName.mdiChevronDown,
+            rotate: visible ? 180 : 0,
+          }}
+          data-testid="test-button-id"
+        />
+      </Dropdown>
+    </Stack>
+  );
+};
+
 describe('Dropdown', () => {
   beforeAll(() => {
     matchMedia = new MatchMediaMock();
@@ -180,5 +212,24 @@ describe('Dropdown', () => {
       'my-dropdown-class'
     );
     expect(dropdownAriaRef.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  test('Should support visible prop toggle via external element', async () => {
+    const { container } = render(<ExternalElementDropdownComponent />);
+    const externalElement = screen.getByTestId('test-external-button-id');
+    const referenceElement = screen.getByTestId('test-button-id');
+    externalElement.click();
+    await waitFor(() => screen.getByText('User profile 1'));
+    const option1 = screen.getByText('User profile 1');
+    expect(option1).toBeTruthy();
+    expect(container.querySelector('.dropdown-wrapper')?.classList).toContain(
+      'my-dropdown-class'
+    );
+    expect(referenceElement.getAttribute('aria-expanded')).toBe('true');
+    externalElement.click();
+    await waitFor(() =>
+      expect(referenceElement.getAttribute('aria-expanded')).toBe('false')
+    );
+    expect(container.querySelector('.dropdown-wrapper')).toBeFalsy();
   });
 });


### PR DESCRIPTION
## SUMMARY:
Previously the `Dropdown` `visible` prop toggle via an external element was being prevented by `useOnClickOutside`. Additionally, there was a bug where the `close` `useState` property was not resetting via `setClosing(!updatedShow);` in the `toggle` function. If the `Dropdown` was previously `visible` via the reference click and then set programmatically via `visible`, the close class was appended once `mergeVisible` is true, causing the visual hide of CSS because both `open` and `close` classes were injected at the same time in `dropdownClasses` once `mergeVisible` is true. Now we check the previous state of close in the `toggle` `timeout` and reset it.


https://github.com/EightfoldAI/octuple/assets/99700808/e835489b-597b-46ce-bf57-9fdcd7510c3f


## JIRA TASK (Eightfold Employees Only):
ENG-47043


## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Dropdown` stories behave as expected.