### PR TITLE
fix: carousel: add controls prop to scroll menu

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -664,6 +664,7 @@ export const Carousel: FC<CarouselProps> = React.forwardRef(
                   {type === 'scroll' && (
                     <ResizeObserver onResize={updateScrollMode}>
                       <ScrollMenu
+                        controls={controls}
                         nextButton={() => autoScrollButton('next')}
                         onWheel={handleOnWheel}
                         previousButton={() => autoScrollButton('previous')}

--- a/src/components/Carousel/Carousel.types.ts
+++ b/src/components/Carousel/Carousel.types.ts
@@ -241,6 +241,11 @@ export interface ScrollMenuProps
    */
   containerPadding?: number;
   /**
+   * Whether to display the previous and next controls.
+   * @default true
+   */
+  controls?: boolean;
+  /**
    * The pixel gap between items.
    */
   gap?: number;

--- a/src/components/Carousel/ScrollMenu/ScrollMenu.tsx
+++ b/src/components/Carousel/ScrollMenu/ScrollMenu.tsx
@@ -34,6 +34,7 @@ export const ScrollMenu: FC<ScrollMenuProps> = forwardRef(
       apiRef = { current: {} as autoScrollApiType },
       children,
       containerPadding = 0,
+      controls = true,
       gap = 8,
       itemClassNames,
       nextButton: _rightArrow,
@@ -163,7 +164,7 @@ export const ScrollMenu: FC<ScrollMenuProps> = forwardRef(
       >
         <VisibilityContext.Provider value={context}>
           <div className={innerWrapperClassName}>
-            {!context?.isFirstItemVisible && LeftArrow}
+            {!context?.isFirstItemVisible && controls && LeftArrow}
             <ScrollContainer
               classNames={scrollContainerClassNames}
               containerPadding={containerPadding}
@@ -181,7 +182,7 @@ export const ScrollMenu: FC<ScrollMenuProps> = forwardRef(
                 {children}
               </MenuItems>
             </ScrollContainer>
-            {!context?.isLastItemVisible && RightArrow}
+            {!context?.isLastItemVisible && controls && RightArrow}
           </div>
         </VisibilityContext.Provider>
       </div>

--- a/src/components/Carousel/Tests/ScrollMenu.test.tsx
+++ b/src/components/Carousel/Tests/ScrollMenu.test.tsx
@@ -307,6 +307,23 @@ describe('ScrollMenu', () => {
 
       expect(container).toMatchSnapshot();
     });
+
+    test('Hides LeftArrow, RightArrow', () => {
+      (useIntersectionObserver as jest.Mock).mockReturnValue({
+        visibleElementsWithSeparators: defaultItemsWithSeparators,
+      });
+
+      const { container } = setup({
+        previousButton: PreviousButton,
+        nextButton: NextButton,
+        controls: false,
+      });
+
+      expect(container.querySelector('.left-arrow')).toBeFalsy();
+      expect(container.querySelector('.right-arrow')).toBeFalsy();
+
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('Events', () => {

--- a/src/components/Carousel/Tests/__snapshots__/ScrollMenu.test.tsx.snap
+++ b/src/components/Carousel/Tests/__snapshots__/ScrollMenu.test.tsx.snap
@@ -1,5 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ScrollMenu Children and buttons Hides LeftArrow, RightArrow 1`] = `
+<div>
+  <div
+    class="carousel-auto-scroll"
+  >
+    <div
+      class="carousel-auto-scroll-inner-wrapper"
+    >
+      <ul
+        class="carousel-auto-scroll-container"
+        style="margin: 0px; padding: 0px;"
+      >
+        <li
+          class="carousel-scroll-menu-item"
+          data-index="0"
+          data-key="test1"
+          style="margin-left: 0px; margin-right: 4px;"
+        >
+          <div
+            data-testid="test1"
+          >
+            {"itemId":"test1","isFirstItemVisible":false,"isLastItemVisible":false,"visibleElements":["test1","test2"],"visibleElementsWithSeparators":["test1","item1-separator","test2"],"visibleItems":["test1","item1-separator","test2"],"visibleItemsWithoutSeparators":["test1","test2"],"initComplete":true}
+          </div>
+        </li>
+        <div
+          aria-hidden="true"
+          class="carousel-scroll-menu-separator"
+          data-index="0.1"
+          data-key="test1-separator"
+          style="margin-left: 0px; margin-right: 4px;"
+        />
+        <li
+          class="carousel-scroll-menu-item"
+          data-index="1"
+          data-key="test2"
+          style="margin-left: 0px; margin-right: 4px;"
+        >
+          <div
+            data-testid="test2"
+          >
+            {"itemId":"test2","isFirstItemVisible":false,"isLastItemVisible":false,"visibleElements":["test1","test2"],"visibleElementsWithSeparators":["test1","item1-separator","test2"],"visibleItems":["test1","item1-separator","test2"],"visibleItemsWithoutSeparators":["test1","test2"],"initComplete":true}
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ScrollMenu Children and buttons LeftArrow, ScrollContainer, MenuItems, RightArrow 1`] = `
 <div>
   <div


### PR DESCRIPTION
## SUMMARY:
Add `controls` prop to scroll menu so that when the `Carousel` `type` prop is set to `'scroll'` the controls props does the work to hide the next/prev buttons if desired.


https://github.com/EightfoldAI/octuple/assets/99700808/4ad5305a-8639-4020-b4d9-ba8f8bb4d548



## JIRA TASK (Eightfold Employees Only):
ENG-63467

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Carousel` `Scroller` stories behave as expected when `controls` is toggled.