### PR TITLE
feat: infobar: adds bordered prop

### DIFF
--- a/src/components/InfoBar/InfoBar.stories.tsx
+++ b/src/components/InfoBar/InfoBar.stories.tsx
@@ -59,6 +59,7 @@ const infoBarArgs: Object = {
     id: 'myActionButton',
     text: 'Action',
   },
+  bordered: false,
   closable: true,
   content: 'Body2 is used inside here.',
   style: {},

--- a/src/components/InfoBar/InfoBar.test.tsx
+++ b/src/components/InfoBar/InfoBar.test.tsx
@@ -80,4 +80,12 @@ describe('InfoBar', () => {
     expect(container.querySelector('.warning')).toBeTruthy();
     expect(container).toMatchSnapshot();
   });
+
+  test('InfoBar is bordered', () => {
+    const { container } = render(
+      <InfoBar bordered content={'InfoBar test border'} />
+    );
+    expect(container.querySelector('.bordered')).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -14,6 +14,7 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
   (props: InfoBarsProps, ref: Ref<HTMLDivElement>) => {
     const {
       actionButtonProps,
+      bordered = false,
       classNames,
       closable,
       closeButtonAriaLabelText: defaultCloseButtonAriaLabelText,
@@ -54,6 +55,7 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
 
     const infoBarClasses: string = mergeClasses([
       styles.infoBar,
+      { [styles.bordered]: !!bordered },
       classNames,
       { [styles.neutral]: type === InfoBarType.neutral },
       { [styles.positive]: type === InfoBarType.positive },

--- a/src/components/InfoBar/InfoBar.types.ts
+++ b/src/components/InfoBar/InfoBar.types.ts
@@ -33,6 +33,11 @@ export interface InfoBarsProps extends OcBaseProps<HTMLDivElement> {
    */
   actionButtonProps?: ButtonProps;
   /**
+   * Whether to visually hide the InfoBar border.
+   * @default false
+   */
+  bordered?: boolean;
+  /**
    * If the InfoBar is closable or not
    */
   closable?: boolean;

--- a/src/components/InfoBar/__snapshots__/InfoBar.test.tsx.snap
+++ b/src/components/InfoBar/__snapshots__/InfoBar.test.tsx.snap
@@ -124,6 +124,37 @@ exports[`InfoBar InfoBar is Warning 1`] = `
 </div>
 `;
 
+exports[`InfoBar InfoBar is bordered 1`] = `
+<div>
+  <div
+    class="info-bar bordered neutral"
+    role="alert"
+  >
+    <span
+      aria-hidden="false"
+      class="icon icon-wrapper"
+      role="presentation"
+    >
+      <svg
+        role="presentation"
+        style="width: 20px; height: 20px;"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+          style="fill: currentColor;"
+        />
+      </svg>
+    </span>
+    <div
+      class="message body2"
+    >
+      InfoBar test border
+    </div>
+  </div>
+</div>
+`;
+
 exports[`InfoBar Renders a custom icon when the icon prop uses a custom icon 1`] = `
 <div>
   <div

--- a/src/components/InfoBar/infoBar.module.scss
+++ b/src/components/InfoBar/infoBar.module.scss
@@ -8,9 +8,17 @@
   padding: $space-ml;
   width: 100%;
 
+  &.bordered {
+    border: var(--info-bar-border);
+  }
+
   &.neutral {
     background-color: var(--info-bar-background-color);
     color: var(--info-bar-text-color);
+
+    &.bordered {
+      border-color: var(--info-bar-border-neutral-color);
+    }
 
     .action-button,
     .close-button {
@@ -23,6 +31,10 @@
   &.positive {
     background-color: var(--info-bar-positive-background-color);
     color: var(--info-bar-positive-text-color);
+
+    &.bordered {
+      border-color: var(--info-bar-border-positive-color);
+    }
 
     .action-button,
     .close-button {
@@ -38,6 +50,10 @@
     background-color: var(--info-bar-warning-background-color);
     color: var(--info-bar-warning-text-color);
 
+    &.bordered {
+      border-color: var(--info-bar-border-warning-color);
+    }
+
     .action-button,
     .close-button {
       &:active {
@@ -51,6 +67,10 @@
   &.disruptive {
     background-color: var(--info-bar-disruptive-background-color);
     color: var(--info-bar-disruptive-text-color);
+
+    &.bordered {
+      border-color: var(--info-bar-border-disruptive-color);
+    }
 
     .action-button,
     .close-button {

--- a/src/components/InfoBar/infoBar.module.scss
+++ b/src/components/InfoBar/infoBar.module.scss
@@ -17,7 +17,7 @@
     color: var(--info-bar-text-color);
 
     &.bordered {
-      border-color: var(--info-bar-border-neutral-color);
+      border-color: var(--info-bar-neutral-border-color);
     }
 
     .action-button,
@@ -33,7 +33,7 @@
     color: var(--info-bar-positive-text-color);
 
     &.bordered {
-      border-color: var(--info-bar-border-positive-color);
+      border-color: var(--info-bar-positive-border-color);
     }
 
     .action-button,
@@ -51,7 +51,7 @@
     color: var(--info-bar-warning-text-color);
 
     &.bordered {
-      border-color: var(--info-bar-border-warning-color);
+      border-color: var(--info-bar-warning-border-color);
     }
 
     .action-button,
@@ -69,7 +69,7 @@
     color: var(--info-bar-disruptive-text-color);
 
     &.bordered {
-      border-color: var(--info-bar-border-disruptive-color);
+      border-color: var(--info-bar-disruptive-border-color);
     }
 
     .action-button,

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -897,6 +897,14 @@
   // ------ Card theme ------
 
   // ------ Info Bar theme ------
+  --info-bar-border-disruptive-color: var(--red-background2-color);
+  --info-bar-border-neutral-color: var(--grey-background2-color);
+  --info-bar-border-positive-color: var(--green-background2-color);
+  --info-bar-border-warning-color: var(--orange-background2-color);
+  --info-bartip-border-style: solid;
+  --info-bar-border-width: 1px;
+  --info-bar-border: var(--info-bar-border-width)
+    var(--info-bartip-border-style) var(--info-bar-border-neutral-color);
   --info-bar-border-radius: var(--border-radius-xl);
   --info-bar-background-color: var(--grey-background1-color);
   --info-bar-button-active-background-color: var(--grey-background2-color);

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -897,14 +897,14 @@
   // ------ Card theme ------
 
   // ------ Info Bar theme ------
-  --info-bar-border-disruptive-color: var(--red-background2-color);
-  --info-bar-border-neutral-color: var(--grey-background2-color);
-  --info-bar-border-positive-color: var(--green-background2-color);
-  --info-bar-border-warning-color: var(--orange-background2-color);
+  --info-bar-disruptive-border-color: var(--red-background2-color);
+  --info-bar-neutral-border-color: var(--grey-background2-color);
+  --info-bar-positive-border-color: var(--green-background2-color);
+  --info-bar-warning-border-color: var(--orange-background2-color);
   --info-bartip-border-style: solid;
   --info-bar-border-width: 1px;
   --info-bar-border: var(--info-bar-border-width)
-    var(--info-bartip-border-style) var(--info-bar-border-neutral-color);
+    var(--info-bartip-border-style) var(--info-bar-neutral-border-color);
   --info-bar-border-radius: var(--border-radius-xl);
   --info-bar-background-color: var(--grey-background1-color);
   --info-bar-button-active-background-color: var(--grey-background2-color);


### PR DESCRIPTION
## SUMMARY:
- Adds `bordered` prop to enable borders if needed
- Updates stories to add `bordered` control
- Adds unit test


https://github.com/EightfoldAI/octuple/assets/99700808/299e174d-6ce7-4ae8-a7fa-baff3695448d


## JIRA TASK (Eightfold Employees Only):
ENG-59527

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify `InfoBar` stories behave as expected when setting `bordered` to true