### PR TITLE
fix: pill: ensure pill heights match latest design specification

### DIFF
--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -63,6 +63,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
 
     const labelClassNames: string = mergeClasses([
       styles.label,
+      { [styles.large]: size === PillSize.Large },
       { [styles.medium]: size === PillSize.Medium },
       { [styles.small]: size === PillSize.Small },
       { [styles.xsmall]: size === PillSize.XSmall },
@@ -73,6 +74,9 @@ export const Pill: FC<PillProps> = React.forwardRef(
       styles.tagPills,
       classNames,
       (styles as any)[theme],
+      { [styles.large]: size === PillSize.Large },
+      { [styles.medium]: size === PillSize.Medium },
+      { [styles.small]: size === PillSize.Small },
       { [styles.xsmall]: size === PillSize.XSmall },
       { [styles.tagPillsDisabled]: mergedDisabled },
       { [styles.tagPillsRtl]: htmlDir === 'rtl' },

--- a/src/components/Pills/__snapshots__/Pill.test.tsx.snap
+++ b/src/components/Pills/__snapshots__/Pill.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Pill Pill should render as closable 1`] = `
 <div>
   <div
-    class="tag-pills blue"
+    class="tag-pills blue medium"
   >
     <span
       class="label medium"
@@ -38,7 +38,7 @@ exports[`Pill Pill should render as closable 1`] = `
 exports[`Pill Pill should render normally 1`] = `
 <div>
   <div
-    class="tag-pills blue read-only"
+    class="tag-pills blue medium read-only"
   >
     <span
       class="label medium"
@@ -52,7 +52,7 @@ exports[`Pill Pill should render normally 1`] = `
 exports[`Pill Pill should render with a theme 1`] = `
 <div>
   <div
-    class="tag-pills white read-only"
+    class="tag-pills white medium read-only"
   >
     <span
       class="label medium"
@@ -66,7 +66,7 @@ exports[`Pill Pill should render with a theme 1`] = `
 exports[`Pill Pill should render with button 1`] = `
 <div>
   <div
-    class="tag-pills blue"
+    class="tag-pills blue medium"
   >
     <span
       class="label medium"
@@ -109,7 +109,7 @@ exports[`Pill Pill should render with button 1`] = `
 exports[`Pill Pill should render with icon 1`] = `
 <div>
   <div
-    class="tag-pills blue read-only"
+    class="tag-pills blue medium read-only"
   >
     <span
       aria-hidden="false"
@@ -139,7 +139,7 @@ exports[`Pill Pill should render with icon 1`] = `
 exports[`Pill Pill should render with icon to the end of its label 1`] = `
 <div>
   <div
-    class="tag-pills blue read-only"
+    class="tag-pills blue medium read-only"
   >
     <span
       class="label medium"

--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -3,8 +3,8 @@
   --label: var(--blue-color);
   --hover-bg: var(--blue-color-30);
   --hover-label: var(--text-primary-color);
-  padding: $space-xxs $space-s;
-  border-radius: $border-radius-m;
+  padding: 5px $space-xs;
+  border-radius: 6px;
   transition: all $motion-duration-extra-fast $motion-easing-easeinout 0s;
   background: var(--bg);
   color: var(--label);
@@ -13,17 +13,23 @@
   align-items: center;
 
   .label {
-    font-family: $octuple-font-family;
-    font-size: $text-font-size-5;
+    font-family: var(--font-stack-full);
     font-weight: $text-font-weight-semibold;
+
+    &.large {
+      font-size: $text-font-size-5;
+      line-height: $text-line-height-3;
+    }
 
     &.medium {
       font-size: $text-font-size-3;
+      line-height: $text-line-height-2;
     }
 
     &.small,
     &.xsmall {
       font-size: $text-font-size-2;
+      line-height: $text-line-height-1;
     }
 
     &.line-clamp {
@@ -120,7 +126,25 @@
     --bg: var(--white-color);
     --label: var(--grey-color-60);
     --hover-bg: var(--grey-color-10);
-    border: 1px solid var(--grey-color-60);
+
+    &:not(.xsmall) {
+      border: 1px solid var(--grey-color-60);
+    }
+  }
+
+  &.large {
+    padding: 10px $space-xs;
+  }
+
+  &.medium {
+    border-radius: 6px;
+    padding: 5px $space-xs;
+  }
+
+  &.small,
+  &.xsmall {
+    border-radius: $border-radius-s;
+    padding: $space-xxs $space-xxs;
   }
 
   &:hover:not(.tag-pills-disabled) {

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`Select Renders with default values when multiple 1`] = `
       class="multi-select-pills"
     >
       <div
-        class="tag-pills multi-select-pill blue-green"
+        class="tag-pills multi-select-pill blue-green medium"
         id="selectPillOption 2-1"
         style="visibility: hidden;"
       >
@@ -114,7 +114,7 @@ exports[`Select Renders with default values when multiple 1`] = `
         </button>
       </div>
       <div
-        class="tag-pills multi-select-pill blue-green"
+        class="tag-pills multi-select-pill blue-green medium"
         id="selectPillOption 3-2"
         style="visibility: hidden;"
       >


### PR DESCRIPTION
## SUMMARY:
Pill component height is determined by the `line-height` of its content because it may wrap via `lineclamp` prop. This change adjusts the `line-height` so it's not a float, updates `padding` as necessary to match the following spec:

`PillSize.Large` = `44px`
`PillSize.Medium` = `30px`
`PillSize.Small` and `PillSize.XSmall` = `24px`

The medium size `Pill` spec also requires the `border-radius` to be `6px`, as this isn't snapped to the base 4 grid, it will not be referenced from SASS variable definitions. Some padding also needs to be local to the module as the base 4 `line-height` effects that spacing relative to the `font-size`.


https://github.com/EightfoldAI/octuple/assets/99700808/6147123d-4db7-4c8c-ac34-8fbcb1cba9b3


[Figma Specification (Eightfold internal only)](https://www.figma.com/file/SlKRC7oKF7XZyHMv2op4ch/Octuple-DS-(Theme-2)?type=design&node-id=560-606&t=f51rWYLNhhyNCWQR-0)

## JIRA TASK (Eightfold Employees Only):
ENG-51328

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (CSS only UI snaps updated with this change)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Pill` stories behave as expected.