### PR TITLE
feat: persistentbar: support small screens and themes plus custom render

### DIFF
--- a/src/components/Locale/Default.tsx
+++ b/src/components/Locale/Default.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/en_US';
 import InfoBar from '../InfoBar/Locale/en_US';
 import Pagination from '../Pagination/Locale/en_US';
 import Panel from '../Panel/Locale/en_US';
+import PersistentBar from '../PersistentBar/Locale/en_US';
 import Stepper from '../Stepper/Locale/en_US';
 import Table from '../Table/Locale/en_US';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_US';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/cs_CZ.tsx
+++ b/src/components/Locale/cs_CZ.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/cs_CZ';
 import InfoBar from '../InfoBar/Locale/cs_CZ';
 import Pagination from '../Pagination/Locale/cs_CZ';
 import Panel from '../Panel/Locale/cs_CZ';
+import PersistentBar from '../PersistentBar/Locale/cs_CZ';
 import Stepper from '../Stepper/Locale/cs_CZ';
 import Table from '../Table/Locale/cs_CZ';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/cs_CZ';
@@ -21,6 +22,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/da_DK.tsx
+++ b/src/components/Locale/da_DK.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/da_DK';
 import InfoBar from '../InfoBar/Locale/da_DK';
 import Pagination from '../Pagination/Locale/da_DK';
 import Panel from '../Panel/Locale/da_DK';
+import PersistentBar from '../PersistentBar/Locale/da_DK';
 import Stepper from '../Stepper/Locale/da_DK';
 import Table from '../Table/Locale/da_DK';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/da_DK';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/de_DE.tsx
+++ b/src/components/Locale/de_DE.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/de_DE';
 import InfoBar from '../InfoBar/Locale/de_DE';
 import Pagination from '../Pagination/Locale/de_DE';
 import Panel from '../Panel/Locale/de_DE';
+import PersistentBar from '../PersistentBar/Locale/de_DE';
 import Stepper from '../Stepper/Locale/de_DE';
 import Table from '../Table/Locale/de_DE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/de_DE';
@@ -73,6 +74,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/el_GR.tsx
+++ b/src/components/Locale/el_GR.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/el_GR';
 import InfoBar from '../InfoBar/Locale/el_GR';
 import Pagination from '../Pagination/Locale/el_GR';
 import Panel from '../Panel/Locale/el_GR';
+import PersistentBar from '../PersistentBar/Locale/el_GR';
 import Stepper from '../Stepper/Locale/el_GR';
 import Table from '../Table/Locale/el_GR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/el_GR';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/en_GB.tsx
+++ b/src/components/Locale/en_GB.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/en_GB';
 import InfoBar from '../InfoBar/Locale/en_GB';
 import Pagination from '../Pagination/Locale/en_GB';
 import Panel from '../Panel/Locale/en_GB';
+import PersistentBar from '../PersistentBar/Locale/en_GB';
 import Stepper from '../Stepper/Locale/en_GB';
 import Table from '../Table/Locale/en_GB';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_GB';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/es_DO.tsx
+++ b/src/components/Locale/es_DO.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/es_DO';
 import InfoBar from '../InfoBar/Locale/es_DO';
 import Pagination from '../Pagination/Locale/es_DO';
 import Panel from '../Panel/Locale/es_DO';
+import PersistentBar from '../PersistentBar/Locale/es_DO';
 import Stepper from '../Stepper/Locale/es_DO';
 import Table from '../Table/Locale/es_DO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_DO';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/es_ES.tsx
+++ b/src/components/Locale/es_ES.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/es_ES';
 import InfoBar from '../InfoBar/Locale/es_ES';
 import Pagination from '../Pagination/Locale/es_ES';
 import Panel from '../Panel/Locale/es_ES';
+import PersistentBar from '../PersistentBar/Locale/es_ES';
 import Stepper from '../Stepper/Locale/es_ES';
 import Table from '../Table/Locale/es_ES';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_ES';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/es_MX.tsx
+++ b/src/components/Locale/es_MX.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/es_MX';
 import InfoBar from '../InfoBar/Locale/es_MX';
 import Pagination from '../Pagination/Locale/es_MX';
 import Panel from '../Panel/Locale/es_MX';
+import PersistentBar from '../PersistentBar/Locale/es_MX';
 import Stepper from '../Stepper/Locale/es_MX';
 import Table from '../Table/Locale/es_MX';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_MX';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/fi_FI.tsx
+++ b/src/components/Locale/fi_FI.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/fi_FI';
 import InfoBar from '../InfoBar/Locale/fi_FI';
 import Pagination from '../Pagination/Locale/fi_FI';
 import Panel from '../Panel/Locale/fi_FI';
+import PersistentBar from '../PersistentBar/Locale/fi_FI';
 import Stepper from '../Stepper/Locale/fi_FI';
 import Table from '../Table/Locale/fi_FI';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fi_FI';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/fr_BE.tsx
+++ b/src/components/Locale/fr_BE.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/fr_BE';
 import InfoBar from '../InfoBar/Locale/fr_BE';
 import Pagination from '../Pagination/Locale/fr_BE';
 import Panel from '../Panel/Locale/fr_BE';
+import PersistentBar from '../PersistentBar/Locale/fr_BE';
 import Stepper from '../Stepper/Locale/fr_BE';
 import Table from '../Table/Locale/fr_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_BE';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/fr_CA.tsx
+++ b/src/components/Locale/fr_CA.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/fr_CA';
 import InfoBar from '../InfoBar/Locale/fr_CA';
 import Pagination from '../Pagination/Locale/fr_CA';
 import Panel from '../Panel/Locale/fr_CA';
+import PersistentBar from '../PersistentBar/Locale/fr_CA';
 import Stepper from '../Stepper/Locale/fr_CA';
 import Table from '../Table/Locale/fr_CA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_CA';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/fr_FR.tsx
+++ b/src/components/Locale/fr_FR.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/fr_FR';
 import InfoBar from '../InfoBar/Locale/fr_FR';
 import Pagination from '../Pagination/Locale/fr_FR';
 import Panel from '../Panel/Locale/fr_FR';
+import PersistentBar from '../PersistentBar/Locale/fr_FR';
 import Stepper from '../Stepper/Locale/fr_FR';
 import Table from '../Table/Locale/fr_FR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_FR';
@@ -75,6 +76,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/he_IL.tsx
+++ b/src/components/Locale/he_IL.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/he_IL';
 import InfoBar from '../InfoBar/Locale/he_IL';
 import Pagination from '../Pagination/Locale/he_IL';
 import Panel from '../Panel/Locale/he_IL';
+import PersistentBar from '../PersistentBar/Locale/he_IL';
 import Stepper from '../Stepper/Locale/he_IL';
 import Table from '../Table/Locale/he_IL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/he_IL';
@@ -73,6 +74,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/hi_IN.tsx
+++ b/src/components/Locale/hi_IN.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/hi_IN';
 import InfoBar from '../InfoBar/Locale/hi_IN';
 import Pagination from '../Pagination/Locale/hi_IN';
 import Panel from '../Panel/Locale/hi_IN';
+import PersistentBar from '../PersistentBar/Locale/hi_IN';
 import Stepper from '../Stepper/Locale/hi_IN';
 import Table from '../Table/Locale/hi_IN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hi_IN';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/hr_HR.tsx
+++ b/src/components/Locale/hr_HR.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/hr_HR';
 import InfoBar from '../InfoBar/Locale/hr_HR';
 import Pagination from '../Pagination/Locale/hr_HR';
 import Panel from '../Panel/Locale/hr_HR';
+import PersistentBar from '../PersistentBar/Locale/hr_HR';
 import Stepper from '../Stepper/Locale/hr_HR';
 import Table from '../Table/Locale/hr_HR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hr_HR';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/ht_HT.tsx
+++ b/src/components/Locale/ht_HT.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/ht_HT';
 import InfoBar from '../InfoBar/Locale/ht_HT';
 import Pagination from '../Pagination/Locale/ht_HT';
 import Panel from '../Panel/Locale/ht_HT';
+import PersistentBar from '../PersistentBar/Locale/ht_HT';
 import Stepper from '../Stepper/Locale/ht_HT';
 import Table from '../Table/Locale/ht_HT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ht_HT';
@@ -75,6 +76,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/hu_HU.tsx
+++ b/src/components/Locale/hu_HU.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/hu_HU';
 import InfoBar from '../InfoBar/Locale/hu_HU';
 import Pagination from '../Pagination/Locale/hu_HU';
 import Panel from '../Panel/Locale/hu_HU';
+import PersistentBar from '../PersistentBar/Locale/hu_HU';
 import Stepper from '../Stepper/Locale/hu_HU';
 import Table from '../Table/Locale/hu_HU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hu_HU';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/it_IT.tsx
+++ b/src/components/Locale/it_IT.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/it_IT';
 import InfoBar from '../InfoBar/Locale/it_IT';
 import Pagination from '../Pagination/Locale/it_IT';
 import Panel from '../Panel/Locale/it_IT';
+import PersistentBar from '../PersistentBar/Locale/it_IT';
 import Stepper from '../Stepper/Locale/it_IT';
 import Table from '../Table/Locale/it_IT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/it_IT';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/ja_JP.tsx
