### PR TITLE
feat: inputs: add readonly support and its styles

### DIFF
--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -95,11 +95,6 @@ export interface ReadOnlyProps {
    */
   clearable?: boolean;
   /**
-   * Whether readonly is enabled.
-   * @default false
-   */
-  enabled?: boolean;
-  /**
    * The readonly icon props.
    */
   iconProps?: IconProps;
@@ -153,7 +148,11 @@ export interface TextAreaProps
    * text area readonly.
    * @default false
    */
-  readonly?: boolean | Omit<ReadOnlyProps, 'clearable'>;
+  readonly?: boolean;
+  /**
+   * text area readonly props.
+   */
+  readOnlyProps?: Omit<ReadOnlyProps, 'clearable'>;
   /**
    * The text area required attribute.
    * @default false
@@ -351,7 +350,11 @@ export interface InputProps<T>
    * input readonly.
    * @default false
    */
-  readonly?: boolean | ReadOnlyProps;
+  readonly?: boolean;
+  /**
+   * input readonly props.
+   */
+  readOnlyProps?: ReadOnlyProps;
   /**
    * Resets the input value cache.
    */

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -134,6 +134,7 @@ export interface TextAreaProps
     | 'iconProps'
     | 'iconButtonProps'
     | 'alignIcon'
+    | 'readonly'
   > {
   /**
    * The text area is expandable.
@@ -148,6 +149,11 @@ export interface TextAreaProps
    * The text area component ref.
    */
   ref?: Ref<HTMLTextAreaElement>;
+  /**
+   * text area readonly.
+   * @default false
+   */
+  readonly?: boolean | Omit<ReadOnlyProps, 'clearable'>;
   /**
    * The text area required attribute.
    * @default false

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -88,6 +88,28 @@ export interface InputIconButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
+export interface ReadOnlyProps {
+  /**
+   * Option to show the clear input button when readonly.
+   * @default false
+   */
+  clearable?: boolean;
+  /**
+   * Whether readonly is enabled.
+   * @default false
+   */
+  enabled?: boolean;
+  /**
+   * The readonly icon props.
+   */
+  iconProps?: IconProps;
+  /**
+   * Whether or not to apply the readonly styles.
+   * @default false
+   */
+  noStyleChange?: boolean;
+}
+
 export interface SearchBoxProps
   extends Omit<InputProps<HTMLInputElement>, 'htmlType'> {
   /**
@@ -323,7 +345,7 @@ export interface InputProps<T>
    * input readonly.
    * @default false
    */
-  readonly?: boolean;
+  readonly?: boolean | ReadOnlyProps;
   /**
    * Resets the input value cache.
    */

--- a/src/components/Inputs/SearchBox/SearchBox.stories.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.stories.tsx
@@ -171,9 +171,9 @@ Search_Box.args = {
   minlength: 0,
   name: 'mySearchBox',
   placeholder: 'Search',
-  readonly: {
+  readonly: false,
+  readOnlyProps: {
     clearable: false,
-    enabled: false,
     iconProps: null,
     noStyleChange: false,
   },

--- a/src/components/Inputs/SearchBox/SearchBox.stories.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.stories.tsx
@@ -171,6 +171,12 @@ Search_Box.args = {
   minlength: 0,
   name: 'mySearchBox',
   placeholder: 'Search',
+  readonly: {
+    clearable: false,
+    enabled: false,
+    iconProps: null,
+    noStyleChange: false,
+  },
   shape: TextInputShape.Pill,
   size: TextInputSize.Medium,
   style: {},

--- a/src/components/Inputs/SearchBox/SearchBox.test.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.test.tsx
@@ -3,6 +3,7 @@ import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import { SearchBox } from './SearchBox';
+import { render } from '@testing-library/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -15,17 +16,28 @@ describe('SearchBox', () => {
   afterEach(() => {
     matchMedia.clear();
   });
-  /*
-   * Functionality Tests
-   */
-  test('text input renders', () => {
+
+  test('Text input renders', () => {
     const wrapper = mount(<SearchBox />);
     expect(wrapper.containsMatchingElement(<SearchBox />)).toEqual(true);
   });
-  test('text input renders with partially customized icon button', () => {
+
+  test('Text input renders with partially customized icon button', () => {
     const wrapper = mount(
       <SearchBox iconButtonProps={{ htmlType: 'submit' }} />
     );
     expect(wrapper.containsMatchingElement(<SearchBox />)).toEqual(true);
+  });
+
+  test('Text input is readOnly', () => {
+    const { container } = render(
+      <SearchBox readonly defaultValue="Test value" />
+    );
+    expect(
+      container.getElementsByTagName('input')[0].hasAttribute('readonly')
+    ).toBeTruthy();
+    expect(
+      container.getElementsByTagName('input')[0].getAttribute('value')
+    ).toBe('Test value');
   });
 });

--- a/src/components/Inputs/SearchBox/SearchBox.test.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.test.tsx
@@ -29,7 +29,7 @@ describe('SearchBox', () => {
     expect(wrapper.containsMatchingElement(<SearchBox />)).toEqual(true);
   });
 
-  test('Text input is readOnly', () => {
+  test('Text input is readonly', () => {
     const { container } = render(
       <SearchBox readonly defaultValue="Test value" />
     );

--- a/src/components/Inputs/SearchBox/SearchBox.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.tsx
@@ -55,6 +55,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
       onReset,
       onSubmit,
       placeholder = 'Search',
+      readonly = false,
       reset = false,
       shape = TextInputShape.Pill,
       size = TextInputSize.Medium,
@@ -126,6 +127,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
           onKeyDown={onKeyDown}
           onReset={onReset}
           placeholder={placeholder}
+          readonly={readonly}
           reset={reset}
           shape={mergedShape}
           size={mergedSize}

--- a/src/components/Inputs/SearchBox/SearchBox.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.tsx
@@ -56,6 +56,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
       onSubmit,
       placeholder = 'Search',
       readonly = false,
+      readOnlyProps,
       reset = false,
       shape = TextInputShape.Pill,
       size = TextInputSize.Medium,
@@ -128,6 +129,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
           onReset={onReset}
           placeholder={placeholder}
           readonly={readonly}
+          readOnlyProps={readOnlyProps}
           reset={reset}
           shape={mergedShape}
           size={mergedSize}

--- a/src/components/Inputs/Styles/rtl.scss
+++ b/src/components/Inputs/Styles/rtl.scss
@@ -248,11 +248,11 @@
 
           &.left-icon {
             padding: $space-xs $input-padding-large-with-icon-and-icon-button
-              $space-xs $space-xxl;
+              $space-xs 48px;
           }
 
           &.right-icon {
-            padding: $space-xs $space-xxl $space-xs
+            padding: $space-xs 48px $space-xs
               $input-padding-large-with-icon-and-icon-button;
           }
 
@@ -377,11 +377,11 @@
         &.with-icon-button {
           &.clear-disabled {
             &.left-icon {
-              padding: $space-xs $space-xl $space-xs $space-xs;
+              padding: $space-xs $space-xxl $space-xs $space-xs;
             }
 
             &.right-icon {
-              padding: $space-xs $space-xs $space-xs $space-xl;
+              padding: $space-xs $space-xs $space-xs $space-xxl;
             }
           }
 
@@ -509,20 +509,21 @@
       }
 
       &.input-small {
-        padding: $space-xs $space-s $space-xs $space-l;
+        padding: $space-xs $space-xs $space-xs $space-l;
 
         &.with-icon,
         &.with-image-icon,
         &.with-icon-button {
-          padding: $space-xs $space-xl $space-xs calc(#{$space-l} + $space-xxs);
+          padding: $space-xs $space-xl $space-xs
+            calc(#{$space-l} + #{$space-xxs});
 
           &.left-icon {
             padding: $space-xs $space-xl $space-xs
-              calc(#{$space-l} + $space-xxs);
+              calc(#{$space-l} + #{$space-xxs});
           }
 
           &.right-icon {
-            padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs
+            padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs
               $space-xl;
           }
 
@@ -545,15 +546,15 @@
 
         &.with-icon-and-icon-button {
           padding: $space-xs $input-padding-small-with-icon-and-icon-button
-            $space-xs calc(#{$space-l} + $space-xxs);
+            $space-xs calc(#{$space-l} + #{$space-xxs});
 
           &.left-icon {
             padding: $space-xs $input-padding-small-with-icon-and-icon-button
-              $space-xs calc(#{$space-l} + $space-xxs);
+              $space-xs calc(#{$space-l} + #{$space-xxs});
           }
 
           &.right-icon {
-            padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs
+            padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs
               $input-padding-small-with-icon-and-icon-button;
           }
 
@@ -579,15 +580,16 @@
 
         &.pill-shape-with-icon,
         &.pill-shape-with-image-icon {
-          padding: $space-xs $space-xl $space-xs calc(#{$space-l} + $space-xxs);
+          padding: $space-xs $space-xl $space-xs
+            calc(#{$space-l} + #{$space-xxs});
 
           &.left-icon {
             padding: $space-xs $space-xl $space-xs
-              calc(#{$space-l} + $space-xxs);
+              calc(#{$space-l} + #{$space-xxs});
           }
 
           &.right-icon {
-            padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs
+            padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs
               $space-xl;
           }
 
@@ -665,7 +667,8 @@
       }
     }
 
-    .icon-wrapper {
+    .icon-wrapper,
+    .read-only-icon-wrapper {
       &.left-icon {
         left: unset;
         right: $space-xxs;
@@ -729,7 +732,8 @@
     }
 
     &.input-large {
-      .icon-wrapper {
+      .icon-wrapper,
+      .read-only-icon-wrapper {
         &.left-icon {
           left: unset;
           right: $space-xs;
@@ -744,27 +748,27 @@
       .icon-button {
         &.left-icon {
           left: unset;
-          right: $space-xs;
+          right: $space-xxs;
         }
 
         &.right-icon {
-          left: $space-xs;
+          left: $space-xxs;
           right: unset;
         }
       }
 
       .clear-icon-button-rtl {
-        left: $space-xxxs;
+        left: $space-xxs;
         right: unset;
 
         &.left-icon {
-          left: $space-xxxs;
+          left: $space-xxs;
           right: unset;
         }
 
         &.right-icon {
           left: unset;
-          right: $space-xxxs;
+          right: $space-xxs;
         }
       }
 
@@ -782,14 +786,15 @@
     }
 
     &.input-medium {
-      .icon-wrapper {
+      .icon-wrapper,
+      .read-only-icon-wrapper {
         &.left-icon {
           left: unset;
-          right: $space-xs;
+          right: $space-xxs;
         }
 
         &.right-icon {
-          left: $space-xs;
+          left: $space-xxs;
           right: unset;
         }
       }
@@ -807,35 +812,36 @@
       }
 
       .clear-icon-button-rtl {
-        left: 1px;
+        left: $space-xxs;
         right: unset;
 
         &.left-icon {
-          left: 1px;
+          left: $space-xxs;
           right: unset;
         }
 
         &.right-icon {
           left: unset;
-          right: $space-xxxs;
+          right: $space-xxs;
         }
       }
 
       .icon-wrapper:not(:empty) + .icon-button {
         &.left-icon {
           left: unset;
-          right: $space-xxl;
+          right: $space-xl;
         }
 
         &.right-icon {
-          left: $space-xxl;
+          left: $space-xl;
           right: unset;
         }
       }
     }
 
     &.input-small {
-      .icon-wrapper {
+      .icon-wrapper,
+      .read-only-icon-wrapper {
         &.left-icon {
           left: unset;
           right: $space-xxs;
@@ -877,11 +883,11 @@
       .icon-wrapper:not(:empty) + .icon-button {
         &.left-icon {
           left: unset;
-          right: $space-xl;
+          right: 28px;
         }
 
         &.right-icon {
-          left: $space-xl;
+          left: 28px;
           right: unset;
         }
       }

--- a/src/components/Inputs/TextArea/TextArea.stories.tsx
+++ b/src/components/Inputs/TextArea/TextArea.stories.tsx
@@ -132,6 +132,12 @@ Text_Area.args = {
   minlength: 0,
   name: 'myTextArea',
   placeholder: 'Placeholder text',
+  readonly: {
+    clearable: false,
+    enabled: false,
+    iconProps: null,
+    noStyleChange: false,
+  },
   required: false,
   size: TextInputSize.Medium,
   shape: TextInputShape.Rectangle,

--- a/src/components/Inputs/TextArea/TextArea.stories.tsx
+++ b/src/components/Inputs/TextArea/TextArea.stories.tsx
@@ -133,7 +133,6 @@ Text_Area.args = {
   name: 'myTextArea',
   placeholder: 'Placeholder text',
   readonly: {
-    clearable: false,
     enabled: false,
     iconProps: null,
     noStyleChange: false,

--- a/src/components/Inputs/TextArea/TextArea.stories.tsx
+++ b/src/components/Inputs/TextArea/TextArea.stories.tsx
@@ -132,8 +132,8 @@ Text_Area.args = {
   minlength: 0,
   name: 'myTextArea',
   placeholder: 'Placeholder text',
-  readonly: {
-    enabled: false,
+  readonly: false,
+  readOnlyProps: {
     iconProps: null,
     noStyleChange: false,
   },

--- a/src/components/Inputs/TextArea/TextArea.test.tsx
+++ b/src/components/Inputs/TextArea/TextArea.test.tsx
@@ -17,15 +17,26 @@ describe('TextArea', () => {
     matchMedia.clear();
   });
 
-  test('text area renders', () => {
+  test('Text area renders', () => {
     const wrapper = mount(<TextArea />);
     expect(wrapper.containsMatchingElement(<TextArea />)).toEqual(true);
   });
 
-  test('text area id does not append uuid when from props', () => {
+  test('Text area id does not append uuid when from props', () => {
     const { container } = render(<TextArea id="textAreaTest" />);
     expect(
       container.getElementsByTagName('textarea')[0].getAttribute('id')
     ).toBe('textAreaTest');
+  });
+
+  test('Text area is readonly', () => {
+    const { container } = render(
+      <TextArea readonly defaultValue="Test value" />
+    );
+    expect(container.querySelector('.read-only')).toBeTruthy();
+    expect(
+      container.querySelector('.text-area').hasAttribute('readonly')
+    ).toBeTruthy();
+    expect(container.querySelector('.text-area').innerHTML).toBe('Test value');
   });
 });

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -3,7 +3,7 @@ import DisabledContext, {
   Disabled,
 } from '../../ConfigProvider/DisabledContext';
 import { ShapeContext, Shape, SizeContext, Size } from '../../ConfigProvider';
-import { Icon, IconName } from '../../Icon';
+import { Icon, IconName, IconSize } from '../../Icon';
 import { Label, LabelSize } from '../../Label';
 import {
   TextAreaProps,
@@ -54,6 +54,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       onKeyDown,
       onReset,
       placeholder,
+      readonly = false,
       required = false,
       reset = false,
       shape = TextInputShape.Rectangle,
@@ -120,6 +121,11 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       });
     };
 
+    const readOnlyIconClassNames: string = mergeClasses([
+      styles.readOnlyIconWrapper,
+      styles.rightIcon,
+    ]);
+
     const textAreaClassNames: string = mergeClasses([
       classNames,
       styles.textArea,
@@ -132,6 +138,13 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
         [styles.underline]: mergedShape === TextInputShape.Underline,
       },
       { [styles.inputStretch]: inputWidth === TextInputWidth.fill },
+      {
+        [styles.readOnly]:
+          !!readonly &&
+          (typeof readonly === 'boolean'
+            ? readonly
+            : readonly?.enabled && !readonly?.noStyleChange),
+      },
       { ['in-form-item']: mergedFormItemInput },
       getStatusClassNames(mergedStatus, hasFeedback),
     ]);
@@ -178,6 +191,13 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       {
         [styles.disabled]: allowDisabledFocus || mergedDisabled,
       },
+      {
+        [styles.readOnly]:
+          !!readonly &&
+          (typeof readonly === 'boolean'
+            ? readonly
+            : readonly?.enabled && !readonly?.noStyleChange),
+      },
       { [styles.inputWrapperRtl]: htmlDir === 'rtl' },
     ]);
 
@@ -217,6 +237,27 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       debouncedChange(e);
     };
 
+    const getIconSize = (): IconSize => {
+      let iconSize: IconSize;
+      if (largeScreenActive) {
+        iconSize = IconSize.Small;
+      } else if (mediumScreenActive) {
+        iconSize = IconSize.Medium;
+      } else if (smallScreenActive) {
+        iconSize = IconSize.Medium;
+      } else if (xSmallScreenActive) {
+        iconSize = IconSize.Large;
+      }
+      return iconSize;
+    };
+
+    const inputSizeToIconSizeMap = new Map<TextInputSize | Size, IconSize>([
+      [TextInputSize.Flex, getIconSize()],
+      [TextInputSize.Large, IconSize.Large],
+      [TextInputSize.Medium, IconSize.Medium],
+      [TextInputSize.Small, IconSize.Small],
+    ]);
+
     const inputSizeToLabelSizeMap = new Map<
       TextInputSize | Size,
       LabelSize | Size
@@ -255,6 +296,9 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
             onFocus={!allowDisabledFocus ? onFocus : null}
             onKeyDown={!allowDisabledFocus ? onKeyDown : null}
             placeholder={placeholder}
+            readOnly={
+              typeof readonly === 'boolean' ? readonly : readonly?.enabled
+            }
             required={required}
             style={style}
             rows={textAreaRows}
@@ -267,6 +311,17 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
               path={IconName.mdiResizeBottomRight}
               rotate={htmlDir === 'rtl' ? 90 : 0}
             />
+          )}
+          {(typeof readonly === 'boolean'
+            ? readonly
+            : readonly?.enabled && !readonly?.noStyleChange) && (
+            <div className={readOnlyIconClassNames}>
+              <Icon
+                path={IconName.mdiLock}
+                {...(typeof readonly === 'object' ? readonly?.iconProps : {})}
+                size={inputSizeToIconSizeMap.get(mergedSize)}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -55,6 +55,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       onReset,
       placeholder,
       readonly = false,
+      readOnlyProps,
       required = false,
       reset = false,
       shape = TextInputShape.Rectangle,
@@ -138,13 +139,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
         [styles.underline]: mergedShape === TextInputShape.Underline,
       },
       { [styles.inputStretch]: inputWidth === TextInputWidth.fill },
-      {
-        [styles.readOnly]:
-          !!readonly &&
-          (typeof readonly === 'boolean'
-            ? readonly
-            : readonly?.enabled && !readonly?.noStyleChange),
-      },
+      { [styles.readOnly]: !!readonly && !readOnlyProps?.noStyleChange },
       { ['in-form-item']: mergedFormItemInput },
       getStatusClassNames(mergedStatus, hasFeedback),
     ]);
@@ -191,13 +186,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       {
         [styles.disabled]: allowDisabledFocus || mergedDisabled,
       },
-      {
-        [styles.readOnly]:
-          !!readonly &&
-          (typeof readonly === 'boolean'
-            ? readonly
-            : readonly?.enabled && !readonly?.noStyleChange),
-      },
+      { [styles.readOnly]: !!readonly && !readOnlyProps?.noStyleChange },
       { [styles.inputWrapperRtl]: htmlDir === 'rtl' },
     ]);
 
@@ -296,9 +285,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
             onFocus={!allowDisabledFocus ? onFocus : null}
             onKeyDown={!allowDisabledFocus ? onKeyDown : null}
             placeholder={placeholder}
-            readOnly={
-              typeof readonly === 'boolean' ? readonly : readonly?.enabled
-            }
+            readOnly={readonly}
             required={required}
             style={style}
             rows={textAreaRows}
@@ -312,13 +299,11 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
               rotate={htmlDir === 'rtl' ? 90 : 0}
             />
           )}
-          {(typeof readonly === 'boolean'
-            ? readonly
-            : readonly?.enabled && !readonly?.noStyleChange) && (
+          {readonly && !readOnlyProps?.noStyleChange && (
             <div className={readOnlyIconClassNames}>
               <Icon
                 path={IconName.mdiLock}
-                {...(typeof readonly === 'object' ? readonly?.iconProps : {})}
+                {...readOnlyProps?.iconProps}
                 size={inputSizeToIconSizeMap.get(mergedSize)}
               />
             </div>

--- a/src/components/Inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/Inputs/TextInput/TextInput.stories.tsx
@@ -167,9 +167,9 @@ Text_Input.args = {
   name: 'myTextInput',
   numbersOnly: false,
   placeholder: 'Placeholder text',
-  readonly: {
+  readonly: false,
+  readOnlyProps: {
     clearable: false,
-    enabled: false,
     iconProps: null,
     noStyleChange: false,
   },

--- a/src/components/Inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/Inputs/TextInput/TextInput.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { IconName } from '../../Icon';
 import {
   TextInput,
+  TextInputIconAlign,
   TextInputShape,
   TextInputSize,
   TextInputWidth,
@@ -137,9 +138,11 @@ Text_Input.args = {
   autocomplete: undefined,
   autoFocus: true,
   classNames: 'my-textinput-class',
+  clearable: true,
   clearButtonAriaLabel: 'Clear',
   disabled: false,
   htmltype: 'text',
+  alignIcon: TextInputIconAlign.Left,
   iconProps: {
     path: IconName.mdiCardsHeart,
     color: 'red',
@@ -164,6 +167,12 @@ Text_Input.args = {
   name: 'myTextInput',
   numbersOnly: false,
   placeholder: 'Placeholder text',
+  readonly: {
+    clearable: false,
+    enabled: false,
+    iconProps: null,
+    noStyleChange: false,
+  },
   required: false,
   size: TextInputSize.Medium,
   shape: TextInputShape.Rectangle,

--- a/src/components/Inputs/TextInput/TextInput.test.tsx
+++ b/src/components/Inputs/TextInput/TextInput.test.tsx
@@ -17,15 +17,27 @@ describe('TextInput', () => {
     matchMedia.clear();
   });
 
-  test('text input renders', () => {
+  test('Text input renders', () => {
     const wrapper = mount(<TextInput />);
     expect(wrapper.containsMatchingElement(<TextInput />)).toEqual(true);
   });
 
-  test('text input id does not append uuid when from props', () => {
+  test('Text input id does not append uuid when from props', () => {
     const { container } = render(<TextInput id="textInputTest" />);
     expect(container.getElementsByTagName('input')[0].getAttribute('id')).toBe(
       'textInputTest'
     );
+  });
+
+  test('Text input is readOnly', () => {
+    const { container } = render(
+      <TextInput readonly defaultValue="Test value" />
+    );
+    expect(
+      container.getElementsByTagName('input')[0].hasAttribute('readonly')
+    ).toBeTruthy();
+    expect(
+      container.getElementsByTagName('input')[0].getAttribute('value')
+    ).toBe('Test value');
   });
 });

--- a/src/components/Inputs/TextInput/TextInput.test.tsx
+++ b/src/components/Inputs/TextInput/TextInput.test.tsx
@@ -29,7 +29,7 @@ describe('TextInput', () => {
     );
   });
 
-  test('Text input is readOnly', () => {
+  test('Text input is readonly', () => {
     const { container } = render(
       <TextInput readonly defaultValue="Test value" />
     );

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -72,6 +72,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
       onReset,
       placeholder,
       readonly = false,
+      readOnlyProps,
       reset = false,
       required = false,
       role = 'textbox',
@@ -242,13 +243,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
       { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
       { [styles.clearDisabled]: !clearable },
       { [styles.clearNotVisible]: !clearButtonShown },
-      {
-        [styles.readOnly]:
-          !!readonly &&
-          (typeof readonly === 'boolean'
-            ? readonly
-            : readonly?.enabled && !readonly?.noStyleChange),
-      },
+      { [styles.readOnly]: !!readonly && !readOnlyProps?.noStyleChange },
       { ['in-form-item']: mergedFormItemInput },
       getStatusClassNames(mergedStatus, hasFeedback),
     ]);
@@ -297,13 +292,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
       {
         [styles.disabled]: allowDisabledFocus || mergedDisabled,
       },
-      {
-        [styles.readOnly]:
-          !!readonly &&
-          (typeof readonly === 'boolean'
-            ? readonly
-            : readonly?.enabled && !readonly?.noStyleChange),
-      },
+      { [styles.readOnly]: !!readonly && !readOnlyProps?.noStyleChange },
       { [styles.inputWrapperRtl]: htmlDir === 'rtl' },
       { ['in-form-item']: mergedFormItemInput },
       { [styles.isExpandable]: expandable },
@@ -493,9 +482,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
               onFocus={!allowDisabledFocus ? onFocus : null}
               onKeyDown={!allowDisabledFocus ? onKeyDown : null}
               placeholder={placeholder}
-              readOnly={
-                typeof readonly === 'boolean' ? readonly : readonly?.enabled
-              }
+              readOnly={readonly}
               required={required}
               role={role}
               style={style}
@@ -548,10 +535,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
                 clearButtonShown &&
                 !numbersOnly &&
                 htmlType !== 'number' &&
-                (typeof readonly === 'boolean'
-                  ? !readonly
-                  : !readonly?.enabled ||
-                    (readonly.enabled && readonly?.clearable)) && (
+                (!readonly || (readonly && readOnlyProps?.clearable)) && (
                   <SystemUIButton
                     ref={clearButtonRef}
                     allowDisabledFocus={allowDisabledFocus}
@@ -572,15 +556,11 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
               {iconButtonProps &&
                 alignIcon === TextInputIconAlign.Right &&
                 getIconButton()}
-              {(typeof readonly === 'boolean'
-                ? readonly
-                : readonly?.enabled && !readonly?.noStyleChange) && (
+              {readonly && !readOnlyProps?.noStyleChange && (
                 <div className={readOnlyIconClassNames}>
                   <Icon
                     path={IconName.mdiLock}
-                    {...(typeof readonly === 'object'
-                      ? readonly?.iconProps
-                      : {})}
+                    {...readOnlyProps?.iconProps}
                     size={inputSizeToIconSizeMap.get(mergedSize)}
                   />
                 </div>

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -71,9 +71,9 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
       onKeyDown,
       onReset,
       placeholder,
+      readonly = false,
       reset = false,
       required = false,
-      readonly = false,
       role = 'textbox',
       shape = TextInputShape.Rectangle,
       size = TextInputSize.Medium,
@@ -146,6 +146,11 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
       styles.iconWrapper,
       { [styles.leftIcon]: alignIcon === TextInputIconAlign.Left },
       { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
+    ]);
+
+    const readOnlyIconClassNames: string = mergeClasses([
+      styles.readOnlyIconWrapper,
+      styles.rightIcon,
     ]);
 
     const iconButtonClassNames: string = mergeClasses([
@@ -237,6 +242,13 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
       { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
       { [styles.clearDisabled]: !clearable },
       { [styles.clearNotVisible]: !clearButtonShown },
+      {
+        [styles.readOnly]:
+          !!readonly &&
+          (typeof readonly === 'boolean'
+            ? readonly
+            : readonly?.enabled && !readonly?.noStyleChange),
+      },
       { ['in-form-item']: mergedFormItemInput },
       getStatusClassNames(mergedStatus, hasFeedback),
     ]);
@@ -284,6 +296,13 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
       { [styles.rightIcon]: alignIcon === TextInputIconAlign.Right },
       {
         [styles.disabled]: allowDisabledFocus || mergedDisabled,
+      },
+      {
+        [styles.readOnly]:
+          !!readonly &&
+          (typeof readonly === 'boolean'
+            ? readonly
+            : readonly?.enabled && !readonly?.noStyleChange),
       },
       { [styles.inputWrapperRtl]: htmlDir === 'rtl' },
       { ['in-form-item']: mergedFormItemInput },
@@ -432,7 +451,11 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
           path: iconButtonProps.iconProps.path,
         }}
         id={iconButtonProps.id}
-        onClick={iconButtonProps.onClick}
+        onClick={
+          !iconButtonProps.disabled && !mergedDisabled
+            ? iconButtonProps.onClick
+            : null
+        }
         shape={inputShapeToButtonShapeMap.get(shape)}
         size={inputSizeToButtonSizeMap.get(mergedSize)}
         transparent
@@ -470,13 +493,15 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
               onFocus={!allowDisabledFocus ? onFocus : null}
               onKeyDown={!allowDisabledFocus ? onKeyDown : null}
               placeholder={placeholder}
+              readOnly={
+                typeof readonly === 'boolean' ? readonly : readonly?.enabled
+              }
               required={required}
               role={role}
               style={style}
               tabIndex={0}
               type={numbersOnly ? 'number' : htmlType}
               value={inputValue}
-              readOnly={readonly}
             />
             {expandable && iconButtonProps && (
               <SystemUIButton
@@ -522,7 +547,11 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
               {clearable &&
                 clearButtonShown &&
                 !numbersOnly &&
-                htmlType !== 'number' && (
+                htmlType !== 'number' &&
+                (typeof readonly === 'boolean'
+                  ? !readonly
+                  : !readonly?.enabled ||
+                    (readonly.enabled && readonly?.clearable)) && (
                   <SystemUIButton
                     ref={clearButtonRef}
                     allowDisabledFocus={allowDisabledFocus}
@@ -543,6 +572,19 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
               {iconButtonProps &&
                 alignIcon === TextInputIconAlign.Right &&
                 getIconButton()}
+              {(typeof readonly === 'boolean'
+                ? readonly
+                : readonly?.enabled && !readonly?.noStyleChange) && (
+                <div className={readOnlyIconClassNames}>
+                  <Icon
+                    path={IconName.mdiLock}
+                    {...(typeof readonly === 'object'
+                      ? readonly?.iconProps
+                      : {})}
+                    size={inputSizeToIconSizeMap.get(mergedSize)}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -32,6 +32,22 @@
       color: var(--input-placeholder-text-color);
     }
 
+    &.clear-disabled {
+      &.left-icon {
+        padding: $space-xs;
+      }
+
+      &.right-icon {
+        padding: $space-xs;
+      }
+    }
+
+    &.clear-not-visible {
+      &.right-icon {
+        padding: $space-xs;
+      }
+    }
+
     &.with-icon,
     &.with-image-icon {
       padding: $space-xs $space-xl $space-xs $space-xxl;
@@ -145,6 +161,7 @@
 
     &.read-only {
       background-color: var(--input-readonly-background-color);
+      border-color: var(--input-readonly-border-color);
       color: var(--input-readonly-text-color);
     }
 
@@ -328,9 +345,11 @@
 
     &.underline {
       border-color: transparent;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
     }
 
-    &:active {
+    &:active:not([disabled]):not([readOnly]) {
       border-color: var(--input-border-color-active);
 
       &.underline {
@@ -338,7 +357,7 @@
       }
     }
 
-    &:hover:not([disabled]) {
+    &:hover:not([disabled]):not([readOnly]) {
       border-color: var(--input-border-color-hover);
 
       &.underline {
@@ -360,7 +379,23 @@
       font-size: $text-font-size-4;
       height: $input-large-size;
       line-height: $text-line-height-5;
-      padding: $space-xs $space-xxl $space-xs $space-m;
+      padding: $space-xs $space-xxl $space-xs $space-xs;
+
+      &.clear-disabled {
+        &.left-icon {
+          padding: $space-xs;
+        }
+
+        &.right-icon {
+          padding: $space-xs;
+        }
+      }
+
+      &.clear-not-visible {
+        &.right-icon {
+          padding: $space-xs;
+        }
+      }
 
       &.with-icon,
       &.with-image-icon,
@@ -400,13 +435,13 @@
           $input-padding-large-with-icon-and-icon-button;
 
         &.left-icon {
-          padding: $space-xs $space-xxl $space-xs
+          padding: $space-xs 48px $space-xs
             $input-padding-large-with-icon-and-icon-button;
         }
 
         &.right-icon {
           padding: $space-xs $input-padding-large-with-icon-and-icon-button
-            $space-xs $space-xxl;
+            $space-xs 48px;
         }
 
         &.clear-disabled {
@@ -501,7 +536,7 @@
       font-size: $text-font-size-3;
       height: $input-medium-size;
       line-height: $text-line-height-4;
-      padding: $space-xs $space-xl $space-xs $space-m;
+      padding: $space-xs $space-xl $space-xs $space-xs;
 
       &.with-icon,
       &.with-image-icon {
@@ -537,16 +572,16 @@
 
         &.left-icon,
         &.right-icon {
-          padding: $space-xs $space-xl $space-xs $space-xl;
+          padding: $space-xs $space-xxl $space-xs $space-xxl;
         }
 
         &.clear-disabled {
           &.left-icon {
-            padding: $space-xs $space-xs $space-xs $space-xl;
+            padding: $space-xs $space-xs $space-xs $space-xxl;
           }
 
           &.right-icon {
-            padding: $space-xs $space-xl $space-xs $space-xs;
+            padding: $space-xs $space-xxl $space-xs $space-xs;
           }
         }
 
@@ -684,19 +719,37 @@
       font-size: $text-font-size-2;
       height: $input-small-size;
       line-height: $text-line-height-3;
-      padding: $space-xs $space-l $space-xs $space-s;
+      padding: $space-xs $space-l $space-xs $space-xs;
+
+      &.clear-disabled {
+        &.left-icon {
+          padding: $space-xs;
+        }
+
+        &.right-icon {
+          padding: $space-xs;
+        }
+      }
+
+      &.clear-not-visible {
+        &.right-icon {
+          padding: $space-xs;
+        }
+      }
 
       &.with-icon,
       &.with-image-icon,
       &.with-icon-button {
-        padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs $space-xl;
+        padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs $space-xl;
 
         &.left-icon {
-          padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs $space-xl;
+          padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs
+            $space-xl;
         }
 
         &.right-icon {
-          padding: $space-xs $space-xl $space-xs calc(#{$space-l} + $space-xxs);
+          padding: $space-xs $space-xl $space-xs
+            calc(#{$space-l} + #{$space-xxs});
         }
 
         &.clear-disabled {
@@ -717,17 +770,17 @@
       }
 
       &.with-icon-and-icon-button {
-        padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs
+        padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs
           $input-padding-small-with-icon-and-icon-button;
 
         &.left-icon {
-          padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs
+          padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs
             $input-padding-small-with-icon-and-icon-button;
         }
 
         &.right-icon {
           padding: $space-xs $input-padding-small-with-icon-and-icon-button
-            $space-xs calc(#{$space-l} + $space-xxs);
+            $space-xs calc(#{$space-l} + #{$space-xxs});
         }
 
         &.clear-disabled {
@@ -752,14 +805,16 @@
 
       &.pill-shape-with-icon,
       &.pill-shape-with-image-icon {
-        padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs $space-xl;
+        padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs $space-xl;
 
         &.left-icon {
-          padding: $space-xs calc(#{$space-l} + $space-xxs) $space-xs $space-xl;
+          padding: $space-xs calc(#{$space-l} + #{$space-xxs}) $space-xs
+            $space-xl;
         }
 
         &.right-icon {
-          padding: $space-xs $space-xl $space-xs calc(#{$space-l} + $space-xxs);
+          padding: $space-xs $space-xl $space-xs
+            calc(#{$space-l} + #{$space-xxs});
         }
 
         &.clear-disabled {
@@ -847,7 +902,8 @@
     }
   }
 
-  .icon-wrapper {
+  .icon-wrapper,
+  .read-only-icon-wrapper {
     bottom: 0;
     height: $input-medium-size;
     position: absolute;
@@ -875,6 +931,12 @@
 
     svg {
       color: var(--grey-tertiary-color);
+    }
+  }
+
+  .read-only-icon-wrapper {
+    span {
+      width: fit-content;
     }
   }
 
@@ -1041,6 +1103,8 @@
 
     &.underline {
       border-color: transparent;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
     }
 
     &.inline {
@@ -1091,6 +1155,13 @@
           bottom: 10px;
         }
       }
+    }
+  }
+
+  .text-area-group {
+    .read-only-icon-wrapper {
+      bottom: unset;
+      top: 0;
     }
   }
 
@@ -1198,6 +1269,7 @@
   &.disabled {
     .clear-icon-button,
     .icon-wrapper,
+    .read-only-icon-wrapper,
     .icon-button,
     input,
     textarea {
@@ -1233,8 +1305,30 @@
     }
   }
 
+  &.read-only {
+    &.underline {
+      .input-group,
+      .text-area-group {
+        &:before {
+          border-color: var(--input-readonly-border-color);
+        }
+
+        &:after {
+          border-bottom: 1px solid var(--input-readonly-border-color);
+        }
+
+        &:hover {
+          &:before {
+            border-color: var(--input-readonly-border-color);
+          }
+        }
+      }
+    }
+  }
+
   &.input-large {
-    .icon-wrapper {
+    .icon-wrapper,
+    .read-only-icon-wrapper {
       bottom: $space-xxxs;
       height: $space-xxl;
       width: $space-xxl;
@@ -1252,25 +1346,30 @@
       }
     }
 
+    .read-only-icon-wrapper {
+      width: fit-content;
+    }
+
     .icon-button {
-      bottom: 0;
-      height: 44px;
+      bottom: $space-xxs;
+      height: 36px;
+      padding: $space-xxs 6px;
 
       &.left-icon {
-        left: $space-xs;
+        left: $space-xxs;
       }
 
       &.right-icon {
-        right: $space-xs;
+        right: $space-xxs;
       }
     }
 
     .clear-icon-button {
-      bottom: $space-xxxs;
-      height: $space-xxl;
-      padding: $space-s;
-      right: $space-xxxs;
-      width: $space-xxl;
+      bottom: $space-xxs;
+      height: 36px;
+      padding: $space-xxs 10px;
+      right: $space-xxs;
+      width: 36px;
     }
 
     .icon-wrapper:not(:empty) + .icon-button {
@@ -1291,22 +1390,27 @@
   }
 
   &.input-medium {
-    .icon-wrapper {
+    .icon-wrapper,
+    .read-only-icon-wrapper {
       bottom: 0;
       height: $input-medium-size;
-      width: $input-medium-size;
+      width: fit-content;
 
       &.left-icon {
-        left: $space-xs;
+        left: $space-xxs;
       }
 
       &.right-icon {
-        right: $space-xs;
+        right: $space-xxs;
       }
 
       span {
         height: $input-medium-size;
       }
+    }
+
+    .read-only-icon-wrapper {
+      width: fit-content;
     }
 
     .icon-button {
@@ -1324,20 +1428,20 @@
     }
 
     .clear-icon-button {
-      bottom: 1px;
-      height: 35px;
-      padding: 6px 10px;
-      right: 1px;
-      width: 35px;
+      bottom: $space-xxs;
+      height: 28px;
+      padding: 6px;
+      right: $space-xxs;
+      width: 28px;
     }
 
     .icon-wrapper:not(:empty) + .icon-button {
       &.left-icon {
-        left: $space-xxl;
+        left: $space-xl;
       }
 
       &.right-icon {
-        right: $space-xxl;
+        right: $space-xl;
       }
     }
 
@@ -1349,7 +1453,8 @@
   }
 
   &.input-small {
-    .icon-wrapper {
+    .icon-wrapper,
+    .read-only-icon-wrapper {
       bottom: $space-xxxs;
       height: $space-l;
       width: $space-l;
@@ -1366,6 +1471,10 @@
         height: $space-l;
         padding: $space-xxs;
       }
+    }
+
+    .read-only-icon-wrapper {
+      width: fit-content;
     }
 
     .icon-button {
@@ -1392,11 +1501,11 @@
 
     .icon-wrapper:not(:empty) + .icon-button {
       &.left-icon {
-        left: $space-xl;
+        left: 28px;
       }
 
       &.right-icon {
-        right: $space-xl;
+        right: 28px;
       }
     }
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -184,7 +184,7 @@ export const __namedExportsOrder = [
 const SelectArgs: SelectProps = {
   classNames: 'octuple-select-class',
   disabled: false,
-  inputReadOnly: false,
+  readonly: false,
   'data-test-id': 'octuple-select-test-id',
   shape: SelectShape.Rectangle,
   size: SelectSize.Medium,

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -184,6 +184,7 @@ export const __namedExportsOrder = [
 const SelectArgs: SelectProps = {
   classNames: 'octuple-select-class',
   disabled: false,
+  inputReadOnly: false,
   'data-test-id': 'octuple-select-test-id',
   shape: SelectShape.Rectangle,
   size: SelectSize.Medium,

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -107,11 +107,31 @@ describe('Select', () => {
 
   test('Renders as read-only and is not editable', () => {
     const { container } = render(
-      <Select filterable inputReadOnly options={options} />
+      <Select filterable readonly options={options} />
     );
     expect(
       container.querySelector('.select-input').hasAttribute('readonly')
     ).toBeTruthy();
+  });
+
+  test('Hides the dropdown when readonly', async () => {
+    const { container, rerender, getByPlaceholderText } = render(
+      <Select options={options} readonly={false} placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    fireEvent.click(select);
+    await waitFor(() =>
+      expect(container.querySelector('.dropdown-wrapper')).toBeTruthy()
+    );
+    rerender(
+      <Select options={options} readonly={true} placeholder="Select test" />
+    );
+    await waitFor(() =>
+      expect(
+        container.querySelector('.select-input').hasAttribute('readOnly')
+      ).toBe(true)
+    );
+    expect(container.querySelector('.dropdown-wrapper')).toBeFalsy();
   });
 
   test('Opens the dropdown when clicked', async () => {

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -98,11 +98,20 @@ describe('Select', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('renders as not read-only and is editable', () => {
-    const { container } = render(<Select options={options} />);
+  test('Renders as not read-only and is editable', () => {
+    const { container } = render(<Select filterable options={options} />);
     expect(
       container.querySelector('.select-input').getAttribute('readonly')
     ).toBeFalsy();
+  });
+
+  test('Renders as read-only and is not editable', () => {
+    const { container } = render(
+      <Select filterable inputReadOnly options={options} />
+    );
+    expect(
+      container.querySelector('.select-input').hasAttribute('readonly')
+    ).toBeTruthy();
   });
 
   test('Opens the dropdown when clicked', async () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -63,7 +63,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       formItemInput = false,
       id,
       inputClassNames,
-      inputReadOnly = false,
+      readonly = false,
       inputWidth = TextInputWidth.fill,
       isLoading,
       loadOptions,
@@ -263,10 +263,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     }, [clear, dropdownVisible, filterable]);
 
     useEffect(() => {
-      if (inputReadOnly && dropdownVisible) {
+      if (readonly && dropdownVisible) {
         setDropdownVisibility(false);
       }
-    }, [inputReadOnly, dropdownVisible]);
+    }, [readonly, dropdownVisible]);
 
     const toggleOption = (option: SelectOption): void => {
       setSearchQuery('');
@@ -518,7 +518,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
             onClose={() => toggleOption(opt)}
             size={selectSizeToPillSizeMap.get(size)}
             theme={'blueGreen'}
-            type={inputReadOnly ? PillType.default : PillType.closable}
+            type={readonly ? PillType.default : PillType.closable}
             style={{
               visibility: index < count ? 'visible' : 'hidden',
             }}
@@ -678,10 +678,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const selectInputProps: TextInputProps = {
       placeholder: showPills() && !!options ? '' : placeholder,
       alignIcon: TextInputIconAlign.Right,
-      clearable: clearable && !inputReadOnly,
+      clearable: clearable && !readonly,
       clearButtonClassNames: clearButtonClassNames,
       inputWidth: inputWidth,
-      iconButtonProps: !inputReadOnly
+      iconButtonProps: !readonly
         ? {
             htmlType: 'button',
             iconProps: {
@@ -755,7 +755,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
             closeOnReferenceClick={closeOnReferenceClick}
             {...dropdownProps}
             classNames={dropdownWrapperClassNames}
-            disabled={mergedDisabled || inputReadOnly}
+            disabled={mergedDisabled || readonly}
             dropdownClassNames={dropdownMenuOverlayClassNames}
             onVisibleChange={(isVisible) => setDropdownVisibility(isVisible)}
             overlay={isLoading ? spinner : <OptionMenu options={options} />}
@@ -793,12 +793,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
                 onFocus={onFocus}
                 onKeyDown={onKeyDown}
                 onReset={(): void => setResetTextInput(false)}
-                readonly={{
+                readonly={!filterable || readonly}
+                readOnlyProps={{
                   clearable:
-                    (filterable || selectInputProps?.clearable) &&
-                    !inputReadOnly,
-                  enabled: !filterable || inputReadOnly,
-                  noStyleChange: !inputReadOnly,
+                    (filterable || selectInputProps?.clearable) && !readonly,
+                  noStyleChange: !readonly,
                 }}
                 reset={resetTextInput}
                 role="combobox"

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -105,6 +105,11 @@ export interface SelectProps
    */
   inputClassNames?: string;
   /**
+   * The Select input is readonly.
+   * @default false
+   */
+  inputReadOnly?: boolean;
+  /**
    * Width of the Select text input.
    * @default TextInputWidth.fitContent
    */

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -108,7 +108,7 @@ export interface SelectProps
    * The Select input is readonly.
    * @default false
    */
-  inputReadOnly?: boolean;
+  readonly?: boolean;
   /**
    * Width of the Select text input.
    * @default TextInputWidth.fitContent

--- a/src/components/Select/Styles/rtl.scss
+++ b/src/components/Select/Styles/rtl.scss
@@ -18,7 +18,7 @@
     &.select-large {
       .select-input-group {
         .select-clear-button-start-rtl {
-          right: 2px;
+          right: $space-xxs;
           left: unset;
         }
 
@@ -32,7 +32,7 @@
     &.select-medium {
       .select-input-group {
         .select-clear-button-start-rtl {
-          right: 2px;
+          right: $space-xxs;
           left: unset;
         }
 
@@ -46,7 +46,7 @@
     &.select-small {
       .select-input-group {
         .select-clear-button-start-rtl {
-          right: 2px;
+          right: $space-xxxs;
           left: unset;
         }
 

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -93,14 +93,14 @@ $multi-select-count-offset: 54px;
     }
 
     .select-clear-button {
-      bottom: 0;
-      height: 44px;
+      bottom: $space-xxs;
+      height: 36px;
       padding: $space-xxs $space-xs;
       width: $space-xl;
     }
 
     .select-clear-button-start {
-      left: $space-xxxs;
+      left: $space-xxs;
       right: unset;
     }
 
@@ -128,7 +128,7 @@ $multi-select-count-offset: 54px;
     }
 
     .select-clear-button-start {
-      left: $space-xxxs;
+      left: $space-xxs;
       right: unset;
     }
 

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -405,6 +405,7 @@
   --input-text-color: var(--text-primary-color);
   --input-placeholder-text-color: var(--text-secondary-color);
   --input-readonly-background-color: var(--grey-background1-color);
+  --input-readonly-border-color: var(--grey-tertiary-color);
   --input-readonly-text-color: var(--text-primary-color);
   --input-success-text-color: var(--text-primary-color);
   --input-success-border-color: var(--input-border-color);

--- a/src/styles/themes/_definitions.scss
+++ b/src/styles/themes/_definitions.scss
@@ -316,8 +316,8 @@ $layout-zero-trigger-height: 32px;
 // Input
 $input-padding-large-with-icon: 48px;
 $input-padding-large-with-icon-and-icon-button: 84px;
-$input-padding-medium-with-icon-and-icon-button: 74px;
-$input-padding-small-with-icon-and-icon-button: 60px;
+$input-padding-medium-with-icon-and-icon-button: 64px;
+$input-padding-small-with-icon-and-icon-button: 56px;
 
 // Table
 


### PR DESCRIPTION
## SUMMARY:

- Updates `TextInput`, `TextArea`, `SearchBox` `readonly` and `readOnlyProps`, enabling complex custom readonly implementations.
- Updates Select `readonly` to behave as expected
- Adds UTs

https://github.com/EightfoldAI/octuple/assets/99700808/75995ec6-fa42-49e3-ba8f-82bcfa0c5f29

## JIRA TASK (Eightfold Employees Only):
ENG-60991

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Inputs` and `Select` stories behave as expected.