### PR TITLE
fix: button: moves button transition to global semantic variables

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -6,7 +6,7 @@
   font-family: var(--button-font-family);
   min-height: max-content;
   min-width: max-content;
-  transition: all $motion-duration-extra-fast $motion-easing-easeinout 0s;
+  transition: var(--button-transition);
   white-space: nowrap;
   position: relative;
   z-index: 0;

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -603,6 +603,7 @@
   --button-nudge-gradient-color-one: var(--primary-tertiary-color);
   --button-nudge-gradient-color-two: var(--primary-background2-color);
   --button-nudge-gradient-color-three: var(--primary-tertiary-color);
+  --button-transition: all 200ms cubic-bezier(0.42, 0, 0.58, 1) 0s;
   // TODO: button text/font related vars
   // ------ Generic button vars ------
 


### PR DESCRIPTION
## SUMMARY:
Some custom themes will update the following properties to have gradient values. Currently CSS3 transitions [do not yet support animating gradients](https://stackoverflow.com/questions/6542212/use-css3-transitions-with-gradient-backgrounds). To work around this technical limitation we're exposing the button transition as a new variable `--button-transition`. That way it may be set to have a value of `none` to avoid a 200ms flicker in scenarios where the button theme background variables use gradient values.

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/692

## JIRA TASK (Eightfold Employees Only):
ENG-62150

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (CSS scope only)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook` Verify the `Button` stories behave as expected. 