+++ b/src/components/Locale/ja_JP.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/ja_JP';
 import InfoBar from '../InfoBar/Locale/ja_JP';
 import Pagination from '../Pagination/Locale/ja_JP';
 import Panel from '../Panel/Locale/ja_JP';
+import PersistentBar from '../PersistentBar/Locale/ja_JP';
 import Stepper from '../Stepper/Locale/ja_JP';
 import Table from '../Table/Locale/ja_JP';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ja_JP';
@@ -70,6 +71,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/ko_KR.tsx
+++ b/src/components/Locale/ko_KR.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/ko_KR';
 import InfoBar from '../InfoBar/Locale/ko_KR';
 import Pagination from '../Pagination/Locale/ko_KR';
 import Panel from '../Panel/Locale/ko_KR';
+import PersistentBar from '../PersistentBar/Locale/ko_KR';
 import Stepper from '../Stepper/Locale/ko_KR';
 import Table from '../Table/Locale/ko_KR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ko_KR';
@@ -70,6 +71,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/ms_MY.tsx
+++ b/src/components/Locale/ms_MY.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/ms_MY';
 import InfoBar from '../InfoBar/Locale/ms_MY';
 import Pagination from '../Pagination/Locale/ms_MY';
 import Panel from '../Panel/Locale/ms_MY';
+import PersistentBar from '../PersistentBar/Locale/ms_MY';
 import Stepper from '../Stepper/Locale/ms_MY';
 import Table from '../Table/Locale/ms_MY';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ms_MY';
@@ -21,6 +22,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/nb_NO.tsx
+++ b/src/components/Locale/nb_NO.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/nb_NO';
 import InfoBar from '../InfoBar/Locale/nb_NO';
 import Pagination from '../Pagination/Locale/nb_NO';
 import Panel from '../Panel/Locale/nb_NO';
+import PersistentBar from '../PersistentBar/Locale/nb_NO';
 import Stepper from '../Stepper/Locale/nb_NO';
 import Table from '../Table/Locale/nb_NO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nb_NO';
@@ -73,6 +74,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/nl_BE.tsx
+++ b/src/components/Locale/nl_BE.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/nl_BE';
 import InfoBar from '../InfoBar/Locale/nl_BE';
 import Pagination from '../Pagination/Locale/nl_BE';
 import Panel from '../Panel/Locale/nl_BE';
+import PersistentBar from '../PersistentBar/Locale/nl_BE';
 import Stepper from '../Stepper/Locale/nl_BE';
 import Table from '../Table/Locale/nl_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_BE';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/nl_NL.tsx
+++ b/src/components/Locale/nl_NL.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/nl_NL';
 import InfoBar from '../InfoBar/Locale/nl_NL';
 import Pagination from '../Pagination/Locale/nl_NL';
 import Panel from '../Panel/Locale/nl_NL';
+import PersistentBar from '../PersistentBar/Locale/nl_NL';
 import Stepper from '../Stepper/Locale/nl_NL';
 import Table from '../Table/Locale/nl_NL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_NL';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/pl_PL.tsx
+++ b/src/components/Locale/pl_PL.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/pl_PL';
 import InfoBar from '../InfoBar/Locale/pl_PL';
 import Pagination from '../Pagination/Locale/pl_PL';
 import Panel from '../Panel/Locale/pl_PL';
+import PersistentBar from '../PersistentBar/Locale/pl_PL';
 import Stepper from '../Stepper/Locale/pl_PL';
 import Table from '../Table/Locale/pl_PL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pl_PL';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/pt_BR.tsx
+++ b/src/components/Locale/pt_BR.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/pt_BR';
 import InfoBar from '../InfoBar/Locale/pt_BR';
 import Pagination from '../Pagination/Locale/pt_BR';
 import Panel from '../Panel/Locale/pt_BR';
+import PersistentBar from '../PersistentBar/Locale/pt_BR';
 import Stepper from '../Stepper/Locale/pt_BR';
 import Table from '../Table/Locale/pt_BR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_BR';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/pt_PT.tsx
+++ b/src/components/Locale/pt_PT.tsx
@@ -5,6 +5,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/pt_PT';
 import InfoBar from '../InfoBar/Locale/pt_PT';
 import Pagination from '../Pagination/Locale/pt_PT';
 import Panel from '../Panel/Locale/pt_PT';
+import PersistentBar from '../PersistentBar/Locale/pt_PT';
 import Stepper from '../Stepper/Locale/pt_PT';
 import Table from '../Table/Locale/pt_PT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_PT';
@@ -18,6 +19,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/ru_RU.tsx
+++ b/src/components/Locale/ru_RU.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/ru_RU';
 import InfoBar from '../InfoBar/Locale/ru_RU';
 import Pagination from '../Pagination/Locale/ru_RU';
 import Panel from '../Panel/Locale/ru_RU';
+import PersistentBar from '../PersistentBar/Locale/ru_RU';
 import Stepper from '../Stepper/Locale/ru_RU';
 import Table from '../Table/Locale/ru_RU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ru_RU';
@@ -73,6 +74,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/sv_SE.tsx
+++ b/src/components/Locale/sv_SE.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/sv_SE';
 import InfoBar from '../InfoBar/Locale/sv_SE';
 import Pagination from '../Pagination/Locale/sv_SE';
 import Panel from '../Panel/Locale/sv_SE';
+import PersistentBar from '../PersistentBar/Locale/sv_SE';
 import Stepper from '../Stepper/Locale/sv_SE';
 import Table from '../Table/Locale/sv_SE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/sv_SE';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/th_TH.tsx
+++ b/src/components/Locale/th_TH.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/th_TH';
 import InfoBar from '../InfoBar/Locale/th_TH';
 import Pagination from '../Pagination/Locale/th_TH';
 import Panel from '../Panel/Locale/th_TH';
+import PersistentBar from '../PersistentBar/Locale/th_TH';
 import Stepper from '../Stepper/Locale/th_TH';
 import Table from '../Table/Locale/th_TH';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/th_TH';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/tr_TR.tsx
+++ b/src/components/Locale/tr_TR.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/tr_TR';
 import InfoBar from '../InfoBar/Locale/tr_TR';
 import Pagination from '../Pagination/Locale/tr_TR';
 import Panel from '../Panel/Locale/tr_TR';
+import PersistentBar from '../PersistentBar/Locale/tr_TR';
 import Stepper from '../Stepper/Locale/tr_TR';
 import Table from '../Table/Locale/tr_TR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/tr_TR';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/uk_UA.tsx
+++ b/src/components/Locale/uk_UA.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/uk_UA';
 import InfoBar from '../InfoBar/Locale/uk_UA';
 import Pagination from '../Pagination/Locale/uk_UA';
 import Panel from '../Panel/Locale/uk_UA';
+import PersistentBar from '../PersistentBar/Locale/uk_UA';
 import Stepper from '../Stepper/Locale/uk_UA';
 import Table from '../Table/Locale/uk_UA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/uk_UA';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/zh_CN.tsx
+++ b/src/components/Locale/zh_CN.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/zh_CN';
 import InfoBar from '../InfoBar/Locale/zh_CN';
 import Pagination from '../Pagination/Locale/zh_CN';
 import Panel from '../Panel/Locale/zh_CN';
+import PersistentBar from '../PersistentBar/Locale/zh_CN';
 import Stepper from '../Stepper/Locale/zh_CN';
 import Table from '../Table/Locale/zh_CN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_CN';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/Locale/zh_TW.tsx
+++ b/src/components/Locale/zh_TW.tsx
@@ -6,6 +6,7 @@ import Dialog from '../Dialog/BaseDialog/Locale/zh_TW';
 import InfoBar from '../InfoBar/Locale/zh_TW';
 import Pagination from '../Pagination/Locale/zh_TW';
 import Panel from '../Panel/Locale/zh_TW';
+import PersistentBar from '../PersistentBar/Locale/zh_TW';
 import Stepper from '../Stepper/Locale/zh_TW';
 import Table from '../Table/Locale/zh_TW';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_TW';
@@ -74,6 +75,7 @@ const localeValues: Locale = {
   InfoBar,
   Pagination,
   Panel,
+  PersistentBar,
   Stepper,
   Table,
   TimePicker,

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -4,6 +4,7 @@ import type { BreadcrumbLocale } from '../Breadcrumb/Breadcrumb.types';
 import type { DialogLocale } from '../Dialog/BaseDialog/BaseDialog.types';
 import type { PaginationLocale } from '../Pagination';
 import type { PanelLocale } from '../Panel';
+import type { PersistentBarLocale } from '../PersistentBar/PersistentBar.types';
 import type { InfoBarLocale } from '../InfoBar';
 import type { PickerLocale as DatePickerLocale } from '../DateTimePicker/DatePicker/Generate/Generate.types';
 import type { StepperLocale } from '../Stepper';
@@ -25,6 +26,7 @@ export interface Locale {
   InfoBar?: InfoBarLocale;
   Pagination?: PaginationLocale;
   Panel?: PanelLocale;
+  PersistentBar?: PersistentBarLocale;
   Stepper?: StepperLocale;
   Table?: TableLocale;
   TimePicker?: Record<string, any>;

--- a/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
+++ b/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
@@ -23,8 +23,8 @@ export const MenuItemCustom: FC<MenuItemCustomProps> = ({
   ]);
 
   return (
-    <div className={menuItemClassNames}>
+    <li className={menuItemClassNames}>
       {item.render({ index, value: item, onChange })}
-    </div>
+    </li>
   );
 };

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`Menu Menu is large 1`] = `
               </span>
             </a>
           </li>
-          <div
+          <li
             class="menu-item-custom large my-menu-item-class"
           >
             <div
@@ -224,7 +224,7 @@ exports[`Menu Menu is large 1`] = `
                 </label>
               </div>
             </div>
