### PR TITLE
fix: slider: increase vertical hit target and handle segmented gap clicks

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -568,6 +568,14 @@ export const Slider: FC<SliderProps> = React.forwardRef(
       }
     };
 
+    const onSliderHitTargetClick = (
+      event: React.MouseEvent<HTMLDivElement>
+    ): void => {
+      event.preventDefault();
+
+      onSliderMouseDown(event);
+    };
+
     const onSliderMouseDown = (
       event: React.MouseEvent<HTMLDivElement>
     ): void => {
@@ -726,6 +734,14 @@ export const Slider: FC<SliderProps> = React.forwardRef(
               ref={sliderRef}
               className={mergeClasses(styles.slider, classNames)}
             >
+              <div
+                className={styles.sliderHitTarget}
+                onClick={
+                  !allowDisabledFocus && !readOnly
+                    ? onSliderHitTargetClick
+                    : null
+                }
+              />
               <div
                 ref={railRef}
                 className={mergeClasses([

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -841,6 +841,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     styles.sliderTooltip,
                     tooltipProps?.classNames,
                   ])}
+                  closeOnReferenceClick={false}
                   content={getTooltipContentByValue(val)}
                   key={`value-tooltip-${index}`}
                   offset={thumbGeometry().diameter + THUMB_TOOLTIP_Y_OFFSET}

--- a/src/components/Slider/slider.module.scss
+++ b/src/components/Slider/slider.module.scss
@@ -138,6 +138,18 @@ $small-min-label-offset-with-steps: 0;
     }
   }
 
+  .rail-marker-segments {
+    pointer-events: none;
+  }
+
+  .slider-hit-target {
+    cursor: pointer;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    width: 100%;
+  }
+
   .slider-rail,
   .slider-track,
   .rail-marker-segments {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -177,6 +177,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
           }
           if (
             !closeOnReferenceClick &&
+            referenceElement &&
             !referenceElement.contains(e.target as Node)
           ) {
             toggle(false)(e);


### PR DESCRIPTION
## SUMMARY:

- Adds a hit target element equal to the height of the `Slider` input + thumb
- Ensures track and rail events are not called twice by adding a new handler
- Ensures clicks between segments are handled when `showMarkers`
- Ensures `Slider` `Tooltip` doesn't dismiss on reference element click by default so value may be passed to it if needed.


https://github.com/EightfoldAI/octuple/assets/99700808/ece38bc6-a377-4e4a-8100-08e155508df3


https://github.com/EightfoldAI/octuple/assets/99700808/24fc4fe8-cdce-4a38-b74c-74c4351b6ddd


## JIRA TASK (Eightfold Employees Only):
ENG-54321
ENG-54319

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Slider` stories behave as expected.