### PR TITLE
fix: menu: add htmltype prop to menu item button

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -86,6 +86,11 @@ export interface MenuItemButtonProps
    */
   dropdownMenuProps?: NestedDropdownMenuProps;
   /**
+   * The button html type.
+   * @default 'button'
+   */
+  htmlType?: 'button' | 'submit' | 'reset';
+  /**
    * Menu item icon props
    */
   iconProps?: MenuIconProps;

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -17,6 +17,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
   disabled,
   dropdownMenuItems,
   dropdownMenuProps,
+  htmlType = 'button',
   iconProps,
   onClick,
   role = 'menuitem',
@@ -85,6 +86,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
       className={styles.menuItemButton}
       disabled={disabled}
       tabIndex={tabIndex}
+      type={htmlType}
       {...rest}
       onClick={handleOnClick}
       role={role}
@@ -108,6 +110,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = ({
           className={styles.menuOuterButton}
           disabled={disabled}
           tabIndex={tabIndex}
+          type={htmlType}
           {...rest}
           onClick={handleOnClick}
         >

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Menu Menu is large 1`] = `
               class="menu-item-button"
               role="menuitem"
               tabindex="0"
+              type="button"
             >
               <span
                 aria-hidden="false"
@@ -86,6 +87,7 @@ exports[`Menu Menu is large 1`] = `
               disabled=""
               role="menuitem"
               tabindex="0"
+              type="button"
             >
               <span
                 class="menu-item-wrapper"
@@ -272,6 +274,7 @@ exports[`Menu Menu is medium 1`] = `
               class="menu-item-button"
               role="menuitem"
               tabindex="0"
+              type="button"
             >
               <span
                 aria-hidden="false"
@@ -315,6 +318,7 @@ exports[`Menu Menu is medium 1`] = `
               disabled=""
               role="menuitem"
               tabindex="0"
+              type="button"
             >
               <span
                 class="menu-item-wrapper"
@@ -501,6 +505,7 @@ exports[`Menu Menu is small 1`] = `
               class="menu-item-button"
               role="menuitem"
               tabindex="0"
+              type="button"
             >
               <span
                 aria-hidden="false"
@@ -544,6 +549,7 @@ exports[`Menu Menu is small 1`] = `
               disabled=""
               role="menuitem"
               tabindex="0"
+              type="button"
             >
               <span
                 class="menu-item-wrapper"


### PR DESCRIPTION
## SUMMARY:
Add `htmlType` prop with a default value of `button` to `MenuItemButton`

## JIRA TASK (Eightfold Employees Only):
ENG-56936

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify `Menu` component behaves as expected.