-          </div>
+          </li>
         </ul>
       </div>
     </div>
@@ -368,7 +368,7 @@ exports[`Menu Menu is medium 1`] = `
               </span>
             </a>
           </li>
-          <div
+          <li
             class="menu-item-custom medium my-menu-item-class"
           >
             <div
@@ -456,7 +456,7 @@ exports[`Menu Menu is medium 1`] = `
                 </label>
               </div>
             </div>
-          </div>
+          </li>
         </ul>
       </div>
     </div>
@@ -600,7 +600,7 @@ exports[`Menu Menu is small 1`] = `
               </span>
             </a>
           </li>
-          <div
+          <li
             class="menu-item-custom small my-menu-item-class"
           >
             <div
@@ -688,7 +688,7 @@ exports[`Menu Menu is small 1`] = `
                 </label>
               </div>
             </div>
-          </div>
+          </li>
         </ul>
       </div>
     </div>

--- a/src/components/Pagination/pagination.module.scss
+++ b/src/components/Pagination/pagination.module.scss
@@ -94,7 +94,8 @@
   }
 
   .page-tracker {
-    opacity: 50%;
+    color: var(--text-secondary-color);
+    white-space: nowrap;
   }
 
   &.dots {

--- a/src/components/PersistentBar/Locale/cs_CZ.tsx
+++ b/src/components/PersistentBar/Locale/cs_CZ.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'cs_CZ',
+    overflowAriaLabelText: 'Další tlačítka',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/da_DK.tsx
+++ b/src/components/PersistentBar/Locale/da_DK.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'da_DK',
+    overflowAriaLabelText: 'Flere knapper',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/de_DE.tsx
+++ b/src/components/PersistentBar/Locale/de_DE.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'de_DE',
+    overflowAriaLabelText: 'Weitere Schaltflächen',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/el_GR.tsx
+++ b/src/components/PersistentBar/Locale/el_GR.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'el_GR',
+    overflowAriaLabelText: 'Περισσότερα κουμπιά',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/en_GB.tsx
+++ b/src/components/PersistentBar/Locale/en_GB.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'en_GB',
+    overflowAriaLabelText: 'More buttons',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/en_US.tsx
+++ b/src/components/PersistentBar/Locale/en_US.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'en_US',
+    overflowAriaLabelText: 'More buttons',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/es_DO.tsx
+++ b/src/components/PersistentBar/Locale/es_DO.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'es_DO',
+    overflowAriaLabelText: 'Más botones',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/es_ES.tsx
+++ b/src/components/PersistentBar/Locale/es_ES.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'es_ES',
+    overflowAriaLabelText: 'Más botones',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/es_MX.tsx
+++ b/src/components/PersistentBar/Locale/es_MX.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'es_MX',
+    overflowAriaLabelText: 'Más botones',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/fi_FI.tsx
+++ b/src/components/PersistentBar/Locale/fi_FI.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'fi_FI',
+    overflowAriaLabelText: 'Lisää painikkeita',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/fr_BE.tsx
+++ b/src/components/PersistentBar/Locale/fr_BE.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'fr_BE',
+    overflowAriaLabelText: 'Plus de boutons',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/fr_CA.tsx
+++ b/src/components/PersistentBar/Locale/fr_CA.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'fr_CA',
+    overflowAriaLabelText: 'Plus de boutons',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/fr_FR.tsx
+++ b/src/components/PersistentBar/Locale/fr_FR.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'fr_FR',
+    overflowAriaLabelText: 'Plus de boutons',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/he_IL.tsx
+++ b/src/components/PersistentBar/Locale/he_IL.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'he_IL',
+    overflowAriaLabelText: 'נוספים לחצנים',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/hi_IN.tsx
+++ b/src/components/PersistentBar/Locale/hi_IN.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'hi_IN',
+    overflowAriaLabelText: 'अधिक बटन',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/hr_HR.tsx
+++ b/src/components/PersistentBar/Locale/hr_HR.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'hr_HR',
+    overflowAriaLabelText: 'Više gumba',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/ht_HT.tsx
+++ b/src/components/PersistentBar/Locale/ht_HT.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'ht_HT',
+    overflowAriaLabelText: 'Plis bouton',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/hu_HU.tsx
+++ b/src/components/PersistentBar/Locale/hu_HU.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'hu_HU',
+    overflowAriaLabelText: 'További gombok',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/it_IT.tsx
+++ b/src/components/PersistentBar/Locale/it_IT.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'it_IT',
+    overflowAriaLabelText: 'Altri pulsanti',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/ja_JP.tsx
+++ b/src/components/PersistentBar/Locale/ja_JP.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'ja_JP',
+    overflowAriaLabelText: 'その他のボタン',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/ko_KR.tsx
+++ b/src/components/PersistentBar/Locale/ko_KR.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'ko_KR',
+    overflowAriaLabelText: '더 많은 버튼',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/ms_MY.tsx
+++ b/src/components/PersistentBar/Locale/ms_MY.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'ms_MY',
+    overflowAriaLabelText: 'Butang lagi',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/nb_NO.tsx
+++ b/src/components/PersistentBar/Locale/nb_NO.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'nb_NO',
+    overflowAriaLabelText: 'Flere knapper',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/nl_BE.tsx
+++ b/src/components/PersistentBar/Locale/nl_BE.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'nl_BE',
+    overflowAriaLabelText: 'Meer knoppen',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/nl_NL.tsx
+++ b/src/components/PersistentBar/Locale/nl_NL.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'nl_NL',
+    overflowAriaLabelText: 'Meer knoppen',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/pl_PL.tsx
+++ b/src/components/PersistentBar/Locale/pl_PL.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'pl_PL',
+    overflowAriaLabelText: 'Więcej przycisków',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/pt_BR.tsx
+++ b/src/components/PersistentBar/Locale/pt_BR.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'pt_BR',
+    overflowAriaLabelText: 'Mais botões',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/pt_PT.tsx
+++ b/src/components/PersistentBar/Locale/pt_PT.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'pt_PT',
+    overflowAriaLabelText: 'Mais botões',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/ru_RU.tsx
+++ b/src/components/PersistentBar/Locale/ru_RU.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'ru_RU',
+    overflowAriaLabelText: 'Дополнительные кнопки',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/sv_SE.tsx
+++ b/src/components/PersistentBar/Locale/sv_SE.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'sv_SE',
+    overflowAriaLabelText: 'Fler knappar',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/th_TH.tsx
+++ b/src/components/PersistentBar/Locale/th_TH.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'th_TH',
+    overflowAriaLabelText: 'ปุ่มเพิ่มเติม',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/tr_TR.tsx
+++ b/src/components/PersistentBar/Locale/tr_TR.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'tr_TR',
+    overflowAriaLabelText: 'Diğer düğmeler',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/uk_UA.tsx
+++ b/src/components/PersistentBar/Locale/uk_UA.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'uk_UA',
+    overflowAriaLabelText: 'Більше кнопок',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/zh_CN.tsx
+++ b/src/components/PersistentBar/Locale/zh_CN.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'zh_CN',
+    overflowAriaLabelText: '更多按钮',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/zh_TW.tsx
+++ b/src/components/PersistentBar/Locale/zh_TW.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'zh_TW',
+    overflowAriaLabelText: '更多按鈕',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/PersistentBar.stories.tsx
+++ b/src/components/PersistentBar/PersistentBar.stories.tsx
@@ -97,17 +97,10 @@ const paginationArgs: Object = {
 };
 
 const persistentBarArgs: Object = {
-  closable: true,
+  bordered: false,
   style: {},
   classNames: 'my-persistent-bar-class',
-  closeButtonProps: {
-    ariaLabel: 'Close',
-    classNames: 'my-close-btn-class',
-    'data-testid': 'my-close-btn-test-id',
-    id: 'myCloseButton',
-  },
-  closeIcon: IconName.mdiClose,
-  role: 'presentation',
+  role: 'toolbar',
   type: PersistentBarType.bottomBarWithText,
   paginationTotal: 150,
 };

--- a/src/components/PersistentBar/PersistentBar.stories.tsx
+++ b/src/components/PersistentBar/PersistentBar.stories.tsx
@@ -4,7 +4,11 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { PersistentBar, PersistentBarType } from './';
 import { IconName } from '../Icon';
 import { PaginationLayoutOptions } from '../Pagination';
-import { ButtonVariant, ButtonVariant as ButtonType } from '../Button';
+import {
+  ButtonVariant,
+  ButtonVariant as ButtonType,
+  ButtonShape,
+} from '../Button';
 
 export default {
   title: 'Persistent Bar',
@@ -48,10 +52,12 @@ const PersistentBar_Story: ComponentStory<typeof PersistentBar> = (args) => (
 export const Bottom_Bar_With_Text = PersistentBar_Story.bind({});
 export const Bottom_Bar_Secondary_Buttons = PersistentBar_Story.bind({});
 export const Bottom_Bar_Buttons_On_Left = PersistentBar_Story.bind({});
+export const Bottom_Bar_Buttons_On_Right = PersistentBar_Story.bind({});
 export const Top_Bar_Buttons = PersistentBar_Story.bind({});
 export const Top_Bar_Buttons_Legacy = PersistentBar_Story.bind({});
 export const Top_Bar_With_Text = PersistentBar_Story.bind({});
 export const Top_Bar_Pagination = PersistentBar_Story.bind({});
+export const Custom = PersistentBar_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
@@ -60,10 +66,12 @@ export const __namedExportsOrder = [
   'Bottom_Bar_With_Text',
   'Bottom_Bar_Secondary_Buttons',
   'Bottom_Bar_Buttons_On_Left',
+  'Bottom_Bar_Buttons_On_Right',
   'Top_Bar_Buttons',
   'Top_Bar_Buttons_Legacy',
   'Top_Bar_With_Text',
   'Top_Bar_Pagination',
+  'Custom',
 ];
 
 const paginationArgs: Object = {
@@ -85,7 +93,7 @@ const paginationArgs: Object = {
   quickNextIconButtonAriaLabel: 'Next 5',
   quickPreviousIconButtonAriaLabel: 'Previous 5',
   totalText: 'Total',
-  'data-test-id': 'myPaginationTestId',
+  'data-testid': 'myPaginationTestId',
 };
 
 const persistentBarArgs: Object = {
@@ -95,7 +103,7 @@ const persistentBarArgs: Object = {
   closeButtonProps: {
     ariaLabel: 'Close',
     classNames: 'my-close-btn-class',
-    'data-test-id': 'my-close-btn-test-id',
+    'data-testid': 'my-close-btn-test-id',
     id: 'myCloseButton',
   },
   closeIcon: IconName.mdiClose,
@@ -109,7 +117,7 @@ Bottom_Bar_With_Text.args = {
   actionButtonOneProps: {
     ariaLabel: 'Primary',
     classNames: 'my-primary-btn-class',
-    'data-test-id': 'my-primary-btn-test-id',
+    'data-testid': 'my-primary-btn-test-id',
     iconProps: null,
     id: 'myPrimaryButton',
     text: 'Primary',
@@ -117,7 +125,7 @@ Bottom_Bar_With_Text.args = {
   actionButtonTwoProps: {
     ariaLabel: 'Default',
     classNames: 'my-default-btn-class',
-    'data-test-id': 'my-default-btn-test-id',
+    'data-testid': 'my-default-btn-test-id',
     iconProps: null,
     id: 'myDefaultButton',
     text: 'Default',
@@ -130,25 +138,25 @@ Bottom_Bar_With_Text.args = {
 Bottom_Bar_Secondary_Buttons.args = {
   ...persistentBarArgs,
   actionButtonOneProps: {
-    ariaLabel: 'Default',
+    ariaLabel: 'Default 1',
     classNames: 'my-default-btn-class',
-    'data-test-id': 'my-default-btn-test-id',
+    'data-testid': 'my-default-btn-test-id-1',
     iconProps: null,
-    id: 'myDefaultButton',
-    text: 'Default',
+    id: 'myDefaultButton1',
+    text: 'Default 1',
   },
   actionButtonTwoProps: {
-    ariaLabel: 'Default',
+    ariaLabel: 'Default 2',
     classNames: 'my-default-btn-class',
-    'data-test-id': 'my-default-btn-test-id',
+    'data-testid': 'my-default-btn-test-id-2',
     iconProps: null,
-    id: 'myDefaultButton',
-    text: 'Default',
+    id: 'myDefaultButton2',
+    text: 'Default 2',
   },
   actionButtonThreeProps: {
     ariaLabel: 'Default',
     classNames: 'my-default-btn-class',
-    'data-test-id': 'my-default-btn-test-id',
+    'data-testid': 'my-default-btn-test-id',
     iconProps: null,
     id: 'myDefaultButton',
     text: 'Default',
@@ -159,25 +167,25 @@ Bottom_Bar_Secondary_Buttons.args = {
 Bottom_Bar_Buttons_On_Left.args = {
   ...persistentBarArgs,
   actionButtonOneProps: {
-    ariaLabel: 'Default',
+    ariaLabel: 'Default 1',
     classNames: 'my-default-btn-class',
-    'data-test-id': 'my-default-btn-test-id',
+    'data-testid': 'my-default-btn-test-id-1',
     iconProps: null,
-    id: 'myDefaultButton',
+    id: 'myDefaultButton1',
     text: 'Default',
   },
   actionButtonTwoProps: {
-    ariaLabel: 'Default',
+    ariaLabel: 'Default 2',
     classNames: 'my-default-btn-class',
-    'data-test-id': 'my-default-btn-test-id',
+    'data-testid': 'my-default-btn-test-id-2',
     iconProps: null,
-    id: 'myDefaultButton',
+    id: 'myDefaultButton2',
     text: 'Default',
   },
   actionButtonThreeProps: {
     ariaLabel: 'Primary',
     classNames: 'my-primary-btn-class',
-    'data-test-id': 'my-primary-btn-test-id',
+    'data-testid': 'my-primary-btn-test-id',
     iconProps: null,
     id: 'myPrimaryButton',
     text: 'Primary',
@@ -185,65 +193,96 @@ Bottom_Bar_Buttons_On_Left.args = {
   type: PersistentBarType.bottomBarButtonsOnLeft,
 };
 
+Bottom_Bar_Buttons_On_Right.args = {
+  ...persistentBarArgs,
+  actionButtonOneProps: {
+    ariaLabel: 'Default 1',
+    classNames: 'my-default-btn-class',
+    'data-testid': 'my-default-btn-test-id-1',
+    iconProps: null,
+    id: 'myDefaultButton1',
+    text: 'Default',
+  },
+  actionButtonTwoProps: {
+    ariaLabel: 'Default 2',
+    classNames: 'my-default-btn-class',
+    'data-testid': 'my-default-btn-test-id-2',
+    iconProps: null,
+    id: 'myDefaultButton2',
+    text: 'Default',
+  },
+  actionButtonThreeProps: {
+    ariaLabel: 'Primary',
+    classNames: 'my-primary-btn-class',
+    'data-testid': 'my-primary-btn-test-id',
+    iconProps: null,
+    id: 'myPrimaryButton',
+    text: 'Primary',
+  },
+  type: PersistentBarType.bottomBarButtonsOnRight,
+};
+
 Top_Bar_Buttons.args = {
   ...persistentBarArgs,
   buttonMenuProps: [
     {
-      ariaLabel: 'Save Icon Button',
+      ariaLabel: 'Bookmark Icon Button 1',
       iconProps: { path: IconName.mdiBookmark },
-      id: 'myBookmarkButton',
+      id: 'myBookmarkButton1',
+      shape: ButtonShape.Round,
       text: null,
       variant: ButtonVariant.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 1',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-1',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton1',
+      text: 'Secondary 1',
       variant: ButtonVariant.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 2',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-2',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton2',
+      text: 'Secondary 2',
       variant: ButtonVariant.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 3',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-3',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton3',
+      text: 'Secondary 3',
       variant: ButtonVariant.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 4',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-4',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton4',
+      text: 'Secondary 4',
       variant: ButtonVariant.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 5',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-5',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton5',
+      text: 'Secondary 5',
       variant: ButtonVariant.Secondary,
     },
     {
-      ariaLabel: 'Save Icon Button',
-      iconProps: { path: IconName.mdiDotsVertical },
-      id: 'myMenuButton',
+      ariaLabel: 'Bookmark Icon Button 2',
+      iconProps: { path: IconName.mdiBookmark },
+      id: 'myBookmarkButton2',
+      shape: ButtonShape.Round,
       text: null,
       variant: ButtonVariant.Secondary,
     },
@@ -256,61 +295,63 @@ Top_Bar_Buttons_Legacy.args = {
   ...persistentBarArgs,
   buttonMenuProps: [
     {
-      ariaLabel: 'Save Icon Button',
+      ariaLabel: 'Bookmark Icon Button 1',
       iconProps: { path: IconName.mdiBookmark },
-      id: 'myBookmarkButton',
+      id: 'myBookmarkButton1',
+      shape: ButtonShape.Round,
       text: null,
       type: ButtonType.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 1',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-1',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton1',
+      text: 'Secondary 1',
       type: ButtonType.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 2',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-2',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton2',
+      text: 'Secondary 2',
       type: ButtonType.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 3',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-3',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton3',
+      text: 'Secondary 3',
       type: ButtonType.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 4',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-4',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton4',
+      text: 'Secondary 4',
       type: ButtonType.Secondary,
     },
     {
-      ariaLabel: 'Secondary',
+      ariaLabel: 'Secondary 5',
       classNames: 'my-primary-btn-class',
-      'data-test-id': 'my-primary-btn-test-id',
+      'data-testid': 'my-primary-btn-test-id-5',
       iconProps: null,
-      id: 'myPrimaryButton',
-      text: 'Secondary',
+      id: 'mySecondaryButton5',
+      text: 'Secondary 5',
       type: ButtonType.Secondary,
     },
     {
-      ariaLabel: 'Save Icon Button',
-      iconProps: { path: IconName.mdiDotsVertical },
-      id: 'myMenuButton',
+      ariaLabel: 'Bookmark Icon Button 2',
+      iconProps: { path: IconName.mdiBookmark },
+      id: 'myBookmarkButton2',
+      shape: ButtonShape.Round,
       text: null,
       type: ButtonType.Secondary,
     },
@@ -329,4 +370,28 @@ Top_Bar_Pagination.args = {
   ...persistentBarArgs,
   type: PersistentBarType.topBarPagination,
   paginationArgs,
+};
+
+Custom.args = {
+  ...persistentBarArgs,
+  children: (
+    <div className="octuple">
+      <div className="octuple-content" style={{ padding: 0 }}>
+        <h4
+          style={{
+            fontSize: '16px',
+            fontWeight: 600,
+            lineHeight: '18px',
+            margin: 0,
+            padding: 0,
+          }}
+        >
+          Header 4 as Title:
+        </h4>
+        <div className="octuple-content__small" style={{ padding: 0 }}>
+          content small is used for supporting text.
+        </div>
+      </div>
+    </div>
+  ),
 };

--- a/src/components/PersistentBar/PersistentBar.test.tsx
+++ b/src/components/PersistentBar/PersistentBar.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import { PersistentBar, PersistentBarType } from './';
+import { render } from '@testing-library/react';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+let matchMedia: any;
+
+class ResizeObserver {
+  observe() {
+    // do nothing
+  }
+  unobserve() {
+    // do nothing
+  }
+  disconnect() {
+    // do nothing
+  }
+}
+
+window.ResizeObserver = ResizeObserver;
+
+describe('PersistentBar', () => {
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  test('Renders without crashing', () => {
+    const { container, getByRole } = render(
+      <PersistentBar content={'PersistentBar test render'} />
+    );
+    const infoBar = getByRole('region');
+    expect(() => container).not.toThrowError();
+    expect(infoBar).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is bottomBarButtonsOnLeft', () => {
+    const { container } = render(
+      <PersistentBar
+        content={'PersistentBar test bottomBarButtonsOnLeft'}
+        type={PersistentBarType.bottomBarButtonsOnLeft}
+      />
+    );
+    expect(container.querySelector('.bottom-left-align')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is bottomBarButtonsOnRight', () => {
+    const { container } = render(
+      <PersistentBar
+        content={'PersistentBar test bottomBarButtonsOnRight'}
+        type={PersistentBarType.bottomBarButtonsOnRight}
+      />
+    );
+    expect(container.querySelector('.bottom-right-align')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is bottomBarSecondaryButtons', () => {
+    const { container } = render(
+      <PersistentBar
+        content={'PersistentBar test bottomBarSecondaryButtons'}
+        type={PersistentBarType.bottomBarSecondaryButtons}
+      />
+    );
+    expect(container.querySelector('.bottom-secondary-buttons')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is bottomBarWithText', () => {
+    const { container } = render(
+      <PersistentBar
+        content={'PersistentBar test bottomBarWithText'}
+        type={PersistentBarType.bottomBarWithText}
+      />
+    );
+    expect(container.querySelector('.bottom-with-text')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is topBarButtons', () => {
+    const { container } = render(
+      <PersistentBar
+        content={'PersistentBar test topBarButtons'}
+        type={PersistentBarType.topBarButtons}
+      />
+    );
+    expect(container.querySelector('.top-button-menu')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is topBarPagination', () => {
+    const { container } = render(
+      <PersistentBar
+        content={'PersistentBar test topBarPagination'}
+        type={PersistentBarType.topBarPagination}
+      />
+    );
+    expect(container.querySelector('.top-pagination')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is topBarWithText', () => {
+    const { container } = render(
+      <PersistentBar
+        content={'PersistentBar test topBarWithText'}
+        type={PersistentBarType.topBarWithText}
+      />
+    );
+    expect(container.querySelector('.top-with-text')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('PersistentBar is custom', () => {
+    const { container } = render(
+      <PersistentBar
+        children={<div className="custom">PersistentBar test custom</div>}
+      />
+    );
+    expect(container.querySelector('.custom')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/PersistentBar/PersistentBar.test.tsx
+++ b/src/components/PersistentBar/PersistentBar.test.tsx
@@ -36,7 +36,7 @@ describe('PersistentBar', () => {
     const { container, getByRole } = render(
       <PersistentBar content={'PersistentBar test render'} />
     );
-    const infoBar = getByRole('region');
+    const infoBar = getByRole('toolbar');
     expect(() => container).not.toThrowError();
     expect(infoBar).toBeTruthy();
     expect(container).toMatchSnapshot();

--- a/src/components/PersistentBar/PersistentBar.tsx
+++ b/src/components/PersistentBar/PersistentBar.tsx
@@ -41,10 +41,11 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
   (props: PersistentBarsProps, ref: Ref<HTMLDivElement>) => {
     const {
       buttonMenuProps,
+      bordered = false,
       content,
       icon,
       type = PersistentBarType.bottomBarWithText,
-      closable,
+      closable, // TODO: implement close support when vscode instances are updated
       children,
       onClose,
       style,
@@ -54,7 +55,7 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
       actionButtonOneProps,
       actionButtonTwoProps,
       actionButtonThreeProps,
-      role = 'region',
+      role = 'toolbar',
       title,
       overflowAriaLabel: defaultOverflowAriaLabel,
       paginationArgs, // TODO: Remove in Octuple v3
@@ -109,6 +110,9 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
     const persistentBarClassNames: string = mergeClasses([
       styles.persistentBar,
       classNames,
+      {
+        [styles.bordered]: !!bordered,
+      },
       {
         [styles.bottomWithText]: type === PersistentBarType.bottomBarWithText,
       },

--- a/src/components/PersistentBar/PersistentBar.tsx
+++ b/src/components/PersistentBar/PersistentBar.tsx
@@ -1,27 +1,51 @@
-import React, { FC, ReactNode, Ref } from 'react';
-import { Icon, IconName } from '../Icon';
-import { PersistentBarsProps, PersistentBarType } from './PersistentBar.types';
-import { mergeClasses } from '../../shared/utilities';
+import React, { FC, ReactNode, Ref, useEffect, useRef, useState } from 'react';
 import {
+  BUTTON_MENU_AFFORDANCE,
+  BUTTON_PADDING,
+  LINES_TO_SHOW,
+  PersistentBarLocale,
+  PersistentBarsProps,
+  PersistentBarType,
+} from './PersistentBar.types';
+import {
+  Button,
   ButtonProps,
+  ButtonShape,
   ButtonVariant,
-  PrimaryButton,
-  DefaultButton,
-  SecondaryButton,
+  ButtonWidth,
 } from '../Button';
-import { Pagination, PaginationLayoutOptions } from '../Pagination';
+import { Dropdown } from '../Dropdown';
+import Grid from '../Grid';
+import { IconName } from '../Icon';
+import { Menu, MenuItemCustomProps, MenuItemType, MenuSize } from '../Menu';
+import {
+  PagerSizeOptions,
+  Pagination,
+  PaginationLayoutOptions,
+} from '../Pagination';
+import { Stack } from '../Stack';
+import LocaleReceiver, {
+  useLocaleReceiver,
+} from '../LocaleProvider/LocaleReceiver';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
+import { useMaxVisibleSections } from '../../hooks/useMaxVisibleSections';
+import { useMergedRefs } from '../../hooks/useMergedRefs';
+import { Breakpoint, mergeClasses } from '../../shared/utilities';
+import enUS from './Locale/en_US';
 
 import styles from './persistentBar.module.scss';
 
+const { useBreakpoint } = Grid;
+
 export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
-  (
-    {
+  (props: PersistentBarsProps, ref: Ref<HTMLDivElement>) => {
+    const {
       buttonMenuProps,
       content,
       icon,
       type = PersistentBarType.bottomBarWithText,
       closable,
+      children,
       onClose,
       style,
       classNames,
@@ -30,17 +54,59 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
       actionButtonOneProps,
       actionButtonTwoProps,
       actionButtonThreeProps,
-      role = 'presentation',
+      role = 'region',
       title,
-      paginationArgs,
+      overflowAriaLabel: defaultOverflowAriaLabel,
+      paginationArgs, // TODO: Remove in Octuple v3
+      paginationProps,
       paginationTotal,
       ...rest
-    },
-    ref: Ref<HTMLDivElement>
-  ) => {
+    } = props;
     const htmlDir: string = useCanvasDirection();
+    const screens: Partial<Record<Breakpoint, boolean>> = useBreakpoint();
+    const internalRef: React.MutableRefObject<HTMLDivElement> =
+      useRef<HTMLDivElement>(null);
+    const buttonRefs: React.MutableRefObject<HTMLElement[]> = useRef<
+      HTMLElement[]
+    >([]);
+    const mergedRef: (node: HTMLDivElement) => void = useMergedRefs(
+      internalRef,
+      ref
+    );
+    const maxSections = useMaxVisibleSections(
+      internalRef,
+      buttonRefs,
+      BUTTON_MENU_AFFORDANCE,
+      BUTTON_PADDING,
+      LINES_TO_SHOW,
+      buttonMenuProps?.length
+    );
 
-    const persistentBarClasses: string = mergeClasses([
+    // ============================ Strings ===========================
+    const [persistentBarLocale] = useLocaleReceiver('PersistentBar');
+    let mergedLocale: PersistentBarLocale;
+
+    if (props.locale) {
+      mergedLocale = props.locale;
+    } else {
+      mergedLocale = persistentBarLocale || props.locale;
+    }
+
+    const [overflowAriaLabel, setOverflowAriaLabel] = useState<string>(
+      defaultOverflowAriaLabel
+    );
+
+    // Locs: if the prop isn't provided use the loc defaults.
+    // If the mergedLocale is changed, update.
+    useEffect((): void => {
+      setOverflowAriaLabel(
+        props.overflowAriaLabel
+          ? props.overflowAriaLabel
+          : mergedLocale.lang!.overflowAriaLabelText
+      );
+    }, [mergedLocale]);
+
+    const persistentBarClassNames: string = mergeClasses([
       styles.persistentBar,
       classNames,
       {
@@ -53,6 +119,10 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
       {
         [styles.bottomLeftAlign]:
           type === PersistentBarType.bottomBarButtonsOnLeft,
+      },
+      {
+        [styles.bottomRightAlign]:
+          type === PersistentBarType.bottomBarButtonsOnRight,
       },
       {
         [styles.topButtonMenu]: type === PersistentBarType.topBarButtons,
@@ -78,14 +148,14 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
       }
     };
 
-    const getTexts = (): ReactNode => {
+    const getContent = (): ReactNode => {
       switch (type) {
         case PersistentBarType.bottomBarWithText:
         case PersistentBarType.topBarWithText:
           return (
             <div>
               <h4>{title}</h4>
-              <span className={styles.content}>{content}</span>
+              <div className={styles.content}>{content}</div>
             </div>
           );
         default:
@@ -93,58 +163,205 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
       }
     };
 
-    const getBarLayout = (): ReactNode => {
+    const getPersistentBarLayout = (): ReactNode => {
+      const breakPoints: string[] = Object.entries(screens)
+        .filter((screen) => !!screen[1])
+        .map((screen) => screen[0]);
+      const smallScreens: boolean = !breakPoints.includes('md');
+      const xSmallScreens: boolean = !breakPoints.includes('sm');
+
       switch (type) {
         case PersistentBarType.bottomBarWithText:
-          return (
-            <>
-              {getTexts()}
-              <div>
+          if (breakPoints.length && xSmallScreens) {
+            return (
+              <Stack
+                direction="vertical"
+                flexGap="m"
+                fullWidth
+                justify="space-between"
+              >
+                {getContent()}
                 {actionButtonTwoProps && (
-                  <DefaultButton
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
                     {...actionButtonTwoProps}
                     classNames={styles.DefaultButton}
                   />
                 )}
                 {actionButtonOneProps && (
-                  <PrimaryButton {...actionButtonOneProps} />
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
+                    variant={ButtonVariant.Primary}
+                    {...actionButtonOneProps}
+                  />
+                )}
+              </Stack>
+            );
+          }
+          return (
+            <>
+              {getContent()}
+              <div>
+                {actionButtonTwoProps && (
+                  <Button
+                    {...actionButtonTwoProps}
+                    classNames={styles.DefaultButton}
+                  />
+                )}
+                {actionButtonOneProps && (
+                  <Button
+                    variant={ButtonVariant.Primary}
+                    {...actionButtonOneProps}
+                  />
                 )}
               </div>
             </>
           );
         case PersistentBarType.bottomBarSecondaryButtons:
+          if (breakPoints.length && xSmallScreens) {
+            return (
+              <Stack
+                direction="vertical"
+                flexGap="m"
+                fullWidth
+                justify="space-between"
+              >
+                {actionButtonOneProps && (
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
+                    variant={ButtonVariant.Secondary}
+                    {...actionButtonOneProps}
+                  />
+                )}
+                {actionButtonTwoProps && (
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
+                    variant={ButtonVariant.Secondary}
+                    {...actionButtonTwoProps}
+                  />
+                )}
+                {actionButtonThreeProps && (
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
+                    variant={ButtonVariant.Secondary}
+                    {...actionButtonThreeProps}
+                  />
+                )}
+              </Stack>
+            );
+          }
+
           return (
             <>
               {actionButtonOneProps && (
-                <SecondaryButton {...actionButtonOneProps} />
+                <Button
+                  variant={ButtonVariant.Secondary}
+                  {...actionButtonOneProps}
+                />
               )}
               {actionButtonTwoProps && (
-                <SecondaryButton {...actionButtonTwoProps} />
+                <Button
+                  variant={ButtonVariant.Secondary}
+                  {...actionButtonTwoProps}
+                />
               )}
               {actionButtonThreeProps && (
-                <SecondaryButton {...actionButtonThreeProps} />
+                <Button
+                  variant={ButtonVariant.Secondary}
+                  {...actionButtonThreeProps}
+                />
               )}
             </>
           );
         case PersistentBarType.bottomBarButtonsOnLeft:
+        case PersistentBarType.bottomBarButtonsOnRight:
+          if (breakPoints.length && xSmallScreens) {
+            return (
+              <Stack
+                direction="vertical"
+                flexGap="m"
+                fullWidth
+                justify="space-between"
+              >
+                {actionButtonOneProps && (
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
+                    {...actionButtonOneProps}
+                  />
+                )}
+                {actionButtonTwoProps && (
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
+                    {...actionButtonTwoProps}
+                  />
+                )}
+                {actionButtonThreeProps && (
+                  <Button
+                    buttonWidth={ButtonWidth.fill}
+                    variant={ButtonVariant.Primary}
+                    {...actionButtonThreeProps}
+                  />
+                )}
+              </Stack>
+            );
+          }
+
           return (
             <>
-              {actionButtonOneProps && (
-                <DefaultButton {...actionButtonOneProps} />
-              )}
-              {actionButtonTwoProps && (
-                <DefaultButton {...actionButtonTwoProps} />
-              )}
+              {actionButtonOneProps && <Button {...actionButtonOneProps} />}
+              {actionButtonTwoProps && <Button {...actionButtonTwoProps} />}
               {actionButtonThreeProps && (
-                <PrimaryButton {...actionButtonThreeProps} />
+                <Button
+                  variant={ButtonVariant.Primary}
+                  {...actionButtonThreeProps}
+                />
               )}
             </>
           );
         case PersistentBarType.topBarWithText:
+          if (breakPoints.length && xSmallScreens) {
+            return (
+              <Stack direction="vertical" fullWidth justify="space-between">
+                <Stack direction="horizontal" fullWidth justify="space-between">
+                  <Button
+                    classNames={styles.iconButton}
+                    iconProps={{ path: getIconName() }}
+                    shape={ButtonShape.Round}
+                    variant={ButtonVariant.SystemUI}
+                    {...actionButtonOneProps}
+                  />
+                  <Pagination
+                    total={paginationTotal}
+                    layout={[
+                      PaginationLayoutOptions.Previous,
+                      PaginationLayoutOptions.Pager,
+                      PaginationLayoutOptions.Next,
+                      PaginationLayoutOptions.Simplified,
+                    ]}
+                    {...paginationArgs}
+                    {...paginationProps}
+                  />
+                </Stack>
+                {getContent()}
+              </Stack>
+            );
+          }
+
           return (
-            <>
-              <Icon path={getIconName()} classNames={styles.icon} />
-              <div>{getTexts()}</div>
+            <Stack
+              direction="horizontal"
+              flexGap="m"
+              fullWidth
+              justify="space-between"
+            >
+              <Button
+                classNames={styles.iconButton}
+                iconProps={{ path: getIconName() }}
+                shape={ButtonShape.Round}
+                variant={ButtonVariant.SystemUI}
+                {...actionButtonOneProps}
+              />
+              {getContent()}
               <Pagination
                 total={paginationTotal}
                 layout={[
@@ -154,41 +371,137 @@ export const PersistentBar: FC<PersistentBarsProps> = React.forwardRef(
                   PaginationLayoutOptions.Simplified,
                 ]}
                 {...paginationArgs}
+                {...paginationProps}
               />
-            </>
+            </Stack>
           );
         case PersistentBarType.topBarPagination:
           return (
-            <>
-              <Pagination total={paginationTotal} {...paginationArgs} />
-            </>
+            <Pagination
+              total={paginationTotal}
+              {...paginationArgs}
+              {...paginationProps}
+              classNames={
+                breakPoints.length && xSmallScreens
+                  ? styles.persistentBarPaginationXsmall
+                  : ''
+              }
+              pagerSize={
+                breakPoints.length && smallScreens
+                  ? PagerSizeOptions.Small
+                  : PagerSizeOptions.Medium
+              }
+            />
           );
         default:
           return null;
       }
     };
 
+    const getButtonMenu = (buttonMenuProps: ButtonProps[]): JSX.Element => {
+      const getItems = (): MenuItemCustomProps[] => {
+        return buttonMenuProps?.map((button?: ButtonProps, idx?: number) => ({
+          classNames: styles.persistentBarMenuItem,
+          render: () => (
+            <Button
+              variant={ButtonVariant.Secondary}
+              buttonWidth={ButtonWidth.fill}
+              {...button}
+              iconProps={{ ...button.iconProps }}
+              key={'buttonMenuItem-' + idx}
+              shape={ButtonShape.Pill}
+              text={
+                !!button.iconProps && !button.text
+                  ? `${button.ariaLabel}`
+                  : `${button.text}`
+              }
+            />
+          ),
+          type: MenuItemType.custom,
+        }));
+      };
+
+      return (
+        <li key="button-menu">
+          <Dropdown
+            overlay={<Menu items={getItems()} size={MenuSize.small} />}
+            portal
+          >
+            <Button
+              ariaLabel={overflowAriaLabel}
+              iconProps={{ path: IconName.mdiDotsVertical }}
+              shape={ButtonShape.Round}
+              variant={ButtonVariant.Secondary}
+            />
+          </Dropdown>
+        </li>
+      );
+    };
+
+    const getButtons = (): ReactNode => {
+      const maxSectionsCount: number = maxSections.count;
+
+      let buttons: React.ReactElement[] = [];
+
+      buttonMenuProps?.forEach((item: ButtonProps, idx: number) => {
+        const button: JSX.Element = (
+          <li
+            className={mergeClasses([
+              styles.persistentBarListItem,
+              { [styles.visuallyHidden]: idx >= maxSectionsCount },
+            ])}
+            key={'buttonItem-' + idx}
+            ref={(ref) => (buttonRefs.current[idx] = ref)}
+          >
+            <Button {...item} />
+          </li>
+        );
+
+        buttons.push(button);
+
+        if (buttons.length === maxSectionsCount && maxSections.filled) {
+          const buttonMenuItems: Array<ButtonProps> =
+            buttonMenuProps?.slice(maxSectionsCount);
+          buttons.push(getButtonMenu(buttonMenuItems));
+        }
+      });
+
+      return <>{buttons}</>;
+    };
+
     return (
-      <div
-        {...rest}
-        className={persistentBarClasses}
-        ref={ref}
-        style={style}
-        role={role}
-      >
-        {buttonMenuProps &&
-          buttonMenuProps.map((button: ButtonProps) => {
-            if (
-              button.variant === ButtonVariant.Secondary ||
-              button.type === ButtonVariant.Secondary
-            ) {
-              return (
-                <SecondaryButton iconProps={button.iconProps} {...button} />
-              );
-            } else return null;
-          })}
-        {getBarLayout()}
-      </div>
+      <LocaleReceiver componentName={'PersistentBar'} defaultLocale={enUS}>
+        {(_contextLocale: PersistentBarLocale) => {
+          if (children) {
+            return (
+              <div
+                {...rest}
+                className={persistentBarClassNames}
+                ref={ref}
+                style={style}
+                role={role}
+              >
+                {children}
+              </div>
+            );
+          }
+
+          return (
+            <div
+              {...rest}
+              className={persistentBarClassNames}
+              ref={mergedRef}
+              style={style}
+              role={role}
+            >
+              {buttonMenuProps && (
+                <ul className={styles.persistentBarList}>{getButtons()}</ul>
+              )}
+              {getPersistentBarLayout()}
+            </div>
+          );
+        }}
+      </LocaleReceiver>
     );
   }
 );

--- a/src/components/PersistentBar/PersistentBar.types.ts
+++ b/src/components/PersistentBar/PersistentBar.types.ts
@@ -48,6 +48,10 @@ export interface PersistentBarsProps extends OcBaseProps<HTMLDivElement> {
    */
   actionButtonThreeProps?: ButtonProps;
   /**
+   * Whether the persistent bar is bordered or not.
+   */
+  bordered?: boolean;
+  /**
    * Buttons to display on top bar.
    */
   buttonMenuProps?: Array<ButtonProps>;

--- a/src/components/PersistentBar/PersistentBar.types.ts
+++ b/src/components/PersistentBar/PersistentBar.types.ts
@@ -1,6 +1,22 @@
 import { IconName } from '../Icon';
 import { ButtonProps } from '../Button';
 import { OcBaseProps } from '../OcBase';
+import { PaginationProps } from '../Pagination';
+
+type Locale = {
+  /**
+   * The PersistentBar locale.
+   */
+  locale: string;
+  /**
+   * The PersistentBar `More buttons` Button aria label string.
+   */
+  overflowAriaLabelText?: string;
+};
+
+export type PersistentBarLocale = {
+  lang: Locale;
+};
 
 export type CloseButtonProps = Omit<ButtonProps, 'onClick' | 'icon'>;
 
@@ -8,72 +24,96 @@ export enum PersistentBarType {
   bottomBarWithText = 'bottomBarWithText',
   bottomBarSecondaryButtons = 'bottomBarSecondaryButtons',
   bottomBarButtonsOnLeft = 'bottomBarButtonsOnLeft',
+  bottomBarButtonsOnRight = 'bottomBarButtonsOnRight',
   topBarButtons = 'topBarButtons',
   topBarWithText = 'topBarWithText',
   topBarPagination = 'topBarPagination',
 }
 
+export const BUTTON_MENU_AFFORDANCE: number = 44;
+export const BUTTON_PADDING: number = 44;
+export const LINES_TO_SHOW: number = 1;
+
 export interface PersistentBarsProps extends OcBaseProps<HTMLDivElement> {
   /**
-   * Props for the first action button
+   * Props for the first action button.
    */
   actionButtonOneProps?: ButtonProps;
   /**
-   * Props for the second action button
+   * Props for the second action button.
    */
   actionButtonTwoProps?: ButtonProps;
   /**
-   * Props for the third action button
+   * Props for the third action button.
    */
   actionButtonThreeProps?: ButtonProps;
   /**
-   * Buttons to display on top bar
+   * Buttons to display on top bar.
    */
   buttonMenuProps?: Array<ButtonProps>;
   /**
-   * If the persistent is closable or not
+   * Custom persitent bar render.
+   */
+  children?: React.ReactNode;
+  /**
+   * If the persistent bar is closable or not.
    */
   closable?: boolean;
   /**
-   * Icon for the close button
+   * Icon for the close button.
    * @default IconName.mdiClose
    */
   closeIcon?: IconName;
   /**
-   * Custom props for the close button
+   * Custom props for the close button.
    */
   closeButtonProps?: CloseButtonProps;
   /**
-   * Content of the persistent bar
+   * String content of the persistent bar.
    */
-  content: string;
+  content?: string;
   /**
-   * Custom icon for the persistent bar
-   * @default PersistentBarType.mdiInformation | IconName.mdiCheckCircle | IconName.mdiAlert
+   * Custom icon for the persistent bar.
+   * @default PersistentBarType.mdiArrowLeft
    */
   icon?: IconName;
   /**
-   * Callback fired on close of the persistent bar
+   * The PersistentBarLocale locale.
+   * @default 'enUS'
+   */
+  locale?: PersistentBarLocale;
+  /**
+   * Callback fired on close of the persistent bar.
    */
   onClose?: () => void;
   /**
-   * Arguments for pagination
+   * Aria label for the overflow button.
+   * @default 'More buttons'
+   */
+  overflowAriaLabel?: string;
+  /**
+   * Arguments for pagination.
+   * @deprecated Use paginatioonProps instead
    */
   paginationArgs?: Object;
   /**
-   * Total pages for pagination
+   * Pagination props.
+   */
+  paginationProps?: PaginationProps;
+  /**
+   * Total pages for pagination.
    */
   paginationTotal?: number;
   /**
-   * Role of the persistent bar
+   * Role of the persistent bar.
    */
   role?: string;
   /**
-   * Title for the persistent bar
+   * Title for the persistent bar.
    */
   title?: string;
   /**
-   * Type of the persistent bar
+   * Type of the persistent bar.
    * @default PersistentBarType.bottom
    */
   type?: PersistentBarType;

--- a/src/components/PersistentBar/__snapshots__/PersistentBar.test.tsx.snap
+++ b/src/components/PersistentBar/__snapshots__/PersistentBar.test.tsx.snap
@@ -1,0 +1,190 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PersistentBar PersistentBar is bottomBarButtonsOnLeft 1`] = `
+<div>
+  <div
+    class="persistent-bar bottom-left-align"
+    role="region"
+  />
+</div>
+`;
+
+exports[`PersistentBar PersistentBar is bottomBarButtonsOnRight 1`] = `
+<div>
+  <div
+    class="persistent-bar bottom-right-align"
+    role="region"
+  />
+</div>
+`;
+
+exports[`PersistentBar PersistentBar is bottomBarSecondaryButtons 1`] = `
+<div>
+  <div
+    class="persistent-bar bottom-secondary-buttons"
+    role="region"
+  />
+</div>
+`;
+
+exports[`PersistentBar PersistentBar is bottomBarWithText 1`] = `
+<div>
+  <div
+    class="persistent-bar bottom-with-text"
+    role="region"
+  >
+    <div>
+      <h4 />
+      <div
+        class="content"
+      >
+        PersistentBar test bottomBarWithText
+      </div>
+    </div>
+    <div />
+  </div>
+</div>
+`;
+
+exports[`PersistentBar PersistentBar is custom 1`] = `
+<div>
+  <div
+    class="persistent-bar bottom-with-text"
+    role="region"
+  >
+    <div
+      class="custom"
+    >
+      PersistentBar test custom
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersistentBar PersistentBar is topBarButtons 1`] = `
+<div>
+  <div
+    class="persistent-bar top-button-menu"
+    role="region"
+  />
+</div>
+`;
+
+exports[`PersistentBar PersistentBar is topBarPagination 1`] = `
+<div>
+  <div
+    class="persistent-bar top-pagination"
+    role="region"
+  >
+    <div
+      class="pagination"
+      role="navigation"
+    >
+      <span />
+      <ul
+        class="pager"
+      >
+        <li>
+          <button
+            aria-current="true"
+            aria-disabled="false"
+            class="pagination-button active button button-neutral button-medium"
+          >
+            <span
+              class="button-text-medium"
+            >
+              1
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersistentBar PersistentBar is topBarWithText 1`] = `
+<div>
+  <div
+    class="persistent-bar top-with-text"
+    role="region"
+  >
+    <div
+      class="stack full-width horizontal undefined gap-m"
+      style="justify-content: space-between;"
+    >
+      <button
+        aria-disabled="false"
+        class="icon-button button button-system-ui button-medium round-shape icon-left"
+      >
+        <span
+          aria-hidden="false"
+          class="icon icon-wrapper"
+          role="presentation"
+        >
+          <svg
+            role="presentation"
+            style="width: 20px; height: 20px;"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
+              style="fill: currentColor;"
+            />
+          </svg>
+        </span>
+      </button>
+      <div>
+        <h4 />
+        <div
+          class="content"
+        >
+          PersistentBar test topBarWithText
+        </div>
+      </div>
+      <div
+        class="pagination"
+        role="navigation"
+      >
+        <span />
+        <ul
+          class="pager page-tracker"
+        >
+          <li>
+            <span>
+              1
+            </span>
+             
+            <span>
+              of
+            </span>
+             
+            <span>
+              1
+            </span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PersistentBar Renders without crashing 1`] = `
+<div>
+  <div
+    class="persistent-bar bottom-with-text"
+    role="region"
+  >
+    <div>
+      <h4 />
+      <div
+        class="content"
+      >
+        PersistentBar test render
+      </div>
+    </div>
+    <div />
+  </div>
+</div>
+`;

--- a/src/components/PersistentBar/__snapshots__/PersistentBar.test.tsx.snap
+++ b/src/components/PersistentBar/__snapshots__/PersistentBar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`PersistentBar PersistentBar is bottomBarButtonsOnLeft 1`] = `
 <div>
   <div
     class="persistent-bar bottom-left-align"
-    role="region"
+    role="toolbar"
   />
 </div>
 `;
@@ -13,7 +13,7 @@ exports[`PersistentBar PersistentBar is bottomBarButtonsOnRight 1`] = `
 <div>
   <div
     class="persistent-bar bottom-right-align"
-    role="region"
+    role="toolbar"
   />
 </div>
 `;
@@ -22,7 +22,7 @@ exports[`PersistentBar PersistentBar is bottomBarSecondaryButtons 1`] = `
 <div>
   <div
     class="persistent-bar bottom-secondary-buttons"
-    role="region"
+    role="toolbar"
   />
 </div>
 `;
@@ -31,7 +31,7 @@ exports[`PersistentBar PersistentBar is bottomBarWithText 1`] = `
 <div>
   <div
     class="persistent-bar bottom-with-text"
-    role="region"
+    role="toolbar"
   >
     <div>
       <h4 />
@@ -50,7 +50,7 @@ exports[`PersistentBar PersistentBar is custom 1`] = `
 <div>
   <div
     class="persistent-bar bottom-with-text"
-    role="region"
+    role="toolbar"
   >
     <div
       class="custom"
@@ -65,7 +65,7 @@ exports[`PersistentBar PersistentBar is topBarButtons 1`] = `
 <div>
   <div
     class="persistent-bar top-button-menu"
-    role="region"
+    role="toolbar"
   />
 </div>
 `;
@@ -74,7 +74,7 @@ exports[`PersistentBar PersistentBar is topBarPagination 1`] = `
 <div>
   <div
     class="persistent-bar top-pagination"
-    role="region"
+    role="toolbar"
   >
     <div
       class="pagination"
@@ -107,7 +107,7 @@ exports[`PersistentBar PersistentBar is topBarWithText 1`] = `
 <div>
   <div
     class="persistent-bar top-with-text"
-    role="region"
+    role="toolbar"
   >
     <div
       class="stack full-width horizontal undefined gap-m"
@@ -174,7 +174,7 @@ exports[`PersistentBar Renders without crashing 1`] = `
 <div>
   <div
     class="persistent-bar bottom-with-text"
-    role="region"
+    role="toolbar"
   >
     <div>
       <h4 />

--- a/src/components/PersistentBar/persistentBar.module.scss
+++ b/src/components/PersistentBar/persistentBar.module.scss
@@ -1,26 +1,56 @@
 .persistent-bar {
-  --info-color: var(--grey-secondary-color);
-  display: flex;
+  align-items: center;
+  background: var(--persistent-bar-background-color);
   border-radius: $space-xxs;
+  box-shadow: $shadow-panel-behind;
+  color: var(--persistent-bar-primary-text-color);
+  display: flex;
+  font-family: var(--font-stack-full);
+  gap: $space-m;
+  height: auto;
+  min-height: $text-line-height-9;
   padding: $space-m;
   width: 100%;
-  background-color: var(--background-color);
-  gap: $space-m;
-  box-shadow: $shadow-panel-behind;
-  height: $text-line-height-9;
-  align-items: center;
 
   h4 {
+    font-weight: $text-font-weight-semibold;
     margin: $disabled-zero;
   }
 
+  .visually-hidden {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  &-list {
+    display: flex;
+    flex-shrink: initial;
+    gap: $space-m;
+    list-style: none;
+    margin: 0;
+    overflow: hidden;
+    padding: 0;
+
+    &-item {
+      display: inline-flex;
+      list-style-type: none;
+    }
+  }
+
+  &-menu-item {
+    list-style-type: none;
+    margin-bottom: $space-s;
+
+    &:first-of-type {
+      margin-top: $space-s;
+    }
+  }
+
   .content {
-    font-family: var(--font-stack-full);
-    font-style: normal;
-    font-weight: $text-font-weight-light;
+    color: var(--persistent-bar-secondary-text-color);
+    font-weight: $text-font-weight-regular;
     font-size: $text-font-size-2;
-    line-height: $text-line-height-3;
-    opacity: 50%;
+    line-height: $text-line-height-2;
   }
 
   &.bottom-with-text {
@@ -39,6 +69,10 @@
     justify-content: start;
   }
 
+  &.bottom-right-align {
+    justify-content: end;
+  }
+
   &.top-button-menu {
     justify-content: center;
   }
@@ -55,9 +89,14 @@
     justify-content: center;
   }
 
-  .icon {
-    color: inherit;
-    width: $text-line-height-12;
+  &-pagination-xsmall {
+    button {
+      margin: $space-xxs 0;
+    }
+  }
+
+  .icon-button {
+    margin-top: $space-xxs;
   }
 
   .buttons-container {

--- a/src/components/PersistentBar/persistentBar.module.scss
+++ b/src/components/PersistentBar/persistentBar.module.scss
@@ -1,8 +1,8 @@
 .persistent-bar {
   align-items: center;
   background: var(--persistent-bar-background-color);
-  border-radius: $space-xxs;
-  box-shadow: $shadow-panel-behind;
+  border-radius: var(--persistent-bar-border-radius);
+  box-shadow: var(--persistent-bar-box-shadow);
   color: var(--persistent-bar-primary-text-color);
   display: flex;
   font-family: var(--font-stack-full);
@@ -15,6 +15,10 @@
   h4 {
     font-weight: $text-font-weight-semibold;
     margin: $disabled-zero;
+  }
+
+  &.bordered {
+    border: var(--persistent-bar-border);
   }
 
   .visually-hidden {

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -1207,6 +1207,13 @@
 
   // ------ Persistent Bar theme ------
   --persistent-bar-background-color: var(--background-color);
+  --persistent-bar-border-color: var(--border-color);
+  --persistent-bar-border-width: 1px;
+  --persistent-bar-border-style: solid;
+  --persistent-bar-border: var(--persistent-bar-border-width)
+    var(--persistent-bar-border-style) var(--persistent-bar-border-color);
+  --persistent-bar-border-radius: var(--border-radius-s);
+  --persistent-bar-box-shadow: 0px -4px 16px rgba(0, 0, 0, 0.12);
   --persistent-bar-primary-text-color: var(--text-primary-color);
   --persistent-bar-secondary-text-color: var(--text-primary-color);
   // ------ Persistent Bar theme ------

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -1204,4 +1204,10 @@
   --radio-button-focus-visible-pip-color: var(--primary-color);
   --radio-button-text-color: var(--primary-secondary-color);
   // ------ Radio Button theme ------
+
+  // ------ Persistent Bar theme ------
+  --persistent-bar-background-color: var(--background-color);
+  --persistent-bar-primary-text-color: var(--text-primary-color);
+  --persistent-bar-secondary-text-color: var(--text-primary-color);
+  // ------ Persistent Bar theme ------
 }


### PR DESCRIPTION
## SUMMARY:
- Adds support for custom `children`
- Adds small screen/responsive support for each `PersistentBarType`, along with overflow menu support for `topBarButtons` variant
- Adds semantic variables to customize the background, header and content text colors
- Adds unit tests


https://github.com/EightfoldAI/octuple/assets/99700808/186fecff-e211-4ddb-b1d3-ce1d0faf564b


## JIRA TASK (Eightfold Employees Only):
ENG-29274

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch in a terminal using node 16 and run `yarn` and `yarn storybook`. Verify the `Persistent Bar` stories behave as expected.