### PR TITLE
fix: dropdown: tweak css slideupin animation

### DIFF
--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -33,13 +33,17 @@
   overflow-y: auto;
 
   &.open {
-    animation: slideUpIn $motion-duration-extra-fast $motion-easing-easeinout 0s
-      forwards;
+    animation-name: slideUpIn;
+    animation-duration: $motion-duration-extra-fast;
+    animation-timing-function: $motion-easing-easeout;
+    animation-fill-mode: forwards;
   }
 
   &.close {
-    animation: slideUpOut $motion-duration-extra-fast $motion-easing-easeinout
-      0s forwards;
+    animation-name: slideUpOut;
+    animation-duration: $motion-duration-extra-fast;
+    animation-timing-function: $motion-easing-easein;
+    animation-fill-mode: forwards;
   }
 
   &.no-padding {
@@ -65,11 +69,6 @@
   0% {
     opacity: 0;
     transform: scaleY(0.8);
-    transform-origin: 0% 0%;
-  }
-  20% {
-    opacity: 1;
-    transform: scaleY(1);
     transform-origin: 0% 0%;
   }
   100% {

--- a/src/components/Dropdown/dropdown.module.scss
+++ b/src/components/Dropdown/dropdown.module.scss
@@ -67,6 +67,11 @@
     transform: scaleY(0.8);
     transform-origin: 0% 0%;
   }
+  20% {
+    opacity: 1;
+    transform: scaleY(1);
+    transform-origin: 0% 0%;
+  }
   100% {
     opacity: 1;
     transform: scaleY(1);


### PR DESCRIPTION
## SUMMARY:
Updates `Dropdown` CSS animation to reduce time in perceptible milliseconds between execution and completion. Removes 0s delay parameter and updates Penner curves to match those used with `DatePicker`, for smoother results.


https://github.com/EightfoldAI/octuple/assets/99700808/d8fb37a1-7029-4482-8e89-c96400b7c199


## JIRA TASK (Eightfold Employees Only):
ENG-53146

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the Dropdown shows and hides as expected.