### PR TITLE
fix: textarea: ensure grip icon doesn't block mouse drag

### DIFF
--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -1055,6 +1055,7 @@
   }
 
   .text-area-resize-icon {
+    pointer-events: none;
     position: absolute;
     bottom: $space-xs;
     right: $space-xxs;


### PR DESCRIPTION
## SUMMARY:
- Adds `pointer-events: none` to grippy so it will not steal click and drag

https://github.com/EightfoldAI/octuple/assets/99700808/5ec3216b-7c35-4e0d-89dd-d3b34029ee72


## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/693

## JIRA TASK (Eightfold Employees Only):
ENG-62761

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (CSS only)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Text Area` story behaves as expected.