### PR TITLE
fix: select: Update selected option based on defaultValue when isLoading changes

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -179,7 +179,26 @@ export const Select: FC<SelectProps> = React.forwardRef(
           ...option,
         }))
       );
-    }, [_options, isLoading]);
+    }, [_options]);
+
+    // Populate options on isLoading change
+    useEffect(() => {
+      const selected: SelectOption[] = options.filter(
+        (opt: SelectOption) => opt.selected
+      );
+      setOptions(
+        _options.map((option: SelectOption, index: number) => ({
+          selected:
+            !!selected.find((opt) => opt.value === option.value) ||
+            option.value === defaultValue,
+          hideOption: false,
+          id: option.text + index,
+          object: option.object,
+          role: 'option',
+          ...option,
+        }))
+      );
+    }, [isLoading]);
 
     // Update options on change
     useEffect(() => {


### PR DESCRIPTION
## SUMMARY:
Options array is updated to consider defaultValue in case defaultValue prop is passed. But if the options are passed asynchronously then options array might be empty when the hook runs. So to consider defaultValue prop is respected on isLoading changes we implement a separate useEffect hook that updates options on isLoading changes.

## GITHUB ISSUE (Open Source Contributors)
NA
## JIRA TASK (Eightfold Employees Only):
NA
## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Tested previously failing seleniums are passing. [Please find recording attached.]
2. Tested the parts of code that use defaultValue with isLoading in vscode are working properly. I've tested following paths:
```
www/react/src/apps/insights/components/DataHub/SQLEditor.js
www/react/src/apps/profile/components/AddNotesTags/AddNote/index.js
```
**Video recording for seleniums that were failing in previous release PR:**
https://drive.google.com/file/d/1eDqgCRXva6KIgRwHcG1vV-cOSti3xCI3/view?usp=sharing