### PR TITLE
fix: popup: fixes style inheritance of reference element

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Badge } from './';
+import { Popup, PopupTheme } from '../Popup';
 
 export default {
   title: 'Badge',
@@ -29,10 +30,33 @@ export default {
 } as ComponentMeta<typeof Badge>;
 
 const Badge_Story: ComponentStory<typeof Badge> = (args) => <Badge {...args} />;
+const Badge_Popup_Story: ComponentStory<typeof Badge> = (args) => (
+  <Popup
+    content={
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'center',
+          height: '100%',
+        }}
+      >
+        A popup
+      </div>
+    }
+    height={40}
+    theme={PopupTheme.dark}
+    triggerAbove
+    width={100}
+  >
+    <Badge {...args} />
+  </Popup>
+);
 
 export const Badge_Default = Badge_Story.bind({});
 export const Badge_Active = Badge_Story.bind({});
 export const Badge_Disruptive = Badge_Story.bind({});
+export const Badge_With_Popup = Badge_Popup_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
@@ -41,6 +65,7 @@ export const __namedExportsOrder = [
   'Badge_Default',
   'Badge_Active',
   'Badge_Disruptive',
+  'Badge_With_Popup',
 ];
 
 const badgeArgs: Object = {
@@ -64,4 +89,8 @@ Badge_Disruptive.args = {
   ...badgeArgs,
   active: true,
   disruptive: true,
+};
+
+Badge_With_Popup.args = {
+  ...badgeArgs,
 };

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,26 +1,22 @@
-import React, { FC } from 'react';
+import React, { FC, Ref } from 'react';
 import { BadgeProps } from './Badge.types';
 import { mergeClasses } from '../../shared/utilities';
 
 import styles from './badge.module.scss';
 
-export const Badge: FC<BadgeProps> = ({
-  active,
-  classNames,
-  style,
-  children,
-  disruptive,
-  ...rest
-}) => {
-  const badgeClasses: string = mergeClasses([
-    styles.badge,
-    { [styles.disruptive]: disruptive },
-    classNames,
-    { [styles.active]: active },
-  ]);
-  return (
-    <span className={badgeClasses} style={style} {...rest}>
-      {children}
-    </span>
-  );
-};
+export const Badge: FC<BadgeProps> = React.forwardRef(
+  (props: BadgeProps, ref: Ref<HTMLElement>) => {
+    const { active, classNames, style, children, disruptive, ...rest } = props;
+    const badgeClassNames: string = mergeClasses([
+      styles.badge,
+      { [styles.disruptive]: disruptive },
+      classNames,
+      { [styles.active]: active },
+    ]);
+    return (
+      <span ref={ref} className={badgeClassNames} style={style} {...rest}>
+        {children}
+      </span>
+    );
+  }
+);

--- a/src/components/Popup/Popup.test.tsx
+++ b/src/components/Popup/Popup.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
+import { Badge } from '../Badge';
 import { Popup, PopupSize } from './';
 import {
   fireEvent,
@@ -107,6 +108,41 @@ describe('Popup', () => {
     );
     expect(container.querySelector('.popup').getAttribute('style')).toContain(
       'width: 500px'
+    );
+  });
+
+  test('Popup reference element retains its classes when inheriting popup classes', async () => {
+    const { container } = render(
+      <Popup
+        content={<div data-testid="popup-4">This is a popup.</div>}
+        triggerAbove
+      >
+        <div className="test-div">test</div>
+      </Popup>
+    );
+    fireEvent.click(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('popup-4'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+    expect(container.querySelector('.test-div').classList).toContain(
+      'trigger-above'
+    );
+  });
+
+  test('Popup reference component retains its classes when inheriting popup classes', async () => {
+    const { container } = render(
+      <Popup
+        content={<div data-testid="popup-5">This is a popup.</div>}
+        triggerAbove
+      >
+        <Badge classNames="test-component">test</Badge>
+      </Popup>
+    );
+    expect(container.querySelector('.test-component')).toBeTruthy();
+    fireEvent.click(container.querySelector('.test-component'));
+    await waitFor(() => screen.getByTestId('popup-5'));
+    expect(container.querySelector('.popup')).toBeTruthy();
+    expect(container.querySelector('.test-component').classList).toContain(
+      'trigger-above'
     );
   });
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -36,6 +36,7 @@ import {
   ConditionalWrapper,
   eventKeys,
   mergeClasses,
+  RenderProps,
   uniqueId,
 } from '../../shared/utilities';
 
@@ -340,16 +341,17 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         if (React.isValidElement(node)) {
           const child = React.Children.only(node) as React.ReactElement<any>;
 
-          // Utilize tha same element clone pattern as Dropdown
+          // Utilize a similar element clone pattern as Dropdown
           // for more complex Popup elements.
-          const referenceWrapperClassNames: string = mergeClasses([
-            styles.referenceWrapper,
+          const popupClassNames: string = mergeClasses([
             { [styles.triggerAbove]: !!triggerAbove },
             // Add any classnames added to the reference element
-            { [child.props.className]: child.props.className },
+            { [child.props.className]: !!child.props.className },
+            { [child.props.classNames]: !!child.props.classNames },
             { [styles.disabled]: disabled },
           ]);
-          return cloneElement(child, {
+
+          const clonedElementProps: RenderProps = {
             ...{
               [TRIGGER_TO_HANDLER_MAP_ON_ENTER[trigger]]: toggle(true),
             },
@@ -357,13 +359,21 @@ export const Tooltip: FC<TooltipProps> = React.memo(
             key: tooltipId?.current,
             onClick: handleReferenceClick,
             onKeyDown: handleReferenceKeyDown,
-            className: referenceWrapperClassNames,
             'aria-controls': tooltipId?.current,
             'aria-expanded': mergedVisible,
             'aria-haspopup': true,
             role: 'button',
             tabIndex: `${tabIndex}`,
-          });
+          };
+
+          // Compares for octuple react prop vs native react html classes.
+          if (child.props.className) {
+            clonedElementProps['className'] = popupClassNames;
+          } else if (child.props.classNames) {
+            clonedElementProps['classNames'] = popupClassNames;
+          }
+
+          return cloneElement(child, clonedElementProps);
         }
         return node;
       };

--- a/src/shared/utilities/reactNode.ts
+++ b/src/shared/utilities/reactNode.ts
@@ -4,7 +4,7 @@ export const { isValidElement } = React;
 
 type AnyObject = Record<any, any>;
 
-type RenderProps =
+export type RenderProps =
   | undefined
   | AnyObject
   | ((originProps: AnyObject) => AnyObject | undefined);


### PR DESCRIPTION
## SUMMARY:
There's a bug where if the `reference` element of the `Popup` is an Octuple component utilizing its `classNames` prop, the cloned element ignores the attribute because it looks for `className`. This change ensures `classNames` is also considered by the Popup, fixing the bug so developers don't need to wrap some components in a `div` to preserve `classNames`.


https://github.com/EightfoldAI/octuple/assets/99700808/45979d92-ce44-47b5-a72a-416ed1469f34


## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Badge With Popup` story behaves as expected.