### PR TITLE
fix: table: adds default overflow back to latest scroll bars mixin

### DIFF
--- a/src/components/DateTimePicker/DatePicker/Styles/mixins.scss
+++ b/src/components/DateTimePicker/DatePicker/Styles/mixins.scss
@@ -57,6 +57,7 @@ $picker-input-padding-vertical: max(
 
 // Picker scroll bars
 @mixin scroll-bars() {
+  overflow: auto;
   -ms-overflow-style: none;
 
   &::-webkit-scrollbar {

--- a/src/components/Table/Internal/octable.module.scss
+++ b/src/components/Table/Internal/octable.module.scss
@@ -1,4 +1,5 @@
 @mixin scroll-bars() {
+  overflow: auto;
   -ms-overflow-style: none;
 
   &::-webkit-scrollbar {


### PR DESCRIPTION
## SUMMARY:
- Adds back removed default `overflow: auto;` in scroll-bars() mixins

https://github.com/EightfoldAI/octuple/assets/99700808/6aa01118-38fc-4f9c-93d6-e6b14b4ec110

## JIRA TASK (Eightfold Employees Only):
ENG-59638

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Table` stories behave as expected.