### PR TITLE
fix: select: adds fall back and optional chaining to avoid null reference errors at runtime

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -58,6 +58,46 @@ describe('Select', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('Renders null options in single mode without crashing', () => {
+    const { container, getAllByPlaceholderText } = render(
+      <Select options={null} placeholder="Select single test" />
+    );
+    const select = getAllByPlaceholderText('Select single test');
+    expect(() => container).not.toThrowError();
+    expect(select).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Renders null options in multiple mode without crashing', () => {
+    const { container, getAllByPlaceholderText } = render(
+      <Select multiple options={null} placeholder="Select multiple test" />
+    );
+    const selectMulti = getAllByPlaceholderText('Select multiple test');
+    expect(() => container).not.toThrowError();
+    expect(selectMulti).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Renders empty options in single mode without crashing', () => {
+    const { container, getAllByPlaceholderText } = render(
+      <Select options={[]} placeholder="Select single test" />
+    );
+    const select = getAllByPlaceholderText('Select single test');
+    expect(() => container).not.toThrowError();
+    expect(select).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Renders empty options in multiple mode without crashing', () => {
+    const { container, getAllByPlaceholderText } = render(
+      <Select multiple options={[]} placeholder="Select multiple test" />
+    );
+    const selectMulti = getAllByPlaceholderText('Select multiple test');
+    expect(() => container).not.toThrowError();
+    expect(selectMulti).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
   test('renders as not read-only and is editable', () => {
     const { container } = render(<Select options={options} />);
     expect(

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -110,11 +110,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
     );
     const [dropdownVisible, setDropdownVisibility] = useState<boolean>(false);
     const [options, setOptions] = useState<SelectOption[]>(
-      _options.map((option: SelectOption, index: number) => ({
+      _options?.map((option: SelectOption, index: number) => ({
         selected: false,
         hideOption: false,
-        id: option.text + '-' + index,
-        object: option.object,
+        id: option?.text + '-' + index,
+        object: option?.object,
         role: 'option',
         ...option,
       }))
@@ -147,12 +147,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
     const getSelectedOptionValues = (): SelectOption['value'][] => {
       return options
-        .filter((option: SelectOption) => option.selected)
-        .map((option: SelectOption) => option.value);
+        ?.filter((option: SelectOption) => option?.selected)
+        .map((option: SelectOption) => option?.value);
     };
 
     const getSelectedOptions = (): SelectOption['value'][] => {
-      return options.filter((option: SelectOption) => option.selected);
+      return options?.filter((option: SelectOption) => option?.selected);
     };
 
     const { count, filled, width } = useMaxVisibleSections(
@@ -161,20 +161,20 @@ export const Select: FC<SelectProps> = React.forwardRef(
       168,
       8,
       1,
-      getSelectedOptionValues().length
+      getSelectedOptionValues()?.length
     );
 
     // Populate options on component render
     useEffect(() => {
-      const selected: SelectOption[] = options.filter(
-        (opt: SelectOption) => opt.selected
+      const selected: SelectOption[] = options?.filter(
+        (opt: SelectOption) => opt?.selected
       );
       setOptions(
-        _options.map((option: SelectOption, index: number) => ({
-          selected: !!selected.find((opt) => opt.value === option.value),
+        _options?.map((option: SelectOption, index: number) => ({
+          selected: !!selected?.find((opt) => opt?.value === option?.value),
           hideOption: false,
-          id: option.text + index,
-          object: option.object,
+          id: option?.text + '-' + index,
+          object: option?.object,
           role: 'option',
           ...option,
         }))
@@ -183,17 +183,17 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
     // Populate options on isLoading change
     useEffect(() => {
-      const selected: SelectOption[] = options.filter(
-        (opt: SelectOption) => opt.selected
+      const selected: SelectOption[] = options?.filter(
+        (opt: SelectOption) => opt?.selected
       );
       setOptions(
-        _options.map((option: SelectOption, index: number) => ({
+        _options?.map((option: SelectOption, index: number) => ({
           selected:
-            !!selected.find((opt) => opt.value === option.value) ||
-            option.value === defaultValue,
+            !!selected?.find((opt) => opt?.value === option?.value) ||
+            option?.value === defaultValue,
           hideOption: false,
-          id: option.text + index,
-          object: option.object,
+          id: option?.text + '-' + index,
+          object: option?.object,
           role: 'option',
           ...option,
         }))
@@ -220,17 +220,17 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (filterable && multiple) {
         setClearInput(false);
       }
-    }, [getSelectedOptionValues().join('')]);
+    }, [getSelectedOptionValues()?.join('')]);
 
     useEffect(() => {
-      const updatedOptions = options.map((opt) => ({
+      const updatedOptions = options?.map((opt) => ({
         ...opt,
         selected:
           (defaultValue !== undefined &&
             (multiple
-              ? defaultValue.includes(opt.value)
-              : opt.value === defaultValue)) ||
-          opt.selected,
+              ? defaultValue.includes(opt?.value)
+              : opt?.value === defaultValue)) ||
+          opt?.selected,
       }));
       setOptions(updatedOptions);
     }, [defaultValue]);
@@ -264,10 +264,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const toggleOption = (option: SelectOption): void => {
       setSearchQuery('');
 
-      const updatedOptions = options.map((opt: SelectOption) => {
-        const defaultState: boolean = multiple ? opt.selected : false;
+      const updatedOptions = options?.map((opt: SelectOption) => {
+        const defaultState: boolean = multiple ? opt?.selected : false;
         const selected: boolean =
-          opt.value === option.value ? !opt.selected : defaultState;
+          opt?.value === option?.value ? !opt?.selected : defaultState;
         const hideOption: boolean = false;
 
         return {
@@ -288,7 +288,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const resetSelectOnDropdownHide = (): void => {
       setSearchQuery('');
       setOptions(
-        options.map((opt: SelectOption) => ({
+        options?.map((opt: SelectOption) => ({
           ...opt,
           hideOption: false,
         }))
@@ -296,10 +296,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     };
 
     const resetSingleSelectOnDropdownToggle = (): void => {
-      const selected: SelectOption[] = options.filter(
-        (opt: SelectOption) => opt.selected
+      const selected: SelectOption[] = options?.filter(
+        (opt: SelectOption) => opt?.selected
       );
-      if (selected.length && inputRef.current?.value !== selectedOptionText) {
+      if (selected?.length && inputRef.current?.value !== selectedOptionText) {
         setResetTextInput(true);
       }
     };
@@ -308,14 +308,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
       setSearchQuery('');
       if (filterable && multiple) {
         setOptions(
-          options.map((opt: SelectOption) => ({
+          options?.map((opt: SelectOption) => ({
             ...opt,
             hideOption: false,
           }))
         );
       } else if (filterable) {
         setOptions(
-          options.map((opt: SelectOption) => ({
+          options?.map((opt: SelectOption) => ({
             ...opt,
             hideOption: false,
             selected: false,
@@ -323,7 +323,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         );
       } else {
         setOptions(
-          options.map((opt: SelectOption) => ({
+          options?.map((opt: SelectOption) => ({
             ...opt,
             selected: false,
           }))
@@ -345,8 +345,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
         !prevDropdownVisible &&
         filterable &&
         !multiple &&
-        searchQuery.length !== 0 &&
-        getSelectedOptions().length === 0
+        searchQuery?.length !== 0 &&
+        getSelectedOptions()?.length === 0
       ) {
         inputRef.current?.click();
       }
@@ -360,11 +360,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
       }
       if (value) {
         setOptions(
-          options.map((opt: SelectOption) => ({
+          options?.map((opt: SelectOption) => ({
             ...opt,
             hideOption: filterOption
               ? !filterOption(opt, value)
-              : !opt.text.toLowerCase().includes(valueLowerCase),
+              : !opt?.text.toLowerCase().includes(valueLowerCase),
           }))
         );
       } else {
@@ -372,8 +372,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
         // When not in multiple mode and the value is empty
         // deselect and execute onClear.
         setOptions(
-          options.map((opt: SelectOption) => {
-            const selected: boolean = multiple ? opt.selected : false;
+          options?.map((opt: SelectOption) => {
+            const selected: boolean = multiple ? opt?.selected : false;
             return {
               ...opt,
               hideOption: false,
@@ -391,7 +391,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
     const showDropdown = (show: boolean) => {
       if (filterable || multiple) {
-        if (!multiple && options.length) {
+        if (!multiple && options?.length) {
           return show;
         }
         return true;
@@ -455,10 +455,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     ]);
 
     const showPills = (): boolean => {
-      const selected: SelectOption[] = options.filter(
-        (opt: SelectOption) => opt.selected
+      const selected: SelectOption[] = options?.filter(
+        (opt: SelectOption) => opt?.selected
       );
-      const selectedCount: number = selected.length;
+      const selectedCount: number = selected?.length;
       return selectedCount !== 0 && multiple;
     };
 
@@ -490,24 +490,24 @@ export const Select: FC<SelectProps> = React.forwardRef(
     };
 
     const getPills = (): JSX.Element => {
-      const selected: SelectOption[] = options.filter(
-        (opt: SelectOption) => opt.selected
+      const selected: SelectOption[] = options?.filter(
+        (opt: SelectOption) => opt?.selected
       );
 
-      const selectedCount: number = selected.length;
+      const selectedCount: number = selected?.length;
       const pills: React.ReactElement[] = [];
       let moreOptionsCount: number = selectedCount;
 
       // TODO: Mutate Array based on order of selection.
-      selected.forEach((opt: SelectOption, index: number) => {
+      selected?.forEach((opt: SelectOption, index: number) => {
         const pill = (): JSX.Element => (
           <Pill
             ref={(ref) => (pillRefs.current[index] = ref)}
-            id={`selectPill${opt.id}`}
+            id={`selectPill${opt?.id}`}
             classNames={pillClassNames}
             disabled={mergedDisabled}
             key={`select-pill-${index}`}
-            label={opt.text}
+            label={opt?.text}
             onClose={() => toggleOption(opt)}
             size={selectSizeToPillSizeMap.get(size)}
             theme={'blueGreen'}
@@ -519,12 +519,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
           />
         );
         if (
-          isPillEllipsisActive(document?.getElementById(`selectPill${opt.id}`))
+          isPillEllipsisActive(document?.getElementById(`selectPill${opt?.id}`))
         ) {
           pills.push(
             <Tooltip
               classNames={styles.selectTooltip}
-              content={opt.text}
+              content={opt?.text}
               id={`selectTooltip${index}`}
               key={`select-tooltip-${index}`}
               placement={'top'}
@@ -537,7 +537,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         } else {
           pills.push(pill());
         }
-        if (pills.length === count && filled) {
+        if (pills?.length === count && filled) {
           pills.push(
             <Pill
               classNames={countPillClassNames}
@@ -562,8 +562,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
         return;
       }
       const selectedOption = options
-        .filter((opt: SelectOption) => opt.selected)
-        .map((opt: SelectOption) => opt.text)
+        ?.filter((opt: SelectOption) => opt?.selected)
+        .map((opt: SelectOption) => opt?.text)
         .join(', ')
         .toLocaleString();
       setSelectedOptionText(selectedOption);
@@ -574,24 +574,26 @@ export const Select: FC<SelectProps> = React.forwardRef(
     }: {
       options: SelectOption[];
     }): JSX.Element => {
-      const filteredOptions = options.filter(
-        (opt: SelectOption) => !opt.hideOption
+      const filteredOptions = options?.filter(
+        (opt: SelectOption) => !opt?.hideOption
       );
-      const updatedItems: SelectOption[] = filteredOptions.map(
+      const updatedItems: SelectOption[] = filteredOptions?.map(
         ({ hideOption, ...opt }) => ({
           ...opt,
-          classNames: mergeClasses([{ [styles.selectedOption]: opt.selected }]),
+          classNames: mergeClasses([
+            { [styles.selectedOption]: opt?.selected },
+          ]),
           role: 'option',
         })
       );
-      if (filteredOptions.length > 0) {
+      if (filteredOptions?.length > 0) {
         return (
           <Menu
             {...menuProps}
             items={updatedItems}
             onChange={(value) => {
-              const option = updatedItems.find(
-                (opt: SelectOption) => opt.value === value
+              const option = updatedItems?.find(
+                (opt: SelectOption) => opt?.value === value
               );
               toggleOption(option);
             }}
@@ -669,7 +671,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     ]);
 
     const selectInputProps: TextInputProps = {
-      placeholder: showPills() ? '' : placeholder,
+      placeholder: showPills() && !!options ? '' : placeholder,
       alignIcon: TextInputIconAlign.Right,
       clearable: clearable,
       clearButtonClassNames: clearButtonClassNames,
@@ -755,8 +757,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
               dropdownVisible &&
               (showEmptyDropdown ||
                 isLoading ||
-                searchQuery.length > 0 ||
-                options.length > 0)
+                searchQuery?.length > 0 ||
+                options?.length > 0)
             }
             ref={dropdownRef}
           >
@@ -769,7 +771,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                 autocomplete={autocomplete}
                 classNames={selectInputClassNames}
                 clear={
-                  (!dropdownVisible && getSelectedOptions().length === 0) ||
+                  (!dropdownVisible && getSelectedOptions()?.length === 0) ||
                   (!dropdownVisible &&
                     multiple &&
                     filterable &&

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -110,11 +110,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
     );
     const [dropdownVisible, setDropdownVisibility] = useState<boolean>(false);
     const [options, setOptions] = useState<SelectOption[]>(
-      _options?.map((option: SelectOption, index: number) => ({
+      (_options || []).map((option: SelectOption, index: number) => ({
         selected: false,
         hideOption: false,
-        id: option?.text + '-' + index,
-        object: option?.object,
+        id: option.text + '-' + index,
+        object: option.object,
         role: 'option',
         ...option,
       }))
@@ -146,13 +146,13 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const prevDropdownVisible: boolean = usePreviousState(dropdownVisible);
 
     const getSelectedOptionValues = (): SelectOption['value'][] => {
-      return options
-        ?.filter((option: SelectOption) => option?.selected)
-        .map((option: SelectOption) => option?.value);
+      return (options || [])
+        .filter((option: SelectOption) => option.selected)
+        .map((option: SelectOption) => option.value);
     };
 
     const getSelectedOptions = (): SelectOption['value'][] => {
-      return options?.filter((option: SelectOption) => option?.selected);
+      return (options || []).filter((option: SelectOption) => option.selected);
     };
 
     const { count, filled, width } = useMaxVisibleSections(
@@ -161,20 +161,20 @@ export const Select: FC<SelectProps> = React.forwardRef(
       168,
       8,
       1,
-      getSelectedOptionValues()?.length
+      getSelectedOptionValues().length
     );
 
     // Populate options on component render
     useEffect(() => {
-      const selected: SelectOption[] = options?.filter(
-        (opt: SelectOption) => opt?.selected
+      const selected: SelectOption[] = (options || []).filter(
+        (opt: SelectOption) => opt.selected
       );
       setOptions(
-        _options?.map((option: SelectOption, index: number) => ({
-          selected: !!selected?.find((opt) => opt?.value === option?.value),
+        (_options || []).map((option: SelectOption, index: number) => ({
+          selected: !!selected.find((opt) => opt.value === option.value),
           hideOption: false,
-          id: option?.text + '-' + index,
-          object: option?.object,
+          id: option.text + '-' + index,
+          object: option.object,
           role: 'option',
           ...option,
         }))
@@ -183,17 +183,17 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
     // Populate options on isLoading change
     useEffect(() => {
-      const selected: SelectOption[] = options?.filter(
-        (opt: SelectOption) => opt?.selected
+      const selected: SelectOption[] = (options || []).filter(
+        (opt: SelectOption) => opt.selected
       );
       setOptions(
-        _options?.map((option: SelectOption, index: number) => ({
+        (_options || []).map((option: SelectOption, index: number) => ({
           selected:
-            !!selected?.find((opt) => opt?.value === option?.value) ||
-            option?.value === defaultValue,
+            !!selected.find((opt) => opt.value === option.value) ||
+            option.value === defaultValue,
           hideOption: false,
-          id: option?.text + '-' + index,
-          object: option?.object,
+          id: option.text + '-' + index,
+          object: option.object,
           role: 'option',
           ...option,
         }))
@@ -220,17 +220,17 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (filterable && multiple) {
         setClearInput(false);
       }
-    }, [getSelectedOptionValues()?.join('')]);
+    }, [getSelectedOptionValues().join('')]);
 
     useEffect(() => {
-      const updatedOptions = options?.map((opt) => ({
+      const updatedOptions = (options || []).map((opt) => ({
         ...opt,
         selected:
           (defaultValue !== undefined &&
             (multiple
-              ? defaultValue.includes(opt?.value)
-              : opt?.value === defaultValue)) ||
-          opt?.selected,
+              ? defaultValue.includes(opt.value)
+              : opt.value === defaultValue)) ||
+          opt.selected,
       }));
       setOptions(updatedOptions);
     }, [defaultValue]);
@@ -264,10 +264,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const toggleOption = (option: SelectOption): void => {
       setSearchQuery('');
 
-      const updatedOptions = options?.map((opt: SelectOption) => {
-        const defaultState: boolean = multiple ? opt?.selected : false;
+      const updatedOptions = (options || []).map((opt: SelectOption) => {
+        const defaultState: boolean = multiple ? opt.selected : false;
         const selected: boolean =
-          opt?.value === option?.value ? !opt?.selected : defaultState;
+          opt.value === option.value ? !opt.selected : defaultState;
         const hideOption: boolean = false;
 
         return {
@@ -288,7 +288,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const resetSelectOnDropdownHide = (): void => {
       setSearchQuery('');
       setOptions(
-        options?.map((opt: SelectOption) => ({
+        (options || []).map((opt: SelectOption) => ({
           ...opt,
           hideOption: false,
         }))
@@ -296,10 +296,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     };
 
     const resetSingleSelectOnDropdownToggle = (): void => {
-      const selected: SelectOption[] = options?.filter(
-        (opt: SelectOption) => opt?.selected
+      const selected: SelectOption[] = (options || []).filter(
+        (opt: SelectOption) => opt.selected
       );
-      if (selected?.length && inputRef.current?.value !== selectedOptionText) {
+      if (selected.length && inputRef.current?.value !== selectedOptionText) {
         setResetTextInput(true);
       }
     };
@@ -308,14 +308,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
       setSearchQuery('');
       if (filterable && multiple) {
         setOptions(
-          options?.map((opt: SelectOption) => ({
+          (options || []).map((opt: SelectOption) => ({
             ...opt,
             hideOption: false,
           }))
         );
       } else if (filterable) {
         setOptions(
-          options?.map((opt: SelectOption) => ({
+          (options || []).map((opt: SelectOption) => ({
             ...opt,
             hideOption: false,
             selected: false,
@@ -323,7 +323,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         );
       } else {
         setOptions(
-          options?.map((opt: SelectOption) => ({
+          (options || []).map((opt: SelectOption) => ({
             ...opt,
             selected: false,
           }))
@@ -346,7 +346,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         filterable &&
         !multiple &&
         searchQuery?.length !== 0 &&
-        getSelectedOptions()?.length === 0
+        getSelectedOptions().length === 0
       ) {
         inputRef.current?.click();
       }
@@ -360,11 +360,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
       }
       if (value) {
         setOptions(
-          options?.map((opt: SelectOption) => ({
+          (options || []).map((opt: SelectOption) => ({
             ...opt,
             hideOption: filterOption
               ? !filterOption(opt, value)
-              : !opt?.text.toLowerCase().includes(valueLowerCase),
+              : !opt.text.toLowerCase().includes(valueLowerCase),
           }))
         );
       } else {
@@ -372,8 +372,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
         // When not in multiple mode and the value is empty
         // deselect and execute onClear.
         setOptions(
-          options?.map((opt: SelectOption) => {
-            const selected: boolean = multiple ? opt?.selected : false;
+          (options || []).map((opt: SelectOption) => {
+            const selected: boolean = multiple ? opt.selected : false;
             return {
               ...opt,
               hideOption: false,
@@ -455,10 +455,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     ]);
 
     const showPills = (): boolean => {
-      const selected: SelectOption[] = options?.filter(
-        (opt: SelectOption) => opt?.selected
+      const selected: SelectOption[] = (options || []).filter(
+        (opt: SelectOption) => opt.selected
       );
-      const selectedCount: number = selected?.length;
+      const selectedCount: number = selected.length;
       return selectedCount !== 0 && multiple;
     };
 
@@ -490,24 +490,24 @@ export const Select: FC<SelectProps> = React.forwardRef(
     };
 
     const getPills = (): JSX.Element => {
-      const selected: SelectOption[] = options?.filter(
-        (opt: SelectOption) => opt?.selected
+      const selected: SelectOption[] = (options || []).filter(
+        (opt: SelectOption) => opt.selected
       );
 
-      const selectedCount: number = selected?.length;
+      const selectedCount: number = selected.length;
       const pills: React.ReactElement[] = [];
       let moreOptionsCount: number = selectedCount;
 
       // TODO: Mutate Array based on order of selection.
-      selected?.forEach((opt: SelectOption, index: number) => {
+      selected.forEach((opt: SelectOption, index: number) => {
         const pill = (): JSX.Element => (
           <Pill
             ref={(ref) => (pillRefs.current[index] = ref)}
-            id={`selectPill${opt?.id}`}
+            id={`selectPill${opt.id}`}
             classNames={pillClassNames}
             disabled={mergedDisabled}
             key={`select-pill-${index}`}
-            label={opt?.text}
+            label={opt.text}
             onClose={() => toggleOption(opt)}
             size={selectSizeToPillSizeMap.get(size)}
             theme={'blueGreen'}
@@ -519,12 +519,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
           />
         );
         if (
-          isPillEllipsisActive(document?.getElementById(`selectPill${opt?.id}`))
+          isPillEllipsisActive(document?.getElementById(`selectPill${opt.id}`))
         ) {
           pills.push(
             <Tooltip
               classNames={styles.selectTooltip}
-              content={opt?.text}
+              content={opt.text}
               id={`selectTooltip${index}`}
               key={`select-tooltip-${index}`}
               placement={'top'}
@@ -561,9 +561,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
         setSelectedOptionText(searchQuery);
         return;
       }
-      const selectedOption = options
-        ?.filter((opt: SelectOption) => opt?.selected)
-        .map((opt: SelectOption) => opt?.text)
+      const selectedOption = (options || [])
+        .filter((opt: SelectOption) => opt.selected)
+        .map((opt: SelectOption) => opt.text)
         .join(', ')
         .toLocaleString();
       setSelectedOptionText(selectedOption);
@@ -574,26 +574,24 @@ export const Select: FC<SelectProps> = React.forwardRef(
     }: {
       options: SelectOption[];
     }): JSX.Element => {
-      const filteredOptions = options?.filter(
-        (opt: SelectOption) => !opt?.hideOption
+      const filteredOptions = (options || []).filter(
+        (opt: SelectOption) => !opt.hideOption
       );
-      const updatedItems: SelectOption[] = filteredOptions?.map(
+      const updatedItems: SelectOption[] = filteredOptions.map(
         ({ hideOption, ...opt }) => ({
           ...opt,
-          classNames: mergeClasses([
-            { [styles.selectedOption]: opt?.selected },
-          ]),
+          classNames: mergeClasses([{ [styles.selectedOption]: opt.selected }]),
           role: 'option',
         })
       );
-      if (filteredOptions?.length > 0) {
+      if (filteredOptions.length > 0) {
         return (
           <Menu
             {...menuProps}
             items={updatedItems}
             onChange={(value) => {
-              const option = updatedItems?.find(
-                (opt: SelectOption) => opt?.value === value
+              const option = updatedItems.find(
+                (opt: SelectOption) => opt.value === value
               );
               toggleOption(option);
             }}
@@ -771,7 +769,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                 autocomplete={autocomplete}
                 classNames={selectInputClassNames}
                 clear={
-                  (!dropdownVisible && getSelectedOptions()?.length === 0) ||
+                  (!dropdownVisible && getSelectedOptions().length === 0) ||
                   (!dropdownVisible &&
                     multiple &&
                     filterable &&

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -152,9 +152,6 @@ exports[`Select Renders null options in multiple mode without crashing 1`] = `
     class="select-wrapper select-wrapper-multiple select-medium"
   >
     <div
-      class="multi-select-pills"
-    />
-    <div
       class="select-dropdown-main-wrapper main-wrapper"
     >
       <div

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -1,5 +1,300 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Select Renders empty options in multiple mode without crashing 1`] = `
+<div>
+  <div
+    class="select-wrapper select-wrapper-multiple select-medium"
+  >
+    <div
+      class="select-dropdown-main-wrapper main-wrapper"
+    >
+      <div
+        class="reference-wrapper select-input-wrapper"
+        id="dropdown-reference"
+      >
+        <div
+          class="input-wrapper input-medium input-stretch right-icon"
+        >
+          <div
+            class="expandable-wrapper"
+          >
+            <div
+              class="select-input-group input-group right-icon"
+            >
+              <input
+                aria-controls="dropdown-"
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="select-input input-medium with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
+                id="input-"
+                placeholder="Select multiple test"
+                readonly=""
+                role="combobox"
+                tabindex="0"
+                type="text"
+                value=""
+              />
+              <div
+                class="action-wrapper"
+              >
+                <div
+                  class="overlay"
+                />
+                <button
+                  aria-disabled="false"
+                  class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="false"
+                    class="icon icon-wrapper"
+                    role="presentation"
+                  >
+                    <svg
+                      role="presentation"
+                      style="width: 20px; height: 20px;"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                        style="fill: currentColor;"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Select Renders empty options in single mode without crashing 1`] = `
+<div>
+  <div
+    class="select-wrapper select-medium"
+  >
+    <div
+      class="select-dropdown-main-wrapper main-wrapper"
+    >
+      <div
+        class="reference-wrapper select-input-wrapper"
+        id="dropdown-reference"
+      >
+        <div
+          class="input-wrapper input-medium input-stretch right-icon"
+        >
+          <div
+            class="expandable-wrapper"
+          >
+            <div
+              class="select-input-group input-group right-icon"
+            >
+              <input
+                aria-controls="dropdown-"
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="select-input input-medium with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
+                id="input-"
+                placeholder="Select single test"
+                readonly=""
+                role="combobox"
+                tabindex="0"
+                type="text"
+                value=""
+              />
+              <div
+                class="action-wrapper"
+              >
+                <div
+                  class="overlay"
+                />
+                <button
+                  aria-disabled="false"
+                  class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="false"
+                    class="icon icon-wrapper"
+                    role="presentation"
+                  >
+                    <svg
+                      role="presentation"
+                      style="width: 20px; height: 20px;"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                        style="fill: currentColor;"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Select Renders null options in multiple mode without crashing 1`] = `
+<div>
+  <div
+    class="select-wrapper select-wrapper-multiple select-medium"
+  >
+    <div
+      class="multi-select-pills"
+    />
+    <div
+      class="select-dropdown-main-wrapper main-wrapper"
+    >
+      <div
+        class="reference-wrapper select-input-wrapper"
+        id="dropdown-reference"
+      >
+        <div
+          class="input-wrapper input-medium input-stretch right-icon"
+        >
+          <div
+            class="expandable-wrapper"
+          >
+            <div
+              class="select-input-group input-group right-icon"
+            >
+              <input
+                aria-controls="dropdown-"
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="select-input input-medium with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
+                id="input-"
+                placeholder="Select multiple test"
+                readonly=""
+                role="combobox"
+                tabindex="0"
+                type="text"
+                value=""
+              />
+              <div
+                class="action-wrapper"
+              >
+                <div
+                  class="overlay"
+                />
+                <button
+                  aria-disabled="false"
+                  class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="false"
+                    class="icon icon-wrapper"
+                    role="presentation"
+                  >
+                    <svg
+                      role="presentation"
+                      style="width: 20px; height: 20px;"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                        style="fill: currentColor;"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Select Renders null options in single mode without crashing 1`] = `
+<div>
+  <div
+    class="select-wrapper select-medium"
+  >
+    <div
+      class="select-dropdown-main-wrapper main-wrapper"
+    >
+      <div
+        class="reference-wrapper select-input-wrapper"
+        id="dropdown-reference"
+      >
+        <div
+          class="input-wrapper input-medium input-stretch right-icon"
+        >
+          <div
+            class="expandable-wrapper"
+          >
+            <div
+              class="select-input-group input-group right-icon"
+            >
+              <input
+                aria-controls="dropdown-"
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="select-input input-medium with-icon-button input-stretch right-icon clear-disabled clear-not-visible"
+                id="input-"
+                placeholder="Select single test"
+                readonly=""
+                role="combobox"
+                tabindex="0"
+                type="text"
+                value=""
+              />
+              <div
+                class="action-wrapper"
+              >
+                <div
+                  class="overlay"
+                />
+                <button
+                  aria-disabled="false"
+                  class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  type="button"
+                >
+                  <span
+                    aria-hidden="false"
+                    class="icon icon-wrapper"
+                    role="presentation"
+                  >
+                    <svg
+                      role="presentation"
+                      style="width: 20px; height: 20px;"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                        style="fill: currentColor;"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Select Renders with default value 1`] = `
 <div>
   <div


### PR DESCRIPTION
## SUMMARY:

- Adds options fallback to empty array where needed and some optional chaining
- Updates `placeholder` to show when `options` are null in` multiple` mode
- Adds unit tests covering null or empty array scenarios
- Updates `options` to ensure `id` alignment.


https://github.com/EightfoldAI/octuple/assets/99700808/4e1e18c7-81da-4707-be4e-10a158edfa2c



## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/666

## JIRA TASK (Eightfold Employees Only):
ENG-58585

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Select` stories behave as expected when its `options` are `null` or `[]`.