### PR TITLE
fix: select: ensure medium and large pills fit inside inputs of same size

### DIFF
--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -1,4 +1,4 @@
-$input-padding-horizontal: 8px;
+$input-padding-horizontal: $space-xs;
 $multi-select-count-offset: 54px;
 
 // Export values for typescript consumption.
@@ -63,6 +63,7 @@ $multi-select-count-offset: 54px;
     text-align: center;
     display: flex;
     justify-content: center;
+    padding: 3px $space-xs;
     pointer-events: all;
 
     span {
@@ -73,6 +74,7 @@ $multi-select-count-offset: 54px;
 
   .multi-select-count {
     margin-right: $space-xs;
+    padding: 3px $space-xs;
   }
 
   .selected-option {
@@ -83,17 +85,22 @@ $multi-select-count-offset: 54px;
   &.select-large {
     .multi-select-pills {
       top: 7px;
+
+      .multi-select-count,
+      .multi-select-pill {
+        padding: 3px $space-xs;
+      }
     }
 
     .select-clear-button {
       bottom: 0;
       height: 44px;
-      padding: 4px 8px;
-      width: 32px;
+      padding: $space-xxs $space-xs;
+      width: $space-xl;
     }
 
     .select-clear-button-start {
-      left: 2px;
+      left: $space-xxxs;
       right: unset;
     }
 
@@ -106,17 +113,22 @@ $multi-select-count-offset: 54px;
   &.select-medium {
     .multi-select-pills {
       top: 5px;
+
+      .multi-select-count,
+      .multi-select-pill {
+        padding: 3px $space-xs;
+      }
     }
 
     .select-clear-button {
-      bottom: 4px;
+      bottom: $space-xxs;
       height: 28px;
-      padding: 4px 6px;
+      padding: $space-xxs 6px;
       width: 28px;
     }
 
     .select-clear-button-start {
-      left: 2px;
+      left: $space-xxxs;
       right: unset;
     }
 
@@ -128,23 +140,23 @@ $multi-select-count-offset: 54px;
 
   &.select-small {
     .multi-select-pills {
-      top: 4px;
+      top: $space-xxs;
 
       .multi-select-count,
       .multi-select-pill {
-        padding: 2px 12px;
+        padding: $space-xxxs $space-s;
       }
     }
 
     .select-clear-button {
-      bottom: 2px;
-      height: 24px;
-      padding: 2px 4px;
-      width: 24px;
+      bottom: $space-xxxs;
+      height: $space-l;
+      padding: $space-xxxs $space-xxs;
+      width: $space-l;
     }
 
     .select-clear-button-start {
-      left: 2px;
+      left: $space-xxxs;
       right: unset;
     }
 


### PR DESCRIPTION
## SUMMARY:
The updated `Pill` sizes are now the same vertical size as `TextInput`. This change ensures that when a `Pill` is presented as a child of a Multiple `Select` `TextInput`, they fit as expected.


https://github.com/EightfoldAI/octuple/assets/99700808/d83f2061-4746-4e97-9f2a-547b54ec11b3


## JIRA TASK (Eightfold Employees Only):
ENG-54999

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (caught via ad hoc test)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the Multiple `Select` story behaves as expected in Small, Medium and Large sizes when selecting options.