### PR TITLE
chore: storybook: update named export order to be more consistent using babel

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ['babel-plugin-named-exports-order'],
+};

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "babel-jest": "27.4.2",
     "babel-loader": "8.2.3",
     "babel-plugin-named-asset-import": "0.3.8",
+    "babel-plugin-named-exports-order": "0.0.2",
     "babel-preset-react-app": "10.0.1",
     "bfj": "7.0.2",
     "browserslist": "4.18.1",

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -82,19 +82,20 @@ const Single_Story: ComponentStory<typeof Accordion> = (args) => (
   <Accordion {...args} />
 );
 
+const List_Story: ComponentStory<typeof List> = (args) => <List {...args} />;
+
 export const Single = Single_Story.bind({});
+export const List_Vertical = List_Story.bind({});
+export const List_Horizontal = List_Story.bind({});
 
-const List_Vertical_Story: ComponentStory<typeof List> = (args) => (
-  <List {...args} />
-);
-
-export const List_Vertical = List_Vertical_Story.bind({});
-
-const List_Horizontal_Story: ComponentStory<typeof List> = (args) => (
-  <List {...args} />
-);
-
-export const List_Horizontal = List_Horizontal_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Single',
+  'List_Vertical',
+  'List_Horizontal',
+];
 
 Single.args = {
   children: (

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -47,41 +47,21 @@ const imageProps = {
   alt: 'random profile image',
 };
 
-const Avatar_Default_Story: ComponentStory<typeof Avatar> = (args) => (
+const Avatar_Story: ComponentStory<typeof Avatar> = (args) => (
   <Avatar {...args} />
 );
-
-export const Avatar_Default = Avatar_Default_Story.bind({});
-
-const Avatar_Icon_Story: ComponentStory<typeof Avatar> = (args) => (
-  <Avatar {...args} />
-);
-
-export const Avatar_Icon = Avatar_Icon_Story.bind({});
 
 const Avatar_Round_Story: ComponentStory<typeof Avatar> = (args) => (
   <Avatar popupProps={{ content: 'A popup' }} {...args} />
 );
 
-export const Avatar_Round = Avatar_Round_Story.bind({});
-
-const Avatar_Round_Icon_Story: ComponentStory<typeof Avatar> = (args) => (
-  <Avatar {...args} />
-);
-
-export const Avatar_Round_Icon = Avatar_Round_Icon_Story.bind({});
-
 const Avatar_Fallback_Theme_Story: ComponentStory<typeof Avatar> = (args) => (
   <Avatar {...args} theme="green" />
 );
 
-export const Avatar_Fallback_Theme = Avatar_Fallback_Theme_Story.bind({});
-
 const Avatar_Fallback_Hashing_Story: ComponentStory<typeof Avatar> = (args) => (
   <Avatar {...args} hashingFunction={() => 3} />
 );
-
-export const Avatar_Fallback_Hashing = Avatar_Fallback_Hashing_Story.bind({});
 
 const Avatar_StatusItem_Story: ComponentStory<typeof Avatar> = (args) => {
   const avatarSize = 100;
@@ -230,13 +210,32 @@ const Avatar_StatusItem_Story: ComponentStory<typeof Avatar> = (args) => {
   );
 };
 
-export const Avatar_StatusItem = Avatar_StatusItem_Story.bind({});
-
 const Avatar_Tooltip_Story: ComponentStory<typeof Avatar> = (args) => (
   <Avatar {...args} theme="red" />
 );
 
+export const Avatar_Default = Avatar_Story.bind({});
+export const Avatar_Icon = Avatar_Story.bind({});
+export const Avatar_Round = Avatar_Round_Story.bind({});
+export const Avatar_Round_Icon = Avatar_Story.bind({});
+export const Avatar_Fallback_Theme = Avatar_Fallback_Theme_Story.bind({});
+export const Avatar_Fallback_Hashing = Avatar_Fallback_Hashing_Story.bind({});
+export const Avatar_StatusItem = Avatar_StatusItem_Story.bind({});
 export const Avatar_Tooltip = Avatar_Tooltip_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Avatar_Default',
+  'Avatar_Icon',
+  'Avatar_Round',
+  'Avatar_Round_Icon',
+  'Avatar_Fallback_Theme',
+  'Avatar_Fallback_Hashing',
+  'Avatar_StatusItem',
+  'Avatar_Tooltip',
+];
 
 const avatarArgs: Object = {
   children: 'JD',

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -198,12 +198,6 @@ const Basic_Story: ComponentStory<typeof AvatarGroup> = (args) => (
   </AvatarGroup>
 );
 
-export const Basic = Basic_Story.bind({});
-
-export const Basic_Spaced = Basic_Story.bind({});
-
-export const Basic_Max_Props_Exceed_Children = Basic_Story.bind({});
-
 const List_Story: ComponentStory<typeof AvatarGroup> = (args) => (
   <AvatarGroup
     animateOnHover
@@ -246,11 +240,24 @@ const List_Story: ComponentStory<typeof AvatarGroup> = (args) => (
   />
 );
 
+export const Basic = Basic_Story.bind({});
+export const Basic_Spaced = Basic_Story.bind({});
+export const Basic_Max_Props_Exceed_Children = Basic_Story.bind({});
 export const List_Group = List_Story.bind({});
-
 export const List_Group_Spaced = List_Story.bind({});
-
 export const List_Group_Max_Props_Exceed_Children = List_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Basic_Spaced',
+  'Basic_Max_Props_Exceed_Children',
+  'List_Group',
+  'List_Group_Spaced',
+  'List_Group_Max_Props_Exceed_Children',
+];
 
 const avatarGroupArgs: Object = {
   classNames: 'my-avatar-group-class',

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -28,23 +28,20 @@ export default {
   },
 } as ComponentMeta<typeof Badge>;
 
-const Badge_Default_Story: ComponentStory<typeof Badge> = (args) => (
-  <Badge {...args} />
-);
+const Badge_Story: ComponentStory<typeof Badge> = (args) => <Badge {...args} />;
 
-export const Badge_Default = Badge_Default_Story.bind({});
+export const Badge_Default = Badge_Story.bind({});
+export const Badge_Active = Badge_Story.bind({});
+export const Badge_Disruptive = Badge_Story.bind({});
 
-const Badge_Active_Story: ComponentStory<typeof Badge> = (args) => (
-  <Badge {...args} />
-);
-
-export const Badge_Active = Badge_Active_Story.bind({});
-
-const Badge_Disruptive_Story: ComponentStory<typeof Badge> = (args) => (
-  <Badge {...args} />
-);
-
-export const Badge_Disruptive = Badge_Disruptive_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Badge_Default',
+  'Badge_Active',
+  'Badge_Disruptive',
+];
 
 const badgeArgs: Object = {
   active: false,

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -179,6 +179,23 @@ export const Split = Button_Story.bind({});
 export const Split_With_Counter = Button_Story.bind({});
 export const Floating_Button = Button_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Primary',
+  'Counter',
+  'Secondary',
+  'Default',
+  'Neutral',
+  'System_UI',
+  'Toggle',
+  'Toggle_With_Counter',
+  'Split',
+  'Split_With_Counter',
+  'Floating_Button',
+];
+
 const buttonArgs: Object = {
   alignIcon: ButtonIconAlign.Left,
   alignText: ButtonTextAlign.Center,

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -31,17 +31,15 @@ export default {
   },
 } as ComponentMeta<typeof Card>;
 
-const Base_Card_Story: ComponentStory<typeof Card> = (args) => (
-  <Card {...args} />
-);
+const Card_Story: ComponentStory<typeof Card> = (args) => <Card {...args} />;
 
-export const BaseCard = Base_Card_Story.bind({});
+export const BaseCard = Card_Story.bind({});
+export const CustomCard = Card_Story.bind({});
 
-const Custom_Card_Story: ComponentStory<typeof Card> = (args) => (
-  <Card {...args} />
-);
-
-export const CustomCard = Custom_Card_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['BaseCard', 'CustomCard'];
 
 const baseCardArgs: Object = {
   dropShadow: true,

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -98,6 +98,11 @@ export const Slider = Slide_Story.bind({});
 export const Scroller = Scroll_Story.bind({});
 export const Scroller_Single = Scroll_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Slider', 'Scroller', 'Scroller_Single'];
+
 const carouselArgs: Object = {
   classNames: 'my-carousel',
   controls: true,

--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -106,15 +106,11 @@ const CheckBox_Story: ComponentStory<typeof CheckBox> = (args) => (
   <CheckBox checked={true} {...args} />
 );
 
-export const Check_Box = CheckBox_Story.bind({});
-
 const CheckBox_Long_text_Story: ComponentStory<typeof CheckBox> = (args) => (
   <div style={{ width: 200 }}>
     <CheckBox checked={true} {...args} />
   </div>
 );
-
-export const Check_Box_Long_Text = CheckBox_Long_text_Story.bind({});
 
 const CheckBoxGroup_Story: ComponentStory<typeof CheckBoxGroup> = (args) => {
   const [selected, setSelected] = useState<CheckboxValueType[]>([]);
@@ -130,7 +126,18 @@ const CheckBoxGroup_Story: ComponentStory<typeof CheckBoxGroup> = (args) => {
   );
 };
 
+export const Check_Box = CheckBox_Story.bind({});
+export const Check_Box_Long_Text = CheckBox_Long_text_Story.bind({});
 export const Check_Box_Group = CheckBoxGroup_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Check_Box',
+  'Check_Box_Long_Text',
+  'Check_Box_Group',
+];
 
 const checkBoxArgs: Object = {
   allowDisabledFocus: false,

--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -20,6 +20,7 @@ import {
   ThemeOptions,
   useConfig,
 } from './';
+import { Label } from '../Label';
 import { MatchScore } from '../MatchScore';
 import { Spinner } from '../Spinner';
 import { Stack } from '../Stack';
@@ -281,22 +282,34 @@ const ThemedComponents: FC = () => {
     };
 
     // If themeOptions isn't custom, ensure any previously set custom
-    // colors don't linger and interfer with named color palette.
+    // colors don't linger and interfere with named color palette.
     if (newThemeOptions.name !== 'custom') {
-      newThemeOptions.customTheme.primaryColor = undefined;
-      newThemeOptions.customTheme.accentColor = undefined;
+      newThemeOptions.customTheme = undefined;
     }
 
     setThemeOptions(addCustomFontsToThemeOptions(newThemeOptions));
   };
 
+  const themeSelectOptions: SelectOption[] = themes.map(
+    (theme: OcThemeName) => ({
+      text: theme,
+      value: theme,
+    })
+  );
+
+  const onThemeOptionChange = (options: SelectOption[]) => {
+    options.forEach((option: SelectOption) => {
+      console.log(option);
+      updateThemeOptions({ name: option as unknown as OcThemeName });
+    });
+  };
+
   return (
     <Stack direction="vertical" flexGap="xxl">
       <h1 style={{ marginBottom: 0 }}>
-        Selected Theme:
+        Selected theme:
         <span
           style={{
-            textTransform: 'capitalize',
             marginLeft: '4px',
             color: 'var(--primary-color)',
           }}
@@ -305,7 +318,6 @@ const ThemedComponents: FC = () => {
         </span>
         <span
           style={{
-            textTransform: 'capitalize',
             marginLeft: '4px',
             color: 'var(--accent-background3-color)',
           }}
@@ -315,30 +327,28 @@ const ThemedComponents: FC = () => {
       </h1>
       <Stack direction="horizontal" flexGap="m" style={{ marginTop: 0 }}>
         <div>
-          <p>Color palette</p>
-          <select
-            value={themeOptions.name}
-            onChange={(e) => {
-              updateThemeOptions({
-                name: e.target.value as OcThemeName,
-              });
+          <Label htmlFor="colorPalette" text="Color palette" />
+          <Select
+            defaultValue="blue"
+            dropdownProps={{
+              closeOnDropdownClick: true,
             }}
-            style={{ fontSize: '1rem' }}
-          >
-            {themes.map((theme) => (
-              <option value={theme} key={theme}>
-                {theme}
-              </option>
-            ))}
-            <option value="custom" key="custom">
-              custom
-            </option>
-          </select>
+            id="colorPalette"
+            onOptionsChange={onThemeOptionChange}
+            options={[
+              ...themeSelectOptions,
+              {
+                text: 'custom',
+                value: 'custom',
+              },
+            ]}
+            size={SelectSize.Small}
+          />
         </div>
         {themeOptions.name === 'custom' && (
           <>
             <div>
-              <p>Custom Primary</p>
+              <Label text="Custom Primary" />
               <CompactPicker
                 color={customPrimaryColor}
                 onChange={async (color) => {
@@ -354,7 +364,7 @@ const ThemedComponents: FC = () => {
               />
             </div>
             <div>
-              <p>Custom Accent</p>
+              <Label text="Custom Accent" />
               <CompactPicker
                 color={customAccentColor}
                 onChange={async (color) => {
@@ -372,8 +382,9 @@ const ThemedComponents: FC = () => {
           </>
         )}
         <div>
-          <p>Custom Font</p>
+          <Label htmlFor="customFont" text="Custom Font" />
           <RadioGroup
+            id="customFont"
             value={customFont}
             items={customFontItems}
             onChange={async (e) => {
@@ -718,8 +729,6 @@ const Theming_Story: ComponentStory<typeof ConfigProvider> = (args) => {
   return <ConfigProvider {...args} />;
 };
 
-export const Theming = Theming_Story.bind({});
-
 const localeValues: string[] = [
   'cs_CZ',
   'da_DK',
@@ -937,7 +946,7 @@ const Locale_Story: ComponentStory<typeof ConfigProvider> = (args) => {
         <p>Locale</p>
         <Select
           defaultValue={localeValue}
-          filterable={true}
+          filterable
           options={localeOptions}
           onOptionsChange={onLocaleChange}
           size={SelectSize.Small}
@@ -972,7 +981,13 @@ const Locale_Story: ComponentStory<typeof ConfigProvider> = (args) => {
   );
 };
 
+export const Theming = Theming_Story.bind({});
 export const Locale = Locale_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Theming', 'Locale'];
 
 const providerArgs = {
   focusVisibleOptions: {

--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -330,9 +330,6 @@ const ThemedComponents: FC = () => {
           <Label htmlFor="colorPalette" text="Color palette" />
           <Select
             defaultValue="blue"
-            dropdownProps={{
-              closeOnDropdownClick: true,
-            }}
             id="colorPalette"
             onOptionsChange={onThemeOptionChange}
             options={[

--- a/src/components/DateTimePicker/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DateTimePicker/DatePicker/DatePicker.stories.tsx
@@ -95,7 +95,7 @@ const Single_Picker_Story: ComponentStory<typeof DatePicker> = (args) => {
   };
 
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <DatePicker {...args} onChange={onChange} />
       <DatePicker {...args} onChange={onChange} picker="week" />
       <DatePicker {...args} onChange={onChange} picker="month" />
@@ -113,7 +113,7 @@ const Single_Picker_Disabled_Story: ComponentStory<typeof DatePicker> = (
   };
 
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <DatePicker {...args} onChange={onChange} />
       <DatePicker {...args} defaultValue={dayjs('2015-06-06', dateFormat)} />
     </Stack>
@@ -143,7 +143,7 @@ const Single_Picker_Disabled_Date_and_Time_Story: ComponentStory<
     disabledSeconds: () => [55, 56],
   });
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <DatePicker
         {...args}
         format="YYYY-MM-DD HH:mm:ss"
@@ -178,7 +178,7 @@ const { RangePicker } = DatePicker;
 
 const Range_Picker_Story: ComponentStory<typeof RangePicker> = (args) => {
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <RangePicker {...args} />
       <RangePicker {...args} picker="week" />
       <RangePicker {...args} picker="month" />
@@ -218,7 +218,7 @@ const Range_Picker_Disabled_Story: ComponentStory<typeof RangePicker> = (
   args
 ) => {
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <RangePicker {...args} />
       <RangePicker
         {...args}
@@ -264,7 +264,7 @@ const Range_Picker_Disabled_Date_and_Time_Story: ComponentStory<
   };
 
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <RangePicker {...args} disabledDate={disabledDate} />
       <RangePicker
         {...args}
@@ -294,7 +294,7 @@ const Preset_Ranges_Story: ComponentStory<typeof RangePicker> = (args) => {
   };
 
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <RangePicker
         {...args}
         ranges={{
@@ -372,7 +372,7 @@ const customFormat: DatePickerProps['format'] = (value) =>
 
 const Date_Format_Basic_Story: ComponentStory<typeof DatePicker> = (args) => {
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <DatePicker
         {...args}
         defaultValue={dayjs('2023/01/01', dateFormat)}
@@ -455,7 +455,7 @@ const Range_Borderless_Story: ComponentStory<typeof RangePicker> = (args) => {
 
 const Single_Status_Story: ComponentStory<typeof DatePicker> = (args) => {
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <DatePicker {...args} status="error" />
       <DatePicker {...args} status="warning" />
     </Stack>
@@ -464,7 +464,7 @@ const Single_Status_Story: ComponentStory<typeof DatePicker> = (args) => {
 
 const Range_Status_Story: ComponentStory<typeof RangePicker> = (args) => {
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <RangePicker {...args} status="error" />
       <RangePicker {...args} status="warning" />
     </Stack>
@@ -495,6 +495,30 @@ export const Single_Borderless = Single_Borderless_Story.bind({});
 export const Range_Borderless = Range_Borderless_Story.bind({});
 export const Single_Status = Single_Status_Story.bind({});
 export const Range_Status = Range_Status_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Single_Picker',
+  'Single_Picker_Disabled',
+  'Single_Picker_Disabled_Date_and_Time',
+  'Single_Picker_Choose_Time',
+  'Range_Picker',
+  'Range_Picker_Disabled',
+  'Range_Picker_Disabled_Date_and_Time',
+  'Range_Picker_Choose_Time',
+  'Preset_Ranges',
+  'Select_Range_By_Day_Limit',
+  'Date_Format_Basic',
+  'Date_Format_Range',
+  'Extra_Footer',
+  'Customized_Date_Styling',
+  'Single_Borderless',
+  'Range_Borderless',
+  'Single_Status',
+  'Range_Status',
+];
 
 const pickerArgs: Object = {
   classNames: 'my-picker-class',

--- a/src/components/DateTimePicker/TimePicker/TimePicker.stories.tsx
+++ b/src/components/DateTimePicker/TimePicker/TimePicker.stories.tsx
@@ -169,7 +169,7 @@ const Time_Range_Picker_Story: ComponentStory<typeof RangePicker> = (args) => {
 
 const Single_Borderless_Story: ComponentStory<typeof TimePicker> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'xxl'}>
+    <Stack direction={'vertical'} flexGap={'xxl'}>
       <TimePicker {...args} />
     </Stack>
   );
@@ -177,7 +177,7 @@ const Single_Borderless_Story: ComponentStory<typeof TimePicker> = (args) => {
 
 const Range_Borderless_Story: ComponentStory<typeof RangePicker> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'xxl'}>
+    <Stack direction={'vertical'} flexGap={'xxl'}>
       <RangePicker {...args} />
     </Stack>
   );
@@ -185,7 +185,7 @@ const Range_Borderless_Story: ComponentStory<typeof RangePicker> = (args) => {
 
 const Single_Status_Story: ComponentStory<typeof TimePicker> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'xxl'}>
+    <Stack direction={'vertical'} flexGap={'xxl'}>
       <TimePicker {...args} status={'error'} />
       <TimePicker {...args} status={'warning'} />
     </Stack>
@@ -194,7 +194,7 @@ const Single_Status_Story: ComponentStory<typeof TimePicker> = (args) => {
 
 const Range_Status_Story: ComponentStory<typeof RangePicker> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'xxl'}>
+    <Stack direction={'vertical'} flexGap={'xxl'}>
       <TimePicker.RangePicker {...args} status={'error'} />
       <TimePicker.RangePicker {...args} status={'warning'} />
     </Stack>
@@ -212,6 +212,23 @@ export const Single_Borderless = Single_Borderless_Story.bind({});
 export const Range_Borderless = Range_Borderless_Story.bind({});
 export const Single_Status = Single_Status_Story.bind({});
 export const Range_Status = Range_Status_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Disabled',
+  'Controlled',
+  'Hour_and_Minute',
+  'Interval',
+  'Extra_Footer',
+  'Time_Range_Picker',
+  'Single_Borderless',
+  'Range_Borderless',
+  'Single_Status',
+  'Range_Status',
+];
 
 const pickerArgs: Object = {
   classNames: 'my-picker-class',

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -144,8 +144,6 @@ const Medium_Story: ComponentStory<typeof Dialog> = (args) => {
   );
 };
 
-export const Medium = Medium_Story.bind({});
-
 const Small_Story: ComponentStory<typeof Dialog> = (args) => {
   const [visible, setVisible] = useState<boolean>(false);
   return (
@@ -166,18 +164,30 @@ const Small_Story: ComponentStory<typeof Dialog> = (args) => {
   );
 };
 
-export const Small = Small_Story.bind({});
-
 const DialogHelper_Story: ComponentStory<typeof Dialog> = (args) => (
   <>
     <PrimaryButton
       text={'Open dialog'}
-      onClick={() => dialogHelper.show({ ...args })}
+      onClick={() =>
+        dialogHelper.show({
+          ...args,
+          onClose: () => dialogHelper.close(),
+          onCancel: () => dialogHelper.close(),
+          onOk: () => dialogHelper.close(),
+        })
+      }
     />
   </>
 );
 
+export const Medium = Medium_Story.bind({});
+export const Small = Small_Story.bind({});
 export const DialogHelper = DialogHelper_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Medium', 'Small', 'DialogHelper'];
 
 const dialogArgs: Object = {
   size: DialogSize.medium,

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import {
@@ -152,8 +152,6 @@ const Dropdown_Button_Story: ComponentStory<typeof Dropdown> = (args) => {
   );
 };
 
-export const Dropdown_Button = Dropdown_Button_Story.bind({});
-
 const Dropdown_IconButton_Story: ComponentStory<typeof Dropdown> = (args) => {
   const [visible, setVisibility] = useState(false);
   return (
@@ -174,8 +172,6 @@ const Dropdown_IconButton_Story: ComponentStory<typeof Dropdown> = (args) => {
   );
 };
 
-export const Dropdown_IconButton = Dropdown_IconButton_Story.bind({});
-
 const Dropdown_Div_Story: ComponentStory<typeof Dropdown> = (args) => {
   const [visible, setVisibility] = useState(false);
   return (
@@ -190,8 +186,6 @@ const Dropdown_Div_Story: ComponentStory<typeof Dropdown> = (args) => {
     </Dropdown>
   );
 };
-
-export const Dropdown_Div = Dropdown_Div_Story.bind({});
 
 const Dropdown_External_Story: ComponentStory<typeof Dropdown> = (args) => {
   const [visible, setVisibility] = useState(false);
@@ -222,7 +216,20 @@ const Dropdown_External_Story: ComponentStory<typeof Dropdown> = (args) => {
   );
 };
 
+export const Dropdown_Button = Dropdown_Button_Story.bind({});
+export const Dropdown_IconButton = Dropdown_IconButton_Story.bind({});
+export const Dropdown_Div = Dropdown_Div_Story.bind({});
 export const Dropdown_External = Dropdown_External_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Dropdown_Button',
+  'Dropdown_IconButton',
+  'Dropdown_Div',
+  'Dropdown_External',
+];
 
 const dropdownArgs: Object = {
   trigger: 'click',

--- a/src/components/Empty/Empty.stories.tsx
+++ b/src/components/Empty/Empty.stories.tsx
@@ -48,6 +48,20 @@ export const Empty_Plan = Empty_Story.bind({});
 export const Empty_Profile = Empty_Story.bind({});
 export const Custom_Image = Empty_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'No_Data',
+  'Error_State',
+  'Empty_Messages',
+  'No_Search_Results',
+  'Tasks_Complete',
+  'Empty_Plan',
+  'Empty_Profile',
+  'Custom_Image',
+];
+
 const emptyArgs: Object = {
   description: 'More detail on how might the user be able to get around this',
   mode: EmptyMode.data,

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -17,7 +17,6 @@ import { Select, SelectOption } from '../Select';
 import DatePicker from '../DateTimePicker/DatePicker';
 import { Stack } from '../Stack';
 import enUS from '../Locale/en_US';
-import zhCN from '../Locale/zh_CN';
 import { ConfigProvider, Shape, Size } from '../ConfigProvider';
 import { Slider } from '../Slider';
 import { snack, SnackbarContainer } from '../Snackbar';
@@ -143,7 +142,7 @@ const Disabled_Story: ComponentStory<typeof Form> = (args) => {
       themeOptions={{ name: 'blue' }}
       locale={enUS}
       children={
-        <Stack direction={'vertical'} gap={'l'} fullWidth>
+        <Stack direction={'vertical'} flexGap={'l'} fullWidth>
           <CheckBox
             checked={componentDisabled}
             label={'Form disabled'}
@@ -178,7 +177,7 @@ const Disabled_Story: ComponentStory<typeof Form> = (args) => {
                 ]}
               />
             </Form.Item>
-            <Form.Item noStyle label={'Slider'} name={'slider'}>
+            <Form.Item label={'Slider'} name={'slider'}>
               <Slider step={1} max={100} min={1} value={50} />
             </Form.Item>
             <Form.Item
@@ -354,7 +353,7 @@ const Methods_Story: ComponentStory<typeof Form> = (args) => {
               }
             </Form.Item>
             <Form.Item {...actionsLayout}>
-              <Stack direction={'horizontal'} gap={'m'} fullWidth>
+              <Stack direction={'horizontal'} flexGap={'m'} fullWidth>
                 <PrimaryButton htmlType={'submit'} text={'Submit'} />
                 <SecondaryButton
                   htmlType={'button'}
@@ -384,7 +383,7 @@ const Form_Story: ComponentStory<typeof Form> = (args) => {
       themeOptions={{ name: 'blue' }}
       locale={enUS}
       children={
-        <Stack direction={'vertical'} gap={'l'} fullWidth>
+        <Stack direction={'vertical'} flexGap={'l'} fullWidth>
           <Form
             {...args}
             labelCol={{ span: 3 }}
@@ -543,7 +542,7 @@ const Non_Blocking_Story: ComponentStory<typeof Form> = (args) => {
               <TextInput placeholder={'Placeholder'} />
             </Form.Item>
             <Form.Item>
-              <Stack direction={'horizontal'} gap={'m'}>
+              <Stack direction={'horizontal'} flexGap={'m'}>
                 <PrimaryButton htmlType={'submit'} text={'Submit'} />
                 <SecondaryButton
                   htmlType={'button'}
@@ -569,7 +568,7 @@ const Watch_Hooks_Story: ComponentStory<typeof Form> = () => {
       themeOptions={{ name: 'blue' }}
       locale={enUS}
       children={
-        <Stack direction={'vertical'} gap={'l'}>
+        <Stack direction={'vertical'} flexGap={'l'}>
           <Form form={form} layout="vertical" autoComplete="off">
             <Form.Item
               name={'foo'}
@@ -646,7 +645,7 @@ const Dynamic_Form_Item_Story: ComponentStory<typeof Form> = (args) => {
                     required={false}
                     key={field.key}
                   >
-                    <Stack direction={'horizontal'} gap={'m'}>
+                    <Stack direction={'horizontal'} flexGap={'m'}>
                       <Form.Item
                         {...field}
                         validateTrigger={['onChange', 'onBlur']}
@@ -1092,7 +1091,7 @@ const Complex_Form_Control_Story: ComponentStory<typeof Form> = (args) => {
           wrapperCol={{ span: 10 }}
         >
           <Form.Item label={'Username'}>
-            <Stack direction={'horizontal'} gap={'m'}>
+            <Stack direction={'horizontal'} flexGap={'m'}>
               <Form.Item
                 name={'username'}
                 noStyle
@@ -1147,7 +1146,7 @@ const Complex_Form_Control_Story: ComponentStory<typeof Form> = (args) => {
             </Stack>
           </Form.Item>
           <Form.Item label="Date of Birth">
-            <Stack direction={'horizontal'} gap={'xxs'}>
+            <Stack direction={'horizontal'} flexGap={'xxs'}>
               <Form.Item
                 name={'year'}
                 rules={[{ required: true }]}
@@ -1224,7 +1223,7 @@ const PriceInput: FC<PriceInputProps> = ({ value = {}, onChange }) => {
   };
 
   return (
-    <Stack direction={'horizontal'} gap={'s'} fullWidth>
+    <Stack direction={'horizontal'} flexGap={'s'} fullWidth>
       <TextInput
         numbersOnly
         value={value.number || number}
@@ -1480,7 +1479,7 @@ const Control_Between_Forms_Story: ComponentStory<typeof Form> = () => {
                       <li key={index}>
                         <Stack
                           direction={'horizontal'}
-                          gap={'xs'}
+                          flexGap={'xs'}
                           style={{ marginBottom: 8 }}
                         >
                           <Avatar
@@ -1506,7 +1505,7 @@ const Control_Between_Forms_Story: ComponentStory<typeof Form> = () => {
                     ))}
                   </ul>
                 ) : (
-                  <Stack direction={'horizontal'} gap={'s'} fullWidth>
+                  <Stack direction={'horizontal'} flexGap={'s'} fullWidth>
                     <Icon path={IconName.mdiAccount} />
                     <span>
                       {' '}
@@ -2093,6 +2092,44 @@ export const Dates_and_Times = Dates_and_Times_Story.bind({});
 export const Manual_Form_Data = Manual_Form_Data_Story.bind({});
 export const Custom_Validation = Custom_Validation_Story.bind({});
 export const Dynamic_Rules = Dynamic_Rules_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Disabled',
+  'Methods',
+  'Flex',
+  'Large',
+  'Medium',
+  'Small',
+  'Rectangle',
+  'Pill',
+  'Underline',
+  'Horizontal',
+  'Vertical',
+  'Inline',
+  'Label_Wrap',
+  'Required',
+  'Required_Hidden',
+  'Optional',
+  'Non_Blocking',
+  'Watch_Hooks',
+  'Dynamic_Form_Item',
+  'Dynamic_Form_Nest_Items',
+  'Complex_Dynamic_Form_Items',
+  'Nest',
+  'Complex_Form_Control',
+  'Custom_Form_Controls',
+  'Store_Form_Data',
+  'Control_Between_Forms',
+  'Form_In_Modal',
+  'Dates_and_Times',
+  'Manual_Form_Data',
+  'Custom_Validation',
+  'Dynamic_Rules',
+];
 
 const formArgs: Object = {
   disabled: false,

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -120,8 +120,6 @@ const Basic_Story: ComponentStory<typeof Row> = (args) => (
   </div>
 );
 
-export const Basic = Basic_Story.bind({});
-
 const style: React.CSSProperties = {
   background: 'var(--primary-color-40)',
   border: '2px solid var(--primary-secondary-color)',
@@ -145,8 +143,6 @@ const Horizontal_Gutter_Story: ComponentStory<typeof Row> = (args) => (
   </Row>
 );
 
-export const Horizontal_Gutter = Horizontal_Gutter_Story.bind({});
-
 const Responsive_Gutter_Story: ComponentStory<typeof Row> = (args) => (
   <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 32 }}>
     <Col {...args} span={3}>
@@ -163,8 +159,6 @@ const Responsive_Gutter_Story: ComponentStory<typeof Row> = (args) => (
     </Col>
   </Row>
 );
-
-export const Responsive_Gutter = Responsive_Gutter_Story.bind({});
 
 const Vertical_Gutter_Story: ComponentStory<typeof Row> = (args) => (
   <Row gutter={[16, 16]}>
@@ -195,8 +189,6 @@ const Vertical_Gutter_Story: ComponentStory<typeof Row> = (args) => (
   </Row>
 );
 
-export const Vertical_Gutter = Vertical_Gutter_Story.bind({});
-
 const Column_Offset_Story: ComponentStory<typeof Row> = (args) => (
   <div style={{ border: '1px solid var(--primary-secondary-color)' }}>
     <Row>
@@ -223,8 +215,6 @@ const Column_Offset_Story: ComponentStory<typeof Row> = (args) => (
   </div>
 );
 
-export const Column_Offset = Column_Offset_Story.bind({});
-
 const Grid_Sort_Story: ComponentStory<typeof Row> = (args) => (
   <div style={{ border: '1px solid var(--primary-secondary-color)' }}>
     <Row>
@@ -237,8 +227,6 @@ const Grid_Sort_Story: ComponentStory<typeof Row> = (args) => (
     </Row>
   </div>
 );
-
-export const Grid_Sort = Grid_Sort_Story.bind({});
 
 const Typesetting_Story: ComponentStory<typeof Row> = (args) => (
   <div style={{ border: '1px solid var(--primary-secondary-color)' }}>
@@ -329,8 +317,6 @@ const Typesetting_Story: ComponentStory<typeof Row> = (args) => (
   </div>
 );
 
-export const Typesetting = Typesetting_Story.bind({});
-
 const DemoBox: React.FC<{ children: React.ReactNode; value: number }> = (
   props
 ) => (
@@ -392,8 +378,6 @@ const Alignment_Story: ComponentStory<typeof Row> = (args) => (
   </>
 );
 
-export const Alignment = Alignment_Story.bind({});
-
 const Order_Normal_Story: ComponentStory<typeof Row> = (args) => (
   <Row>
     <Col {...args} span={3} order={4}>
@@ -410,8 +394,6 @@ const Order_Normal_Story: ComponentStory<typeof Row> = (args) => (
     </Col>
   </Row>
 );
-
-export const Order_Normal = Order_Normal_Story.bind({});
 
 const Order_Responsive_Story: ComponentStory<typeof Row> = (args) => (
   <Row>
@@ -458,8 +440,6 @@ const Order_Responsive_Story: ComponentStory<typeof Row> = (args) => (
   </Row>
 );
 
-export const Order_Responsive = Order_Responsive_Story.bind({});
-
 const Percentage_Columns_Story: ComponentStory<typeof Row> = (args) => (
   <Row>
     <Col {...args} flex={2}>
@@ -471,8 +451,6 @@ const Percentage_Columns_Story: ComponentStory<typeof Row> = (args) => (
   </Row>
 );
 
-export const Percentage_Columns = Percentage_Columns_Story.bind({});
-
 const Fill_Rest_Story: ComponentStory<typeof Row> = (args) => (
   <Row>
     <Col {...args} flex="100px">
@@ -483,8 +461,6 @@ const Fill_Rest_Story: ComponentStory<typeof Row> = (args) => (
     </Col>
   </Row>
 );
-
-export const Fill_Rest = Fill_Rest_Story.bind({});
 
 const Raw_Flex_Style_Story: ComponentStory<typeof Row> = (args) => (
   <>
@@ -507,8 +483,6 @@ const Raw_Flex_Style_Story: ComponentStory<typeof Row> = (args) => (
     </Row>
   </>
 );
-
-export const Raw_Flex_Style = Raw_Flex_Style_Story.bind({});
 
 const Responsive_Story: ComponentStory<typeof Row> = (args) => (
   <Row>
@@ -542,17 +516,15 @@ const Responsive_Story: ComponentStory<typeof Row> = (args) => (
   </Row>
 );
 
-export const Responsive = Responsive_Story.bind({});
-
 const { useBreakpoint } = Grid;
 
 const useBreakPoint_Story: FC = () => {
   const screens = useBreakpoint();
 
   return (
-    <Stack gap="m" direction="vertical">
+    <Stack flexGap="m" direction="vertical">
       <div>Current break point:</div>
-      <Stack gap="l" direction="horizontal">
+      <Stack flexGap="l" direction="horizontal">
         {Object.entries(screens)
           .filter((screen) => !!screen[1])
           .map((screen) => (
@@ -562,8 +534,6 @@ const useBreakPoint_Story: FC = () => {
     </Stack>
   );
 };
-
-export const useBreakPoint = useBreakPoint_Story.bind({});
 
 const gutters: Record<string, number> = {};
 const vgutters: Record<string, number> = {};
@@ -601,7 +571,7 @@ const Playground_Story: FC = () => {
   }
 
   return (
-    <Stack direction="vertical" gap="l" justify="flex-start" fullWidth>
+    <Stack direction="vertical" flexGap="l" justify="flex-start" fullWidth>
       <span>Horizontal Gutter: </span>
       <div style={{ width: '50%' }}>
         <Slider
@@ -644,7 +614,44 @@ const Playground_Story: FC = () => {
   );
 };
 
+export const Basic = Basic_Story.bind({});
+export const Horizontal_Gutter = Horizontal_Gutter_Story.bind({});
+export const Responsive_Gutter = Responsive_Gutter_Story.bind({});
+export const Vertical_Gutter = Vertical_Gutter_Story.bind({});
+export const Column_Offset = Column_Offset_Story.bind({});
+export const Grid_Sort = Grid_Sort_Story.bind({});
+export const Typesetting = Typesetting_Story.bind({});
+export const Alignment = Alignment_Story.bind({});
+export const Order_Normal = Order_Normal_Story.bind({});
+export const Order_Responsive = Order_Responsive_Story.bind({});
+export const Percentage_Columns = Percentage_Columns_Story.bind({});
+export const Fill_Rest = Fill_Rest_Story.bind({});
+export const Raw_Flex_Style = Raw_Flex_Style_Story.bind({});
+export const Responsive = Responsive_Story.bind({});
+export const useBreakPoint = useBreakPoint_Story.bind({});
 export const Playground = Playground_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Horizontal_Gutter',
+  'Responsive_Gutter',
+  'Vertical_Gutter',
+  'Column_Offset',
+  'Grid_Sort',
+  'Typesetting',
+  'Alignment',
+  'Order_Normal',
+  'Order_Responsive',
+  'Percentage_Columns',
+  'Fill_Rest',
+  'Raw_Flex_Style',
+  'Responsive',
+  'useBreakPoint',
+  'Playground',
+];
 
 const basicArgs: Object = {
   style: {

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -90,8 +90,6 @@ export default {
 
 const Basic_Story: ComponentStory<typeof Icon> = (args) => <Icon {...args} />;
 
-export const Basic = Basic_Story.bind({});
-
 const Icomoon_Story: ComponentStory<typeof Icon> = (args) => (
   <ConfigProvider
     icomoonIconSet={iconSet}
@@ -103,20 +101,14 @@ const Icomoon_Story: ComponentStory<typeof Icon> = (args) => (
   </ConfigProvider>
 );
 
+export const Basic = Basic_Story.bind({});
 export const Icomoon = Icomoon_Story.bind({});
+export const Icomoon_Multicolor = Icomoon_Story.bind({});
 
-const Icomoon_Multicolor_Story: ComponentStory<typeof Icon> = (args) => (
-  <ConfigProvider
-    icomoonIconSet={iconSet}
-    themeOptions={{
-      name: 'blue',
-    }}
-  >
-    <Icon {...args} />
-  </ConfigProvider>
-);
-
-export const Icomoon_Multicolor = Icomoon_Multicolor_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Basic', 'Icomoon', 'Icomoon_Multicolor'];
 
 const iconArgs: Object = {
   path: IconName.mdiCardsHeart,

--- a/src/components/InfoBar/InfoBar.stories.tsx
+++ b/src/components/InfoBar/InfoBar.stories.tsx
@@ -31,29 +31,24 @@ export default {
   },
 } as ComponentMeta<typeof InfoBar>;
 
-const Neutral_Story: ComponentStory<typeof InfoBar> = (args) => (
+const InfoBar_Story: ComponentStory<typeof InfoBar> = (args) => (
   <InfoBar {...args} />
 );
 
-export const Neutral = Neutral_Story.bind({});
+export const Neutral = InfoBar_Story.bind({});
+export const Positive = InfoBar_Story.bind({});
+export const Warning = InfoBar_Story.bind({});
+export const Disruptive = InfoBar_Story.bind({});
 
-const Positive_Story: ComponentStory<typeof InfoBar> = (args) => (
-  <InfoBar {...args} />
-);
-
-export const Positive = Positive_Story.bind({});
-
-const Warning_Story: ComponentStory<typeof InfoBar> = (args) => (
-  <InfoBar {...args} />
-);
-
-export const Warning = Warning_Story.bind({});
-
-const Disruptive_Story: ComponentStory<typeof InfoBar> = (args) => (
-  <InfoBar {...args} />
-);
-
-export const Disruptive = Disruptive_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Neutral',
+  'Positive',
+  'Warning',
+  'Disruptive',
+];
 
 const infoBarArgs: Object = {
   actionButtonProps: {

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -67,6 +67,15 @@ export const Basic = Label_Story.bind({});
 export const Default_Info_Button = Label_Story.bind({});
 export const Custom_Button = Label_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Default_Info_Button',
+  'Custom_Button',
+];
+
 Basic.args = {
   text: 'This is a label',
   size: LabelSize.Medium,

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -95,7 +95,7 @@ const getNavBar = (): JSX.Element => (
 );
 
 const Basic_Story: ComponentStory<typeof Layout> = (args) => (
-  <Stack direction="vertical" gap="xxxl" justify="center" fullWidth>
+  <Stack direction="vertical" flexGap="xxxl" justify="center" fullWidth>
     <Layout {...args}>
       <Nav>{getNavBar()}</Nav>
       <Header style={{ border: '1px solid #f6f7f8' }}>
@@ -224,8 +224,6 @@ const Basic_Story: ComponentStory<typeof Layout> = (args) => (
   </Stack>
 );
 
-export const Basic = Basic_Story.bind({});
-
 const Fixed_Navbar_Story: ComponentStory<typeof Layout> = (args) => (
   <Layout {...args} style={{ height: '294px' }}>
     <Nav
@@ -273,8 +271,6 @@ const Fixed_Navbar_Story: ComponentStory<typeof Layout> = (args) => (
     </Layout>
   </Layout>
 );
-
-export const Fixed_Navbar = Fixed_Navbar_Story.bind({});
 
 const Fixed_Aside_Story: ComponentStory<typeof Layout> = (args) => (
   <Layout {...args}>
@@ -467,8 +463,6 @@ const Fixed_Aside_Story: ComponentStory<typeof Layout> = (args) => (
   </Layout>
 );
 
-export const Fixed_Aside = Fixed_Aside_Story.bind({});
-
 const Responsive_Story: ComponentStory<typeof Layout> = (args) => (
   <Layout {...args}>
     <Aside
@@ -510,8 +504,6 @@ const Responsive_Story: ComponentStory<typeof Layout> = (args) => (
     </Layout>
   </Layout>
 );
-
-export const Responsive = Responsive_Story.bind({});
 
 const Trigger_Story: ComponentStory<typeof Layout> = (args) => {
   const [collapsed, setCollapsed] = useState(false);
@@ -561,7 +553,22 @@ const Trigger_Story: ComponentStory<typeof Layout> = (args) => {
   );
 };
 
+export const Basic = Basic_Story.bind({});
+export const Fixed_Navbar = Fixed_Navbar_Story.bind({});
+export const Fixed_Aside = Fixed_Aside_Story.bind({});
+export const Responsive = Responsive_Story.bind({});
 export const Trigger = Trigger_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Fixed_Navbar',
+  'Fixed_Aside',
+  'Responsive',
+  'Trigger',
+];
 
 const layoutArgs: Object = {
   octupleStyles: true,

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -83,6 +83,26 @@ export const Secondary_Disabled = Link_Story.bind({});
 export const Neutral_Disabled = Link_Story.bind({});
 export const Disruptive_Disabled = Link_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Default',
+  'Primary',
+  'Secondary',
+  'Neutral',
+  'Disruptive',
+  'Primary_Underline',
+  'Secondary_Underline',
+  'Neutral_Underline',
+  'Disruptive_Underline',
+  'Default_Disabled',
+  'Primary_Disabled',
+  'Secondary_Disabled',
+  'Neutral_Disabled',
+  'Disruptive_Disabled',
+];
+
 const linkArgs: Object = {
   classNames: 'my-link-class',
   children: (

--- a/src/components/LinkButton/LinkButton.stories.tsx
+++ b/src/components/LinkButton/LinkButton.stories.tsx
@@ -135,6 +135,19 @@ export const Neutral = Link_Button_Story.bind({});
 export const System_UI = Link_Button_Story.bind({});
 export const Floating = Link_Button_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Primary',
+  'Counter',
+  'Secondary',
+  'Default',
+  'Neutral',
+  'System_UI',
+  'Floating',
+];
+
 const linkButtonArgs: Object = {
   alignIcon: LinkButtonIconAlign.Left,
   alignText: LinkButtonTextAlign.Center,

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -53,17 +53,15 @@ const sampleList: User[] = [1, 2, 3, 4, 5].map((i) => ({
   img: '',
 }));
 
-const Vertical_Story: ComponentStory<typeof List> = (args) => (
-  <List {...args} />
-);
+const List_Story: ComponentStory<typeof List> = (args) => <List {...args} />;
 
-export const Vertical = Vertical_Story.bind({});
+export const Vertical = List_Story.bind({});
+export const Horizontal = List_Story.bind({});
 
-const Horizontal_Story: ComponentStory<typeof List> = (args) => (
-  <List {...args} />
-);
-
-export const Horizontal = Horizontal_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Vertical', 'Horizontal'];
 
 const listArgs: Object = {
   items: sampleList,

--- a/src/components/MatchScore/MatchScore.stories.tsx
+++ b/src/components/MatchScore/MatchScore.stories.tsx
@@ -57,10 +57,13 @@ const Default_Story: ComponentStory<typeof MatchScore> = (args) => (
 );
 
 export const Default = Default_Story.bind({});
-
 export const Custom_Label = Default_Story.bind({});
-
 export const Without_Label = Default_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Default', 'Custom_Label', 'Without_Label'];
 
 const matchScoreArgs: Object = {
   classNames: 'my-match-score-class',

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -426,6 +426,18 @@ export const Menu_Sub_Header = Menu_Sub_Header_Story.bind({});
 export const Menu_Footer = Menu_Header_Story.bind({});
 export const Cascading_Menu = Cascading_Menu_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic_Menu',
+  'Link_Menu',
+  'Menu_Header',
+  'Menu_Sub_Header',
+  'Menu_Footer',
+  'Cascading_Menu',
+];
+
 const menuArgs: object = {
   variant: MenuVariant.neutral,
   size: MenuSize.medium,

--- a/src/components/MessageBar/MessageBar.stories.tsx
+++ b/src/components/MessageBar/MessageBar.stories.tsx
@@ -31,29 +31,24 @@ export default {
   },
 } as ComponentMeta<typeof MessageBar>;
 
-const Neutral_Story: ComponentStory<typeof MessageBar> = (args) => (
+const MessageBar_Story: ComponentStory<typeof MessageBar> = (args) => (
   <MessageBar {...args} />
 );
 
-export const Neutral = Neutral_Story.bind({});
+export const Neutral = MessageBar_Story.bind({});
+export const Positive = MessageBar_Story.bind({});
+export const Warning = MessageBar_Story.bind({});
+export const Disruptive = MessageBar_Story.bind({});
 
-const Positive_Story: ComponentStory<typeof MessageBar> = (args) => (
-  <MessageBar {...args} />
-);
-
-export const Positive = Positive_Story.bind({});
-
-const Warning_Story: ComponentStory<typeof MessageBar> = (args) => (
-  <MessageBar {...args} />
-);
-
-export const Warning = Warning_Story.bind({});
-
-const Disruptive_Story: ComponentStory<typeof MessageBar> = (args) => (
-  <MessageBar {...args} />
-);
-
-export const Disruptive = Disruptive_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Neutral',
+  'Positive',
+  'Warning',
+  'Disruptive',
+];
 
 const messageBarArgs: Object = {
   actionButtonProps: {

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -82,7 +82,7 @@ export default {
   },
 } as ComponentMeta<typeof Modal>;
 
-const Small_Story: ComponentStory<typeof Modal> = (args) => {
+const Modal_Story: ComponentStory<typeof Modal> = (args) => {
   const [visible, setVisible] = useState<boolean>(false);
   return (
     <>
@@ -91,56 +91,6 @@ const Small_Story: ComponentStory<typeof Modal> = (args) => {
     </>
   );
 };
-
-export const Small = Small_Story.bind({});
-
-const Medium_Story: ComponentStory<typeof Modal> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open modal'} onClick={() => setVisible(true)} />
-      <Modal {...args} onClose={() => setVisible(false)} visible={visible} />
-    </>
-  );
-};
-
-export const Medium = Medium_Story.bind({});
-
-const Large_Story: ComponentStory<typeof Modal> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open modal'} onClick={() => setVisible(true)} />
-      <Modal {...args} onClose={() => setVisible(false)} visible={visible} />
-    </>
-  );
-};
-
-export const Large = Large_Story.bind({});
-
-const XLarge_Story: ComponentStory<typeof Modal> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open modal'} onClick={() => setVisible(true)} />
-      <Modal {...args} onClose={() => setVisible(false)} visible={visible} />
-    </>
-  );
-};
-
-export const XLarge = XLarge_Story.bind({});
-
-const Fullscreen_Story: ComponentStory<typeof Modal> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open modal'} onClick={() => setVisible(true)} />
-      <Modal {...args} onClose={() => setVisible(false)} visible={visible} />
-    </>
-  );
-};
-
-export const Fullscreen = Fullscreen_Story.bind({});
 
 const Scrollable_Story: ComponentStory<typeof Modal> = (args) => {
   const [visible, setVisible] = useState<boolean>(false);
@@ -162,19 +112,26 @@ const Scrollable_Story: ComponentStory<typeof Modal> = (args) => {
   );
 };
 
+export const Small = Modal_Story.bind({});
+export const Medium = Modal_Story.bind({});
+export const Large = Modal_Story.bind({});
+export const XLarge = Modal_Story.bind({});
+export const Fullscreen = Modal_Story.bind({});
 export const Scrollable = Scrollable_Story.bind({});
+export const Header_Actions = Modal_Story.bind({});
 
-const Header_Actions_Story: ComponentStory<typeof Modal> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open modal'} onClick={() => setVisible(true)} />
-      <Modal {...args} onClose={() => setVisible(false)} visible={visible} />
-    </>
-  );
-};
-
-export const Header_Actions = Header_Actions_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Small',
+  'Medium',
+  'Large',
+  'XLarge',
+  'Fullscreen',
+  'Scrollable',
+  'Header_Actions',
+];
 
 const modalArgs: Object = {
   size: ModalSize.small,

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -150,5 +150,10 @@ const Theme_Story: ComponentStory<typeof Navbar> = (args) => {
 export const Basic = Basic_Story.bind({});
 export const Theme = Theme_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Basic', 'Theme'];
+
 Basic.args = {};
 Theme.args = {};

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -50,53 +50,32 @@ export default {
   },
 } as ComponentMeta<typeof Pagination>;
 
-const Basic_Few_Story: ComponentStory<typeof Pagination> = (args) => (
+const Pagination_Story: ComponentStory<typeof Pagination> = (args) => (
   <Pagination {...args} />
 );
 
-export const Basic_Few = Basic_Few_Story.bind({});
+export const Basic_Few = Pagination_Story.bind({});
+export const Basic_Many = Pagination_Story.bind({});
+export const Dots = Pagination_Story.bind({});
+export const Total_Item_Count = Pagination_Story.bind({});
+export const Change_Page_Size = Pagination_Story.bind({});
+export const Jump_To = Pagination_Story.bind({});
+export const All_Combined = Pagination_Story.bind({});
+export const Simplified = Pagination_Story.bind({});
 
-const Basic_Many_Story: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-);
-
-export const Basic_Many = Basic_Many_Story.bind({});
-
-const Dots_Story: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-);
-
-export const Dots = Dots_Story.bind({});
-
-const Total_Item_Count_Story: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-);
-
-export const Total_Item_Count = Total_Item_Count_Story.bind({});
-
-const Change_Page_Size_Story: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-);
-
-export const Change_Page_Size = Change_Page_Size_Story.bind({});
-
-const Jump_To_Story: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-);
-
-export const Jump_To = Jump_To_Story.bind({});
-
-const All_Combined_Story: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-);
-
-export const All_Combined = All_Combined_Story.bind({});
-
-const Simplified_Story: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-);
-
-export const Simplified = Simplified_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic_Few',
+  'Basic_Many',
+  'Dots',
+  'Total_Item_Count',
+  'Change_Page_Size',
+  'Jump_To',
+  'All_Combined',
+  'Simplified',
+];
 
 const paginationArgs: Object = {
   classNames: 'my-pagination-class',

--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -103,7 +103,7 @@ export default {
   },
 } as ComponentMeta<typeof Panel>;
 
-const Small_Story: ComponentStory<typeof Panel> = (args) => {
+const Panel_Story: ComponentStory<typeof Panel> = (args) => {
   const [visible, setVisible] = useState<boolean>(false);
   return (
     <>
@@ -121,50 +121,6 @@ const Small_Story: ComponentStory<typeof Panel> = (args) => {
     </>
   );
 };
-
-export const Small = Small_Story.bind({});
-
-const Medium_Story: ComponentStory<typeof Panel> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open panel'} onClick={() => setVisible(true)} />
-      <Panel
-        {...args}
-        footer={
-          <div>
-            <PrimaryButton text={'Close'} onClick={() => setVisible(false)} />
-          </div>
-        }
-        visible={visible}
-        onClose={() => setVisible(false)}
-      />
-    </>
-  );
-};
-
-export const Medium = Medium_Story.bind({});
-
-const Large_Story: ComponentStory<typeof Panel> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open panel'} onClick={() => setVisible(true)} />
-      <Panel
-        {...args}
-        footer={
-          <div>
-            <PrimaryButton text={'Close'} onClick={() => setVisible(false)} />
-          </div>
-        }
-        visible={visible}
-        onClose={() => setVisible(false)}
-      />
-    </>
-  );
-};
-
-export const Large = Large_Story.bind({});
 
 const Stacked_Story: ComponentStory<typeof Panel> = (args) => {
   const [visible, setVisible] = useState<Record<string, boolean>>({});
@@ -225,92 +181,6 @@ const Stacked_Story: ComponentStory<typeof Panel> = (args) => {
   );
 };
 
-export const Stacked = Stacked_Story.bind({});
-
-const Left_Story: ComponentStory<typeof Panel> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open panel'} onClick={() => setVisible(true)} />
-      <Panel
-        {...args}
-        footer={
-          <div>
-            <PrimaryButton text={'Close'} onClick={() => setVisible(false)} />
-          </div>
-        }
-        visible={visible}
-        onClose={() => setVisible(false)}
-      />
-    </>
-  );
-};
-
-export const Left = Left_Story.bind({});
-
-const Bottom_Story: ComponentStory<typeof Panel> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open panel'} onClick={() => setVisible(true)} />
-      <Panel
-        {...args}
-        footer={
-          <div>
-            <PrimaryButton text={'Close'} onClick={() => setVisible(false)} />
-          </div>
-        }
-        visible={visible}
-        onClose={() => setVisible(false)}
-      />
-    </>
-  );
-};
-
-export const Bottom = Bottom_Story.bind({});
-
-const Top_Story: ComponentStory<typeof Panel> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open panel'} onClick={() => setVisible(true)} />
-      <Panel
-        {...args}
-        footer={
-          <div>
-            <PrimaryButton text={'Close'} onClick={() => setVisible(false)} />
-          </div>
-        }
-        visible={visible}
-        onClose={() => setVisible(false)}
-      />
-    </>
-  );
-};
-
-export const Top = Top_Story.bind({});
-
-const Header_Actions_Story: ComponentStory<typeof Panel> = (args) => {
-  const [visible, setVisible] = useState<boolean>(false);
-  return (
-    <>
-      <PrimaryButton text={'Open panel'} onClick={() => setVisible(true)} />
-      <Panel
-        {...args}
-        footer={
-          <div>
-            <PrimaryButton text={'Close'} onClick={() => setVisible(false)} />
-          </div>
-        }
-        visible={visible}
-        onClose={() => setVisible(false)}
-      />
-    </>
-  );
-};
-
-export const Header_Actions = Header_Actions_Story.bind({});
-
 const Panel_Header_Story: ComponentStory<typeof Panel> = (args) => {
   const [visible, setVisible] = useState<boolean>(false);
   return (
@@ -360,7 +230,30 @@ const Panel_Header_Story: ComponentStory<typeof Panel> = (args) => {
   );
 };
 
+export const Small = Panel_Story.bind({});
+export const Medium = Panel_Story.bind({});
+export const Large = Panel_Story.bind({});
+export const Stacked = Stacked_Story.bind({});
+export const Left = Panel_Story.bind({});
+export const Bottom = Panel_Story.bind({});
+export const Top = Panel_Story.bind({});
+export const Header_Actions = Panel_Story.bind({});
 export const Panel_Header = Panel_Header_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Small',
+  'Medium',
+  'Large',
+  'Stacked',
+  'Left',
+  'Bottom',
+  'Top',
+  'Header_Actions',
+  'Panel_Header',
+];
 
 const panelArgs: Object = {
   size: PanelSize.small,

--- a/src/components/PersistentBar/PersistentBar.stories.tsx
+++ b/src/components/PersistentBar/PersistentBar.stories.tsx
@@ -18,7 +18,7 @@ export default {
               <p>
                 Persistent bars are sticky sections that can be used to
                 highlight a few actions that are out of the view to be displayed
-                inside the view. For example, if there’s a very long form with
+                inside the view. For example, if there's a very long form with
                 Save and Cancel buttons at the bottom, we can use the bottom bar
                 to show those two buttons in the view. We are making these bars
                 to be flexible in height and also allowing any component to be
@@ -41,17 +41,30 @@ export default {
   },
 } as ComponentMeta<typeof PersistentBar>;
 
-const Bar_Story: ComponentStory<typeof PersistentBar> = (args) => (
+const PersistentBar_Story: ComponentStory<typeof PersistentBar> = (args) => (
   <PersistentBar {...args} />
 );
 
-export const BottomBarWithText = Bar_Story.bind({});
-export const BottomBarSecondaryButtons = Bar_Story.bind({});
-export const BottomBarButtonsOnLeft = Bar_Story.bind({});
-export const TopBarButtons = Bar_Story.bind({});
-export const TopBarButtonsLegacy = Bar_Story.bind({});
-export const TopBarWithText = Bar_Story.bind({});
-export const TopBarPagination = Bar_Story.bind({});
+export const Bottom_Bar_With_Text = PersistentBar_Story.bind({});
+export const Bottom_Bar_Secondary_Buttons = PersistentBar_Story.bind({});
+export const Bottom_Bar_Buttons_On_Left = PersistentBar_Story.bind({});
+export const Top_Bar_Buttons = PersistentBar_Story.bind({});
+export const Top_Bar_Buttons_Legacy = PersistentBar_Story.bind({});
+export const Top_Bar_With_Text = PersistentBar_Story.bind({});
+export const Top_Bar_Pagination = PersistentBar_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Bottom_Bar_With_Text',
+  'Bottom_Bar_Secondary_Buttons',
+  'Bottom_Bar_Buttons_On_Left',
+  'Top_Bar_Buttons',
+  'Top_Bar_Buttons_Legacy',
+  'Top_Bar_With_Text',
+  'Top_Bar_Pagination',
+];
 
 const paginationArgs: Object = {
   classNames: 'my-pagination-class',
@@ -91,7 +104,7 @@ const persistentBarArgs: Object = {
   paginationTotal: 150,
 };
 
-BottomBarWithText.args = {
+Bottom_Bar_With_Text.args = {
   ...persistentBarArgs,
   actionButtonOneProps: {
     ariaLabel: 'Primary',
@@ -114,7 +127,7 @@ BottomBarWithText.args = {
   type: PersistentBarType.bottomBarWithText,
 };
 
-BottomBarSecondaryButtons.args = {
+Bottom_Bar_Secondary_Buttons.args = {
   ...persistentBarArgs,
   actionButtonOneProps: {
     ariaLabel: 'Default',
@@ -143,7 +156,7 @@ BottomBarSecondaryButtons.args = {
   type: PersistentBarType.bottomBarSecondaryButtons,
 };
 
-BottomBarButtonsOnLeft.args = {
+Bottom_Bar_Buttons_On_Left.args = {
   ...persistentBarArgs,
   actionButtonOneProps: {
     ariaLabel: 'Default',
@@ -172,7 +185,7 @@ BottomBarButtonsOnLeft.args = {
   type: PersistentBarType.bottomBarButtonsOnLeft,
 };
 
-TopBarButtons.args = {
+Top_Bar_Buttons.args = {
   ...persistentBarArgs,
   buttonMenuProps: [
     {
@@ -239,7 +252,7 @@ TopBarButtons.args = {
 };
 
 // TODO: Remove in Octuple v3.0.0
-TopBarButtonsLegacy.args = {
+Top_Bar_Buttons_Legacy.args = {
   ...persistentBarArgs,
   buttonMenuProps: [
     {
@@ -305,14 +318,14 @@ TopBarButtonsLegacy.args = {
   type: PersistentBarType.topBarButtons,
 };
 
-TopBarWithText.args = {
+Top_Bar_With_Text.args = {
   ...persistentBarArgs,
   type: PersistentBarType.topBarWithText,
   content: 'Body2 is used for supporting text.',
   title: 'Header 4 as Title:',
 };
 
-TopBarPagination.args = {
+Top_Bar_Pagination.args = {
   ...persistentBarArgs,
   type: PersistentBarType.topBarPagination,
   paginationArgs,

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -70,55 +70,13 @@ const themes: PillThemeName[] = [
   'white',
 ];
 
-const Default_Story: ComponentStory<typeof Pill> = (args) => (
+const Pill_Story: ComponentStory<typeof Pill> = (args) => (
   <Stack direction="vertical" flexGap="l">
     {themes.map((theme) => (
       <Pill {...args} label={theme} theme={theme} key={theme} />
     ))}
   </Stack>
 );
-
-export const Default = Default_Story.bind({});
-
-const With_Icon_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" flexGap="l">
-    {themes.map((theme) => (
-      <Pill {...args} label={theme} theme={theme} key={theme} />
-    ))}
-  </Stack>
-);
-
-export const With_Icon = With_Icon_Story.bind({});
-
-const Closable_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" flexGap="l">
-    {themes.map((theme) => (
-      <Pill {...args} label={theme} theme={theme} key={theme} />
-    ))}
-  </Stack>
-);
-
-export const Closable = Closable_Story.bind({});
-
-const Custom_Closable_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" flexGap="l">
-    {themes.map((theme) => (
-      <Pill {...args} label={theme} theme={theme} key={theme} />
-    ))}
-  </Stack>
-);
-
-export const Custom_Closable = Custom_Closable_Story.bind({});
-
-const With_Button_Story: ComponentStory<typeof Pill> = (args) => (
-  <Stack direction="vertical" flexGap="l">
-    {themes.map((theme) => (
-      <Pill {...args} label={theme} theme={theme} key={theme} />
-    ))}
-  </Stack>
-);
-
-export const With_Button = With_Button_Story.bind({});
 
 const With_Long_Text_Story: ComponentStory<typeof Pill> = (args) => (
   <Stack direction="vertical" flexGap="l" style={{ width: 216 }}>
@@ -133,7 +91,24 @@ const With_Long_Text_Story: ComponentStory<typeof Pill> = (args) => (
   </Stack>
 );
 
+export const Default = Pill_Story.bind({});
+export const With_Icon = Pill_Story.bind({});
+export const Closable = Pill_Story.bind({});
+export const Custom_Closable = Pill_Story.bind({});
+export const With_Button = Pill_Story.bind({});
 export const With_Long_Text = With_Long_Text_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Default',
+  'With_Icon',
+  'Closable',
+  'Custom_Closable',
+  'With_Button',
+  'With_Long_Text',
+];
 
 const pillArgs: Object = {
   alignIcon: PillIconAlign.Start,

--- a/src/components/Progress/Progress.stories.tsx
+++ b/src/components/Progress/Progress.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Progress, { ProgressSize } from '.';
@@ -33,7 +33,7 @@ export default {
 
 const Line_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'s'} fullWidth>
+    <Stack direction={'vertical'} flexGap={'s'} fullWidth>
       <Progress
         {...args}
         percent={30}
@@ -62,7 +62,7 @@ const Line_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Small_Line_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'s'} style={{ width: 200 }}>
+    <Stack direction={'vertical'} flexGap={'s'} style={{ width: 200 }}>
       <Progress
         {...args}
         percent={30}
@@ -99,7 +99,7 @@ const Small_Line_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Circle_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'s'} fullWidth>
+    <Stack direction={'vertical'} flexGap={'s'} fullWidth>
       <Progress {...args} type={'circle'} percent={75} />
       <Progress {...args} type={'circle'} percent={70} status={'exception'} />
       <Progress {...args} type={'circle'} percent={100} />
@@ -109,7 +109,7 @@ const Circle_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Small_Circle_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'s'} style={{ width: 200 }}>
+    <Stack direction={'vertical'} flexGap={'s'} style={{ width: 200 }}>
       <Progress
         {...args}
         type={'circle'}
@@ -138,7 +138,7 @@ const Small_Circle_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Dashboard_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'s'} style={{ width: 200 }}>
+    <Stack direction={'vertical'} flexGap={'s'} style={{ width: 200 }}>
       <Progress {...args} type="dashboard" percent={75} />
       <Progress {...args} type="dashboard" percent={75} gapDegree={30} />
     </Stack>
@@ -147,7 +147,7 @@ const Dashboard_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Line_Cap_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'s'} style={{ width: 200 }}>
+    <Stack direction={'vertical'} flexGap={'s'} style={{ width: 200 }}>
       <Progress {...args} strokeLinecap={'butt'} percent={75} />
       <Progress {...args} strokeLinecap={'butt'} type={'circle'} percent={75} />
       <Progress
@@ -162,7 +162,7 @@ const Line_Cap_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Steps_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'l'} fullWidth>
+    <Stack direction={'vertical'} flexGap={'l'} fullWidth>
       <Progress
         {...args}
         percent={50}
@@ -195,7 +195,7 @@ const Steps_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Success_Segment_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'l'} fullWidth>
+    <Stack direction={'vertical'} flexGap={'l'} fullWidth>
       <Tooltip
         content={'3 done / 3 in progress / 4 to do'}
         offset={-24}
@@ -242,7 +242,7 @@ const Success_Segment_Story: ComponentStory<typeof Progress> = (args) => {
 
 const Gradient_Story: ComponentStory<typeof Progress> = (args) => {
   return (
-    <Stack direction={'vertical'} gap={'s'} fullWidth>
+    <Stack direction={'vertical'} flexGap={'s'} fullWidth>
       <Progress
         {...args}
         strokeColor={{
@@ -297,6 +297,21 @@ export const Line_Cap = Line_Cap_Story.bind({});
 export const Steps = Steps_Story.bind({});
 export const Success_Segment = Success_Segment_Story.bind({});
 export const Gradient = Gradient_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Line',
+  'Small_Line',
+  'Circle',
+  'Small_Circle',
+  'Dashboard',
+  'Line_Cap',
+  'Steps',
+  'Success_Segment',
+  'Gradient',
+];
 
 const progressArgs: Object = {
   classNames: 'my-progress',

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -133,8 +133,6 @@ const RadioButton_Story: ComponentStory<typeof RadioButton> = (args) => {
   );
 };
 
-export const Radio_Button = RadioButton_Story.bind({});
-
 const RadioButtonLongText_Story: ComponentStory<typeof RadioButton> = (
   args
 ) => {
@@ -157,8 +155,6 @@ const RadioButtonLongText_Story: ComponentStory<typeof RadioButton> = (
   );
 };
 
-export const Radio_Button_Long_Text = RadioButtonLongText_Story.bind({});
-
 const RadioGroup_Story: ComponentStory<typeof RadioGroup> = (args) => {
   const [selected1, setSelected1] = useState<RadioButtonValue>(args.value);
 
@@ -177,8 +173,6 @@ const RadioGroup_Story: ComponentStory<typeof RadioGroup> = (args) => {
   );
 };
 
-export const Radio_Group = RadioGroup_Story.bind({});
-
 const Bespoke_RadioGroup_Story: ComponentStory<typeof RadioButton> = (args) => {
   const [selected2a, setSelected2a] = useState<RadioButtonValue>('label1');
   const [selected2b, setSelected2b] = useState<RadioButtonValue>('label1');
@@ -196,7 +190,7 @@ const Bespoke_RadioGroup_Story: ComponentStory<typeof RadioButton> = (args) => {
   };
 
   return (
-    <Stack direction="vertical" gap="m">
+    <Stack direction="vertical" flexGap="m">
       <Label text="Group 1" />
       <RadioButton
         {...args}
@@ -263,8 +257,6 @@ const Bespoke_RadioGroup_Story: ComponentStory<typeof RadioButton> = (args) => {
   );
 };
 
-export const Bespoke_Radio_Group = Bespoke_RadioGroup_Story.bind({});
-
 const RadioButton_With_Custom_Label_Story: ComponentStory<
   typeof RadioButton
 > = (args) => {
@@ -285,9 +277,6 @@ const RadioButton_With_Custom_Label_Story: ComponentStory<
   );
 };
 
-export const RadioButton_With_Custom_Label =
-  RadioButton_With_Custom_Label_Story.bind({});
-
 const RadioGroup_With_Custom_Label_Story: ComponentStory<typeof RadioGroup> = (
   args
 ) => {
@@ -304,8 +293,26 @@ const RadioGroup_With_Custom_Label_Story: ComponentStory<typeof RadioGroup> = (
   );
 };
 
+export const Radio_Button = RadioButton_Story.bind({});
+export const Radio_Button_Long_Text = RadioButtonLongText_Story.bind({});
+export const Radio_Group = RadioGroup_Story.bind({});
+export const Bespoke_Radio_Group = Bespoke_RadioGroup_Story.bind({});
+export const RadioButton_With_Custom_Label =
+  RadioButton_With_Custom_Label_Story.bind({});
 export const RadioGroup_With_Custom_Label =
   RadioGroup_With_Custom_Label_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Radio_Button',
+  'Radio_Button_Long_Text',
+  'Radio_Group',
+  'Bespoke_Radio_Group',
+  'RadioButton_With_Custom_Label',
+  'RadioGroup_With_Custom_Label',
+];
 
 const radioButtonArgs: Object = {
   allowDisabledFocus: false,

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -151,17 +151,35 @@ const Dynamic_Story: ComponentStory<typeof Select> = (args) => (
 );
 
 export type SelectStory = ComponentStory<React.FC<SelectProps>>;
+
 export const Basic: SelectStory = Basic_Story.bind({});
 export const Dynamic_Width: SelectStory = Basic_Story.bind({});
-export const With_DefaultValue: SelectStory = Basic_Story.bind({});
-export const With_DefaultValueMultiple: SelectStory = Basic_Story.bind({});
+export const With_Default_Value: SelectStory = Basic_Story.bind({});
+export const With_Default_Value_Multiple: SelectStory = Basic_Story.bind({});
 export const Disabled: SelectStory = Basic_Story.bind({});
 export const With_Clear: SelectStory = Basic_Story.bind({});
 export const Options_Disabled: SelectStory = Basic_Story.bind({});
 export const Filterable: SelectStory = Basic_Story.bind({});
 export const Multiple: SelectStory = Basic_Story.bind({});
-export const Multiple_With_NoFilter: SelectStory = Basic_Story.bind({});
+export const Multiple_With_No_Filter: SelectStory = Basic_Story.bind({});
 export const Dynamic: SelectStory = Dynamic_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Dynamic_Width',
+  'With_Default_Value',
+  'With_Default_Value_Multiple',
+  'Disabled',
+  'With_Clear',
+  'Options_Disabled',
+  'Filterable',
+  'Multiple',
+  'Multiple_With_No_Filter',
+  'Dynamic',
+];
 
 const SelectArgs: SelectProps = {
   classNames: 'octuple-select-class',
@@ -186,12 +204,12 @@ Dynamic_Width.args = {
   },
 };
 
-With_DefaultValue.args = {
+With_Default_Value.args = {
   ...Basic.args,
   defaultValue: 'hat',
 };
 
-With_DefaultValueMultiple.args = {
+With_Default_Value_Multiple.args = {
   ...Basic.args,
   defaultValue: ['verylarge', 'account', 'hat'],
   multiple: true,
@@ -201,10 +219,10 @@ With_DefaultValueMultiple.args = {
 };
 
 Disabled.args = {
-  ...With_DefaultValue.args,
+  ...With_Default_Value.args,
   disabled: true,
   textInputProps: {
-    ...With_DefaultValue.args.textInputProps,
+    ...With_Default_Value.args.textInputProps,
     disabled: true,
   },
 };
@@ -223,9 +241,9 @@ Options_Disabled.args = {
 };
 
 With_Clear.args = {
-  ...With_DefaultValue.args,
+  ...With_Default_Value.args,
   textInputProps: {
-    ...With_DefaultValue.args.textInputProps,
+    ...With_Default_Value.args.textInputProps,
     clearable: true,
   },
 };
@@ -252,7 +270,7 @@ Multiple.args = {
   },
 };
 
-Multiple_With_NoFilter.args = {
+Multiple_With_No_Filter.args = {
   ...Basic.args,
   filterable: false,
   multiple: true,

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -50,18 +50,14 @@ const Default_Story: ComponentStory<typeof Skeleton> = (args) => (
   <Skeleton {...args} />
 );
 
-export const Default = Default_Story.bind({});
-
 const Child_Wrapper_Story: ComponentStory<typeof Skeleton> = (args) => (
   <Skeleton {...args}>
     <DefaultButton text={'Sample button'} />
   </Skeleton>
 );
 
-export const ChildWrapper = Child_Wrapper_Story.bind({});
-
-const SampleUsage_Story: ComponentStory<typeof Skeleton> = (args) => (
-  <Stack direction="vertical" gap="xs" style={{ width: 210 }}>
+const Sample_Usage_Story: ComponentStory<typeof Skeleton> = (args) => (
+  <Stack direction="vertical" flexGap="xs" style={{ width: 210 }}>
     <Skeleton
       width={210}
       height={10}
@@ -83,7 +79,14 @@ const SampleUsage_Story: ComponentStory<typeof Skeleton> = (args) => (
   </Stack>
 );
 
-export const Sample_Usage = SampleUsage_Story.bind({});
+export const Default = Default_Story.bind({});
+export const Child_Wrapper = Child_Wrapper_Story.bind({});
+export const Sample_Usage = Sample_Usage_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Default', 'Child_Wrapper', 'Sample_Usage'];
 
 const skeletonArgs: SkeletonProps = {
   animating: true,
@@ -98,7 +101,7 @@ Default.args = {
   variant: SkeletonVariant.Rectangular,
 };
 
-ChildWrapper.args = {
+Child_Wrapper.args = {
   ...skeletonArgs,
   variant: SkeletonVariant.Pill,
 };

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -1004,6 +1004,24 @@ export const With_Benchmark = With_Benchmark_Story.bind({});
 export const Data_Inactive = Data_Inactive_Story.bind({});
 export const Data_Active = Data_Active_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Standard_Slider',
+  'Range_Slider',
+  'Inline_Extemity_Labels',
+  'Custom_Markers_Included',
+  'Custom_Markers_Excluded',
+  'Custom_Markers_With_Step',
+  'Custom_Markers_Null_Step',
+  'Dots',
+  'Toggle_Thumb',
+  'With_Benchmark',
+  'Data_Inactive',
+  'Data_Active',
+];
+
 const sliderArgs: Object = {
   allowDisabledFocus: false,
   ariaLabel: 'Slider',

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -66,8 +66,6 @@ const Default_Story: ComponentStory<typeof Snackbar> = (args) => (
   </>
 );
 
-export const Default = Default_Story.bind({});
-
 const Closable_Story: ComponentStory<typeof Snackbar> = (args) => (
   <>
     <DefaultButton
@@ -78,8 +76,6 @@ const Closable_Story: ComponentStory<typeof Snackbar> = (args) => (
     <SnackbarContainer />
   </>
 );
-
-export const Closable = Closable_Story.bind({});
 
 const With_Action_Story: ComponentStory<typeof Snackbar> = (args) => (
   <>
@@ -92,7 +88,14 @@ const With_Action_Story: ComponentStory<typeof Snackbar> = (args) => (
   </>
 );
 
+export const Default = Default_Story.bind({});
+export const Closable = Closable_Story.bind({});
 export const With_Action = With_Action_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = ['Default', 'Closable', 'With_Action'];
 
 const snackArgs: Object = {
   position: 'top-center',

--- a/src/components/Stack/Stack.stories.tsx
+++ b/src/components/Stack/Stack.stories.tsx
@@ -93,29 +93,24 @@ export default {
   },
 } as ComponentMeta<typeof Stack>;
 
-const Horizontal_Story: ComponentStory<typeof Stack> = (args) => {
-  return <Stack {...args}>{args.children}</Stack>;
-};
+const Stack_Story: ComponentStory<typeof Stack> = (args) => (
+  <Stack {...args}>{args.children}</Stack>
+);
 
-export const Horizontal = Horizontal_Story.bind({});
+export const Horizontal = Stack_Story.bind({});
+export const Vertical = Stack_Story.bind({});
+export const Responsive = Stack_Story.bind({});
+export const Sample_Nav_List = Stack_Story.bind({});
 
-const Vertical_Story: ComponentStory<typeof Stack> = (args) => {
-  return <Stack {...args}>{args.children}</Stack>;
-};
-
-export const Vertical = Vertical_Story.bind({});
-
-const Responsive_Story: ComponentStory<typeof Stack> = (args) => {
-  return <Stack {...args}>{args.children}</Stack>;
-};
-
-export const Responsive = Responsive_Story.bind({});
-
-const Sample_Nav_List_Story: ComponentStory<typeof Stack> = (args) => {
-  return <Stack {...args}>{args.children}</Stack>;
-};
-
-export const Sample_Nav_List = Sample_Nav_List_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Horizontal',
+  'Vertical',
+  'Responsive',
+  'Sample_Nav_List',
+];
 
 const stackArgs: Object = {
   fullWidth: false,

--- a/src/components/Stepper/Stepper.stories.tsx
+++ b/src/components/Stepper/Stepper.stories.tsx
@@ -130,7 +130,7 @@ export default {
   },
 } as ComponentMeta<typeof Stepper>;
 
-const Default_Story: ComponentStory<typeof Stepper> = (args) => {
+const Stepper_Story: ComponentStory<typeof Stepper> = (args) => {
   const workflow: Step[] = [1, 2, 3, 4, 5].map((i: number) => ({
     index: i,
     content: `Step label ${i}`,
@@ -146,18 +146,36 @@ const Default_Story: ComponentStory<typeof Stepper> = (args) => {
   );
 };
 
-export const Default_Horizontal_Small = Default_Story.bind({});
-export const Default_Horizontal_Small_Required = Default_Story.bind({});
-export const Default_Horizontal_Small_Read_Only = Default_Story.bind({});
-export const Default_Horizontal_Medium = Default_Story.bind({});
-export const Default_Horizontal_Medium_Required = Default_Story.bind({});
-export const Default_Horizontal_Medium_Read_Only = Default_Story.bind({});
-export const Default_Horizontal_Medium_Active_Scroll = Default_Story.bind({});
-export const Default_Vertical = Default_Story.bind({});
-export const Default_Vertical_Required = Default_Story.bind({});
-export const Default_Vertical_Read_Only = Default_Story.bind({});
-export const Default_Vertical_Scroll = Default_Story.bind({});
-export const Default_Vertical_Active_Scroll = Default_Story.bind({});
+export const Default_Horizontal_Small = Stepper_Story.bind({});
+export const Default_Horizontal_Small_Required = Stepper_Story.bind({});
+export const Default_Horizontal_Small_Read_Only = Stepper_Story.bind({});
+export const Default_Horizontal_Medium = Stepper_Story.bind({});
+export const Default_Horizontal_Medium_Required = Stepper_Story.bind({});
+export const Default_Horizontal_Medium_Read_Only = Stepper_Story.bind({});
+export const Default_Horizontal_Medium_Active_Scroll = Stepper_Story.bind({});
+export const Default_Vertical = Stepper_Story.bind({});
+export const Default_Vertical_Required = Stepper_Story.bind({});
+export const Default_Vertical_Read_Only = Stepper_Story.bind({});
+export const Default_Vertical_Scroll = Stepper_Story.bind({});
+export const Default_Vertical_Active_Scroll = Stepper_Story.bind({});
+
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Default_Horizontal_Small',
+  'Default_Horizontal_Small_Required',
+  'Default_Horizontal_Small_Read_Only',
+  'Default_Horizontal_Medium',
+  'Default_Horizontal_Medium_Required',
+  'Default_Horizontal_Medium_Read_Only',
+  'Default_Horizontal_Medium_Active_Scroll',
+  'Default_Vertical',
+  'Default_Vertical_Required',
+  'Default_Vertical_Read_Only',
+  'Default_Vertical_Scroll',
+  'Default_Vertical_Active_Scroll',
+];
 
 const stepperArgs: Object = {
   activeStepIndex: 2,

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1410,6 +1410,47 @@ export const Virtual_List: FC = () => {
   );
 };
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Bordered',
+  'Cell_Bordered',
+  'Header_Bordered',
+  'Inner_Bordered',
+  'Outer_Bordered',
+  'Row_Bordered',
+  'Column_Bordered',
+  'Row_Hover_Background_Disabled',
+  'Small',
+  'Medium',
+  'Large',
+  'Empty',
+  'Header_Grouping',
+  'Header_And_Footer',
+  'Fixed_Header',
+  'Fixed_Columns',
+  'Fixed_Columns_and_Header',
+  'Fixed_Columns_with_Scroller',
+  'Fixed_Columns_and_Header_with_Scroller',
+  'Selection',
+  'Expandable_Row',
+  'Order_Select_And_Expand_Column',
+  'Colspan_Rows',
+  'Sort',
+  'Sort_Multiple',
+  'Summary',
+  'Filter',
+  'Ellipsis',
+  'Ellipsis_With_Tooltip',
+  'Responsive',
+  'Tree',
+  'Nested',
+  'Page_Sizes',
+  'Virtual_List',
+];
+
 const tableArgs: Object = {
   alternateRowColor: true,
   headerClassName: 'my-header',

--- a/src/components/Tabs/StatTabs.stories.tsx
+++ b/src/components/Tabs/StatTabs.stories.tsx
@@ -125,6 +125,17 @@ export const Stat_Group_Read_Only = Stat_Story.bind({});
 export const Stat_Group_Theme = Stat_Story.bind({});
 export const Stat_Item_Theme_Override = Stat_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Stat_Medium',
+  'Stat_Small',
+  'Stat_Group_Read_Only',
+  'Stat_Group_Theme',
+  'Stat_Item_Theme_Override',
+];
+
 const tabsArgs: Object = {
   bordered: true,
   divider: true,

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -84,7 +84,7 @@ const scrollableTabs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => ({
   ...(i === 4 ? { disabled: true } : {}),
 }));
 
-const Default_Story: ComponentStory<typeof Tabs> = (args) => {
+const Tabs_Story: ComponentStory<typeof Tabs> = (args) => {
   const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
   return (
     <Tabs
@@ -95,139 +95,36 @@ const Default_Story: ComponentStory<typeof Tabs> = (args) => {
   );
 };
 
-export const Default = Default_Story.bind({});
+export const Default = Tabs_Story.bind({});
+export const Default_Underlined = Tabs_Story.bind({});
+export const Default_Loader = Tabs_Story.bind({});
+export const Small = Tabs_Story.bind({});
+export const With_Badge = Tabs_Story.bind({});
+export const Icon = Tabs_Story.bind({});
+export const Icon_Label = Tabs_Story.bind({});
+export const Scrollable = Tabs_Story.bind({});
+export const Pill_Default = Tabs_Story.bind({});
+export const Pill_With_Badge = Tabs_Story.bind({});
+export const Pill_Icon = Tabs_Story.bind({});
+export const Pill_Icon_Label = Tabs_Story.bind({});
 
-export const DefaultUnderlined = Default_Story.bind({});
-
-const Default_Loading_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const DefaultLoader = Default_Loading_Story.bind({});
-
-const Small_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Small = Small_Story.bind({});
-
-const With_Badge_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const With_Badge = With_Badge_Story.bind({});
-
-const Icon_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Icon = Icon_Story.bind({});
-
-const Icon_Label_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Icon_Label = Icon_Label_Story.bind({});
-
-const Scrollable_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Scrollable = Scrollable_Story.bind({});
-
-const Pill_Default_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Pill_Default = Pill_Default_Story.bind({});
-
-const Pill_With_Badge_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Pill_With_Badge = Pill_With_Badge_Story.bind({});
-
-const Pill_Icon_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Pill_Icon = Pill_Icon_Story.bind({});
-
-const Pill_Icon_Label_Story: ComponentStory<typeof Tabs> = (args) => {
-  const [activeTabs, setActiveTabs] = useState({ defaultTab: 'tab1' });
-  return (
-    <Tabs
-      {...args}
-      onChange={(tab) => setActiveTabs({ ...activeTabs, defaultTab: tab })}
-      value={activeTabs.defaultTab}
-    />
-  );
-};
-
-export const Pill_Icon_Label = Pill_Icon_Label_Story.bind({});
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Default',
+  'Default_Underlined',
+  'Default_Loader',
+  'Small',
+  'With_Badge',
+  'Icon',
+  'Icon_Label',
+  'Scrollable',
+  'Pill_Default',
+  'Pill_With_Badge',
+  'Pill_Icon',
+  'Pill_Icon_Label',
+];
 
 const tabsArgs: Object = {
   scrollable: false,
@@ -242,12 +139,12 @@ Default.args = {
   ...tabsArgs,
 };
 
-DefaultUnderlined.args = {
+Default_Underlined.args = {
   ...tabsArgs,
   underlined: true,
 };
 
-DefaultLoader.args = {
+Default_Loader.args = {
   ...tabsArgs,
   children: badgeTabs.map((tab, index) => (
     <Tab key={tab.value} {...tab} loading={index % 2 === 0} />

--- a/src/components/Upload/Upload.stories.tsx
+++ b/src/components/Upload/Upload.stories.tsx
@@ -624,6 +624,23 @@ export const Image_List = Image_List_Story.bind({});
 export const Image_Editor = Image_Editor_Story.bind({});
 export const Basic_Deferred_API = Basic_Deferred_API_Story.bind({});
 
+// Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
+// this line ensures they are exported in the desired order.
+// See https://www.npmjs.com/package/babel-plugin-named-exports-order
+export const __namedExportsOrder = [
+  'Basic',
+  'Basic_With_Upload_List',
+  'Drag_and_Drop_Single_Small',
+  'Drag_and_Drop_Multiple_Small',
+  'Drag_and_Drop_Single_Medium',
+  'Drag_and_Drop_Multiple_Medium',
+  'Drag_and_Drop_Single_Large',
+  'Drag_and_Drop_Multiple_Large',
+  'Image_List',
+  'Image_Editor',
+  'Basic_Deferred_API',
+];
+
 const uploadArgs: Object = {};
 
 Basic.args = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3108,7 +3108,7 @@
   dependencies:
     "@storybook/node-logger" "^6.1.14"
     css-loader "^3.6.0"
-    postcss "^7.0.35"
+    postcss "^7.0.36"
     postcss-loader "^4.2.0"
     style-loader "^1.3.0"
 
@@ -5729,7 +5729,7 @@ autoprefixer@^9.8.6:
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     picocolors "^0.2.1"
-    postcss "^7.0.32"
+    postcss "^7.0.36"
     postcss-value-parser "^4.1.0"
 
 axe-core@^4.2.0, axe-core@^4.3.5:
@@ -5842,7 +5842,7 @@ babel-plugin-named-asset-import@0.3.8:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz#6b7fa43c59229685368683c28bc9734f24524cc2"
   integrity sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==
 
-babel-plugin-named-exports-order@^0.0.2:
+babel-plugin-named-exports-order@0.0.2, babel-plugin-named-exports-order@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-exports-order/-/babel-plugin-named-exports-order-0.0.2.tgz#ae14909521cf9606094a2048239d69847540cb09"
   integrity sha512-OgOYHOLoRK+/mvXU9imKHlG6GkPLYrUCvFXG/CM93R/aNNO8pOOF4aS+S8CCHMDQoNSeiOYEZb/G6RwL95Jktw==
@@ -7518,7 +7518,7 @@ css-loader@^3.6.0:
     icss-utils "^4.1.1"
     loader-utils "^1.4.2"
     normalize-path "^3.0.0"
-    postcss "^7.0.32"
+    postcss "^7.0.36"
     postcss-modules-extract-imports "^2.0.0"
     postcss-modules-local-by-default "^3.0.2"
     postcss-modules-scope "^2.2.0"
@@ -13659,7 +13659,7 @@ postcss-flexbugs-fixes@^4.2.1:
   resolved "https://registry.yarnpkg.com/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz#9218a65249f30897deab1033aced8578562a6690"
   integrity sha512-9SiofaZ9CWpQWxOwRh1b/r85KD5y7GgvsNt1056k6OYLvWUun0czCvogfJgylC22uJTwW1KzY3Gz65NZRlvoiQ==
   dependencies:
-    postcss "^7.0.26"
+    postcss "^7.0.36"
 
 postcss-focus-visible@^6.0.1:
   version "6.0.4"
@@ -13818,7 +13818,7 @@ postcss-modules-extract-imports@^2.0.0:
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz#818719a1ae1da325f9832446b01136eeb493cd7e"
   integrity sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==
   dependencies:
-    postcss "^7.0.5"
+    postcss "^7.0.36"
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"
@@ -13831,7 +13831,7 @@ postcss-modules-local-by-default@^3.0.2:
   integrity sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==
   dependencies:
     icss-utils "^4.1.1"
-    postcss "^7.0.32"
+    postcss "^7.0.36"
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
@@ -13849,7 +13849,7 @@ postcss-modules-scope@^2.2.0:
   resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz#385cae013cc7743f5a7d7602d1073a89eaae62ee"
   integrity sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==
   dependencies:
-    postcss "^7.0.6"
+    postcss "^7.0.36"
     postcss-selector-parser "^6.0.0"
 
 postcss-modules-scope@^3.0.0:
@@ -13865,7 +13865,7 @@ postcss-modules-values@^3.0.0:
   integrity sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==
   dependencies:
     icss-utils "^4.0.0"
-    postcss "^7.0.6"
+    postcss "^7.0.36"
 
 postcss-modules-values@^4.0.0:
   version "4.0.0"
@@ -15118,7 +15118,7 @@ resolve-url-loader@4.0.0:
     adjust-sourcemap-loader "^4.0.0"
     convert-source-map "^1.7.0"
     loader-utils "^2.0.0"
-    postcss "^7.0.35"
+    postcss "^7.0.36"
     source-map "0.6.1"
 
 resolve-url@^0.2.1:


### PR DESCRIPTION
## SUMMARY:

In order to merge [Dependabot PR 564](https://github.com/EightfoldAI/octuple/pull/564), the folks at Storybook recommended the [babel-plugin-named-exports-order](https://www.npmjs.com/package/babel-plugin-named-exports-order) plugin. This will resolve a critical security issue.

[Issue logged against Storybook](https://github.com/storybookjs/storybook/issues/22804)

- Adds `babel-plugin-named-exports-order` dev dependency
- Adds `.babelrc.js `file to expose plugin globally
- Updates all stories with more than 1 story to use it as documented
- Updates all `Stack` component instances to use `flexGap` instead of `gap` prop
- Updates `ConfigProvider` `Theme` story to use an Octuple `Select` component rather than an`<select>` html element
- Updates `ConfigProvider` `Theme` story by removing `<p>` html elements and replacing them with Octuple `Label` components
- Fixes a bug where the `var(--primary-color)` was `undefined` when choosing a canned themed
- Optimizes stories where possible by deduping  exported function components
- Normalizes `export const` across the board
- Updates `Form` `Disabled` story by removing `noStyle` from `Slider` form item

## JIRA TASK (Eightfold Employees Only):
ENG-56839

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Ensure all stories behave as expected.