### PR TITLE
chore: i18n: exports octuple locales and locale type

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -46,6 +46,7 @@ import Upload, { UploadProps } from '../Upload';
 import dayjs, { Dayjs } from 'dayjs';
 
 // locales
+import type { Locale as OcLocale } from '../LocaleProvider'; // Need to alias because story name declaration conflicts with the type
 import csCZ from '../Locale/cs_CZ'; // čeština
 import daDK from '../Locale/da_DK'; // Dansk
 import deDE from '../Locale/de_DE'; // Deutsch
@@ -787,10 +788,10 @@ const snackArgs: Object = {
 
 const Locale_Story: ComponentStory<typeof ConfigProvider> = (args) => {
   const [_, updateArgs] = useArgs();
-  const [locale, setLocale] = useState(enUS);
+  const [locale, setLocale] = useState<OcLocale>(enUS);
   const [localeValue, setLocaleValue] = useState<string>('en_US');
 
-  const locales: Record<string, any> = {
+  const locales: Record<string, OcLocale> = {
     cs_CZ: csCZ,
     da_DK: daDK,
     de_DE: deDE,

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -242,6 +242,44 @@ import { useScrollLock } from './hooks/useScrollLock';
 
 import { useMaxVisibleSections } from './hooks/useMaxVisibleSections';
 
+// supported locales
+import type { Locale } from './components/LocaleProvider';
+import csCZ from './components/Locale/cs_CZ'; // čeština
+import daDK from './components/Locale/da_DK'; // Dansk
+import deDE from './components/Locale/de_DE'; // Deutsch
+import elGR from './components/Locale/el_GR'; // Ελληνικά
+import enGB from './components/Locale/en_GB'; // English (United Kingdom)
+import enUS from './components/Locale/en_US'; // English (United States)
+import esES from './components/Locale/es_ES'; // Español
+import esDO from './components/Locale/es_DO'; // Español (Dominican Republic)
+import esMX from './components/Locale/es_MX'; // Español (Mexico)
+import fiFI from './components/Locale/fi_FI'; // Suomi
+import frBE from './components/Locale/fr_BE'; // Français (Belgium) TODO: dayjs has no fr_BE locale, use fr
+import frCA from './components/Locale/fr_CA'; // Français (Canada)
+import frFR from './components/Locale/fr_FR'; // Français
+import heIL from './components/Locale/he_IL'; // עברית
+import hiIN from './components/Locale/hi_IN'; // हिंदी
+import hrHR from './components/Locale/hr_HR'; // Hrvatski
+import htHT from './components/Locale/ht_HT'; // Haitian
+import huHU from './components/Locale/hu_HU'; // Magyar
+import itIT from './components/Locale/it_IT'; // Italiano
+import jaJP from './components/Locale/ja_JP'; // 日本語
+import koKR from './components/Locale/ko_KR'; // 한국어
+import msMY from './components/Locale/ms_MY'; // Bahasa melayu
+import nbNO from './components/Locale/nb_NO'; // Norsk
+import nlBE from './components/Locale/nl_BE'; // Nederlands (Belgium)
+import nlNL from './components/Locale/nl_NL'; // Nederlands
+import plPL from './components/Locale/pl_PL'; // Polski
+import ptBR from './components/Locale/pt_BR'; // Português (Brazil)
+import ptPT from './components/Locale/pt_PT'; // Português
+import ruRU from './components/Locale/ru_RU'; // Pусский
+import svSE from './components/Locale/sv_SE'; // Svenska
+import thTH from './components/Locale/th_TH'; // ภาษาไทย
+import trTR from './components/Locale/tr_TR'; // Türkçe
+import ukUA from './components/Locale/uk_UA'; // Yкраїнська
+import zhCN from './components/Locale/zh_CN'; // 中文 (简体)
+import zhTW from './components/Locale/zh_TW'; // 中文 (繁體)
+
 export {
   Accordion,
   AccordionShape,
@@ -316,6 +354,7 @@ export {
   List,
   Loader,
   LoaderSize,
+  Locale,
   MatchScore,
   Menu,
   MenuItemIconAlign,
@@ -426,4 +465,40 @@ export {
   useMaxVisibleSections,
   useOnClickOutside,
   useScrollLock,
+  // Group exported locales separately for readability.
+  csCZ,
+  daDK,
+  deDE,
+  elGR,
+  enGB,
+  enUS,
+  esES,
+  esDO,
+  esMX,
+  fiFI,
+  frBE,
+  frCA,
+  frFR,
+  heIL,
+  hiIN,
+  hrHR,
+  htHT,
+  huHU,
+  itIT,
+  jaJP,
+  koKR,
+  msMY,
+  nbNO,
+  nlBE,
+  nlNL,
+  plPL,
+  ptBR,
+  ptPT,
+  ruRU,
+  svSE,
+  thTH,
+  trTR,
+  ukUA,
+  zhCN,
+  zhTW,
 };


### PR DESCRIPTION
## SUMMARY:

- Ensures supported locales are exported for use in host apps (e.g. `enUS`, `hiIN`, ...)
- Ensures the `Locale` type is exported for use in host apps

## JIRA TASK (Eightfold Employees Only):
ENG-61285

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (exports only)
- [ ] I have added unittests for this change

## TEST PLAN:

To test locally -
Pull the PR branch and run `yarn`, then run `yarn build` to generate the lib folder and the content of the local package. Run `yarn storybook`.

in your chosen IDE, open  src/components/ConfigProvider/ConfigProvider.stories.tsx and update the following 2 lines:

**Line 49** update
from:
`import type { Locale as OcLocale } from '../LocaleProvider';`
to:
`import type { Locale as OcLocale } from '../../../lib/octuple'; `

**Line 56** update (`esES` used as an example, but you may test any locale)
from:
`import esES from '../Locale/es_ES';`
to:
`import { esES } from from '../../../lib/octuple'; `

Allow Storybook to recompile and use the story to update the locale using newly generated lib


![localeTest](https://github.com/EightfoldAI/octuple/assets/99700808/e666c997-efc1-4fc2-ac37-22acd96f2130)


