### PR TITLE
fix: matchscore: color contrast and vertical alignment fix up

### DIFF
--- a/src/components/MatchScore/matchScore.module.scss
+++ b/src/components/MatchScore/matchScore.module.scss
@@ -1,13 +1,14 @@
-$indicator-size: 12px;
+$indicator-size: $space-s;
 
 .match-score-container {
   display: flex;
   align-items: center;
 
   .label {
-    color: var(--primary-secondary-color);
-    font-family: $octuple-font-family;
+    color: var(--match-score-text-color);
+    font-family: var(--font-stack-full);
     font-size: $text-font-size-3;
+    line-height: $indicator-size;
     margin: 0;
     margin-left: $space-xxs;
   }
@@ -16,22 +17,23 @@ $indicator-size: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid var(--primary-tertiary-color);
+    border: 1px solid var(--match-score-background-color);
     box-sizing: border-box;
     height: $indicator-size;
     width: $indicator-size;
     border-radius: 50%;
+    margin-top: $space-xxxs;
     margin-right: $space-xxs;
 
     &.full {
-      background: var(--accent-background3-color);
+      background: var(--match-score-background-color);
     }
 
     &.half {
-      background: var(--accent-background3-color);
+      background: var(--match-score-background-color);
       background: linear-gradient(
         to right,
-        var(--accent-background3-color) 50%,
+        var(--match-score-background-color) 50%,
         transparent 50%
       );
 
@@ -39,7 +41,7 @@ $indicator-size: 12px;
         content: '';
         height: $indicator-size;
         width: 1px;
-        background: var(--primary-tertiary-color);
+        background: var(--match-score-background-color);
       }
     }
   }
@@ -57,7 +59,7 @@ $indicator-size: 12px;
       &.half {
         background: linear-gradient(
           to left,
-          var(--accent-background3-color) 50%,
+          var(--match-score-background-color) 50%,
           transparent 50%
         );
       }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -1047,4 +1047,9 @@
   --pill-small-size-border-radius: var(--border-radius-s);
   --pill-xsmall-size-border-radius: var(--border-radius-s);
   // ------ Pill theme ------
+
+  // ------ Match Score theme ------
+  --match-score-background-color: var(--primary-tertiary-color);
+  --match-score-text-color: var(--primary-secondary-color);
+  // ------ Match Score theme ------
 }


### PR DESCRIPTION
## SUMMARY:

- Ensures `MatchScore` dots adhere to 3:5:1 color contrast baseline by using the latest Figma spec tertiary blue
- Fixes vertical center alignment of dots when label is present

Before:
![matchscoreCurrent](https://github.com/EightfoldAI/octuple/assets/99700808/eaaaf2e6-1831-4060-aeb0-04e7f48014c3)

After:
![matchscoreUpdated](https://github.com/EightfoldAI/octuple/assets/99700808/a1a34164-4944-4789-90c7-2516761f4cc9)


## JIRA TASK (Eightfold Employees Only):\
ENG-55945

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (CSS only change)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `MatchScore` stories behave as expected.