### PR TITLE
fix: slider: ensure tooltip is visually hidden when slider is disabled

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -841,6 +841,9 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     styles.sliderTooltip,
                     tooltipProps?.classNames,
                   ])}
+                  wrapperClassNames={
+                    mergedDisabled ? styles.hideSliderTooltip : ''
+                  }
                   closeOnReferenceClick={false}
                   content={getTooltipContentByValue(val)}
                   key={`value-tooltip-${index}`}

--- a/src/components/Slider/slider.module.scss
+++ b/src/components/Slider/slider.module.scss
@@ -136,6 +136,11 @@ $small-min-label-offset-with-steps: 0;
     &-tooltip {
       min-width: max-content;
     }
+
+    .hide-slider-tooltip {
+      opacity: 0;
+      visibility: hidden;
+    }
   }
 
   .rail-marker-segments {


### PR DESCRIPTION
## SUMMARY:
Ensure the reference wrapper is visually hidden upon `Tooltip` disabled

https://github.com/EightfoldAI/octuple/assets/99700808/be0b1093-62e7-4d45-94b1-e94b22d7c2be

## JIRA TASK (Eightfold Employees Only):
ENG-56910

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (CSS only)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Slider` disable prop behaves as expected.