### PR TITLE
fix: select: revert update selected option based on defaultValue when isLoading

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -214,7 +214,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
           opt.selected,
       }));
       setOptions(updatedOptions);
-    }, [defaultValue, isLoading]);
+    }, [defaultValue]);
 
     useEffect(() => {
       // When filterable and not multiple if the input value does not match


### PR DESCRIPTION
## SUMMARY:
Reverts [PR 631](https://github.com/EightfoldAI/octuple/pull/631) pending further investigation of how to improve isLoading.

## JIRA TASK (Eightfold Employees Only):
ENG-55821

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
N/A