### PR TITLE
feat: card: update card size prop and remove bunko story

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Card, CardType } from './';
+import { Card, CardSize } from './';
 import { IconName } from '../Icon';
 import { Avatar } from '../Avatar';
 import { Pill } from '../Pills';
@@ -29,113 +29,35 @@ export default {
       ),
     },
   },
+  argTypes: {
+    size: {
+      options: [CardSize.Flex, CardSize.Large, CardSize.Medium, CardSize.Small],
+      control: { type: 'radio' },
+    },
+  },
 } as ComponentMeta<typeof Card>;
 
 const Card_Story: ComponentStory<typeof Card> = (args) => <Card {...args} />;
 
-export const BaseCard = Card_Story.bind({});
 export const CustomCard = Card_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
 // See https://www.npmjs.com/package/babel-plugin-named-exports-order
-export const __namedExportsOrder = ['BaseCard', 'CustomCard'];
+export const __namedExportsOrder = ['CustomCard'];
 
 const baseCardArgs: Object = {
   dropShadow: true,
+  size: CardSize.Medium,
   style: {},
   classNames: 'my-card-class',
-  icon: IconName.mdiInformation,
-  type: CardType.list,
-  headerButtonProps: {
-    iconProps: {
-      path: IconName.mdiBookmark,
-    },
-  },
-  headerTitle: <div>Senior UX Designer</div>,
-  bodyListOneProps: {
-    iconProps: {
-      path: IconName.mdiCheck,
-      color: 'green',
-      style: { marginRight: '2px' },
-    },
-    type: 'list',
-    contents: [
-      {
-        showIcon: true,
-        label: 'Matched Skill',
-      },
-      {
-        showIcon: true,
-        label: 'Matched Skill',
-      },
-      {
-        showIcon: true,
-        label: 'Matched Skill',
-      },
-      {
-        showIcon: false,
-        label: 'Other Skill',
-      },
-      {
-        showIcon: false,
-        label: 'Other Skill',
-      },
-    ],
-  },
-  bodyListTwoProps: {
-    iconProps: {
-      path: IconName.mdiCheck,
-      color: 'green',
-    },
-    type: 'pills',
-    contents: [
-      {
-        showIcon: false,
-        label: 'Department',
-      },
-      {
-        showIcon: false,
-        label: 'Urgent Hire',
-      },
-    ],
-  },
-  bodyListOnePillProps: {
-    theme: 'grey',
-  },
-  bodyListTwoPillProps: {
-    theme: 'grey',
-  },
-  subHeaderSeparatorIcon: IconName.mdiCircle,
-  subHeaderProps: ['Company', 'Job Location'],
-  footerProps: [
-    {
-      iconProps: {
-        path: IconName.mdiWeb,
-        color: 'blue',
-        style: { marginRight: '2px' },
-      },
-      text: 'Strong match',
-    },
-    {
-      iconProps: {
-        path: IconName.mdiCheck,
-        color: 'green',
-        style: { marginRight: '2px' },
-      },
-      text: 'Applied',
-    },
-  ],
-};
-
-BaseCard.args = {
-  ...baseCardArgs,
 };
 
 CustomCard.args = {
   ...baseCardArgs,
   width: '360px',
   height: '520px',
+  size: CardSize.Large,
   children: (
     <div style={{ textAlign: 'center', position: 'relative' }}>
       <Avatar

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -4,6 +4,8 @@ import Enzyme, { mount, ReactWrapper } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { Card } from './Card';
 import { IconName } from '../Icon';
+import { render } from '@testing-library/react';
+import { CardSize } from './Card.types';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -48,5 +50,34 @@ describe('Card', () => {
       },
     });
     expect(wrapper.find('.header-button').length).toBeTruthy();
+  });
+
+  test('Card is large', () => {
+    const { container } = render(
+      <Card body={body} footer={footer} header={header} size={CardSize.Large} />
+    );
+    expect(container.getElementsByClassName('card-large')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Card is medium', () => {
+    const { container } = render(
+      <Card
+        body={body}
+        footer={footer}
+        header={header}
+        size={CardSize.Medium}
+      />
+    );
+    expect(container.getElementsByClassName('card-medium')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('Card is small', () => {
+    const { container } = render(
+      <Card body={body} footer={footer} header={header} size={CardSize.Small} />
+    );
+    expect(container.getElementsByClassName('card-small')).toHaveLength(1);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -122,6 +122,7 @@ export const Card: FC<CardProps> = React.forwardRef(
           children
         ) : (
           <>
+            {/** TODO: Update predefined variants to meet latest specification. */}
             <div className={headerClasses}>
               {header && header}
               {(icon || headerTitle) && (

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -9,7 +9,7 @@ export enum CardSize {
   Flex = 'flex',
   Large = 'large',
   Medium = 'medium',
-  Small = 'medium',
+  Small = 'small',
 }
 
 export enum CardType {
@@ -149,7 +149,7 @@ export interface CardProps extends OcBaseProps<HTMLDivElement> {
    */
   size?: CardSize | Size;
   /**
-   * The button style.
+   * The card style.
    */
   style?: React.CSSProperties;
   /**

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Card Card is large 1`] = `
+<div>
+  <div
+    class="card list card-large"
+  >
+    <div
+      class="header"
+    >
+      This is the card header
+    </div>
+    <div
+      class="body"
+    >
+      This is the card body
+    </div>
+    <div
+      class="footer"
+    >
+      This is the card footer
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Card Card is medium 1`] = `
+<div>
+  <div
+    class="card list card-medium"
+  >
+    <div
+      class="header"
+    >
+      This is the card header
+    </div>
+    <div
+      class="body"
+    >
+      This is the card body
+    </div>
+    <div
+      class="footer"
+    >
+      This is the card footer
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Card Card is small 1`] = `
+<div>
+  <div
+    class="card list card-small"
+  >
+    <div
+      class="header"
+    >
+      This is the card header
+    </div>
+    <div
+      class="body"
+    >
+      This is the card body
+    </div>
+    <div
+      class="footer"
+    >
+      This is the card footer
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Card/card.module.scss
+++ b/src/components/Card/card.module.scss
@@ -5,7 +5,8 @@
   display: block;
   font-family: var(--card-font-family);
   gap: $space-m;
-  padding: $space-ml;
+  height: 260px;
+  padding: $space-m;
   width: 360px;
   position: relative;
 
@@ -30,11 +31,17 @@
 
   &-large {
     height: 278px;
+    padding: $space-ml;
   }
 
-  &-medium,
+  &-medium {
+    height: 260px;
+    padding: $space-m;
+  }
+
   &-small {
     height: 260px;
+    padding: $space-s;
   }
 
   &.disabled {


### PR DESCRIPTION
## SUMMARY:
- Removes Outdated Story
- Adds `TODO` comment to add predefined card variants and update the one that currently exists
- Adds a small size (small used to map to medium via the `CardSize` enum)
- Updates padding for each size (`large`, `medium`, and `small`) to spec
- Adds unit tests


https://github.com/EightfoldAI/octuple/assets/99700808/afbd8299-766a-406d-8903-16d8d0e10e24


## JIRA TASK (Eightfold Employees Only):
ENG-61008

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Card` story behaves as expected.