### PR TITLE
fix: tabs: pill variant color contrast fix up

### DIFF
--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -124,17 +124,20 @@
     --tab-label: var(--tab-pill-label);
     --tab-active-label: var(--tab-pill-active-label);
     --tab-active-background: var(--tab-pill-active-background);
+    --tab-active-border: var(--tab-pill-active-border);
     --tab-hover-label: var(--tab-pill-hover-label);
     background-color: var(--tab-pill-background);
-    width: fit-content;
     border-radius: var(--tab-pill-border-radius);
     padding: var(--tab-pill-medium-padding);
+    width: fit-content;
 
     .tab {
-      padding: $button-padding-vertical-medium $button-padding-horizontal-medium;
+      border: var(--tab-pill-border);
       border-radius: var(--tab-pill-border-radius);
+      padding: $button-padding-vertical-medium $button-padding-horizontal-medium;
 
       &.active {
+        border: var(--tab-pill-active-border);
         .badge {
           background-color: var(--primary-background1-color);
         }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -427,9 +427,19 @@
   --tab-pill-large-padding: 8px;
   --tab-pill-medium-padding: 6px;
   --tab-pill-small-padding: 4px;
+  --tab-pill-border-color: var(--grey-background1-color);
+  --tab-pill-border-style: solid;
+  --tab-pill-border-width: 1px;
+  --tab-pill-border: var(--tab-pill-border-width) var(--tab-pill-border-style)
+    var(--tab-pill-border-color);
   --tab-pill-label: var(--text-secondary-color);
   --tab-pill-active-label: var(--primary-color);
   --tab-pill-active-background: var(--primary-background2-color);
+  --tab-pill-active-border-color: var(--primary-tertiary-color);
+  --tab-pill-active-border-style: solid;
+  --tab-pill-active-border-width: 1px;
+  --tab-pill-active-border: var(--tab-pill-active-border-width)
+    var(--tab-pill-active-border-style) var(--tab-pill-active-border-color);
   --tab-pill-hover-label: var(--primary-color);
   --tab-pill-background: var(--grey-background1-color);
   --tab-underline: var(--border-color);


### PR DESCRIPTION
## SUMMARY:
- Ensure `Tabs` `Pill` variant selected tab adheres to 3:5:1 color contrast ratio
- Adds CSS Variables

Before:
![tabpillsCurrent](https://github.com/EightfoldAI/octuple/assets/99700808/31726d26-eb70-4a2b-a03d-4643c7e205ca)

After:
![tabpillsUpdated](https://github.com/EightfoldAI/octuple/assets/99700808/733fd281-da0e-4824-984a-db7e930f6606)


## JIRA TASK (Eightfold Employees Only):
ENG-55940

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (CSS only change)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify `Tabs` stories behave as expected.