### PR TITLE
feat: progress: add pill variant

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -124,8 +124,27 @@ const { RangePicker } = DatePicker;
 
 const customFonts: CustomFont[] = [
   {
-    fontFamily: 'Noto Serif',
-    src: `url(https://fonts.gstatic.com/s/notoserif/v22/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZqFCTyscKpKrCzi0iNaA.woff2) format('woff2')`,
+    fontFamily: 'Athiti',
+    src: "url(https://fonts.gstatic.com/s/athiti/v12/pe0vMISdLIZIv1wIHxJXOtY.woff2) format('woff2')",
+    unicodeRange: 'U+0E01-0E5B, U+200C-200D, U+25CC',
+  },
+  {
+    fontFamily: 'Athiti',
+    src: "url(https://fonts.gstatic.com/s/athiti/v12/pe0vMISdLIZIv1wIBBJXOtY.woff2) format('woff2')",
+    unicodeRange:
+      'U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB',
+  },
+  {
+    fontFamily: 'Athiti',
+    src: "url(https://fonts.gstatic.com/s/athiti/v12/pe0vMISdLIZIv1wIBRJXOtY.woff2) format('woff2')",
+    unicodeRange:
+      'U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF',
+  },
+  {
+    fontFamily: 'Athiti',
+    src: "url(https://fonts.gstatic.com/s/athiti/v12/pe0vMISdLIZIv1wICxJX.woff2) format('woff2')",
+    unicodeRange:
+      'U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD',
   },
   {
     fontFamily: 'Pacifico',

--- a/src/components/Progress/Line.tsx
+++ b/src/components/Progress/Line.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useLayoutEffect, useRef } from 'react';
-import { LineProps, ProgressSize } from './Progress.types';
+import { LineProps, ProgressSize, ProgressVariant } from './Progress.types';
 import type { ProgressGradient, StringGradients } from './Progress.types';
 import { getSuccessPercent, validProgress } from './Utils';
 import type { DirectionType } from '../ConfigProvider';
@@ -81,6 +81,7 @@ const Line: FC<LineProps> = (props) => {
     successLabelRef,
     trailColor = null,
     valueLabelRef,
+    variant,
   } = props;
 
   const progressBgRef: React.MutableRefObject<HTMLDivElement> =
@@ -251,7 +252,12 @@ const Line: FC<LineProps> = (props) => {
 
   return (
     <ResizeObserver onResize={updateLayout}>
-      <div className={styles.progressOuter}>
+      <div
+        className={mergeClasses([
+          styles.progressOuter,
+          { [styles.progressOuterPill]: variant === ProgressVariant.Pill },
+        ])}
+      >
         <div
           className={mergeClasses([
             styles.progressInner,

--- a/src/components/Progress/Line.tsx
+++ b/src/components/Progress/Line.tsx
@@ -70,6 +70,7 @@ const Line: FC<LineProps> = (props) => {
     maxLabelRef,
     minLabelRef,
     percent,
+    pillBordered,
     showLabels,
     showSuccessLabel,
     showValueLabel,
@@ -103,9 +104,21 @@ const Line: FC<LineProps> = (props) => {
     borderRadius,
   };
 
+  const getPercentHeight = (): number => {
+    let height: number = 6;
+    if (size === ProgressSize.Large) {
+      height = 12;
+    } else if (size === ProgressSize.Medium) {
+      height = 6;
+    } else if (size === ProgressSize.Small) {
+      height = 4;
+    }
+    return height;
+  };
+
   const percentStyle = {
     width: `${validProgress(percent)}%`,
-    height: strokeWidth || (size === ProgressSize.Small ? 2 : 4),
+    height: strokeWidth || getPercentHeight(),
     borderRadius,
     ...backgroundProps,
   };
@@ -114,7 +127,7 @@ const Line: FC<LineProps> = (props) => {
 
   const successPercentStyle = {
     width: `${validProgress(successPercent)}%`,
-    height: strokeWidth || (size === ProgressSize.Small ? 2 : 4),
+    height: strokeWidth || getPercentHeight(),
     borderRadius,
     background: success?.strokeColor,
   };
@@ -256,6 +269,7 @@ const Line: FC<LineProps> = (props) => {
         className={mergeClasses([
           styles.progressOuter,
           { [styles.progressOuterPill]: variant === ProgressVariant.Pill },
+          { [styles.progressOuterPillBordered]: !!pillBordered },
         ])}
       >
         <div

--- a/src/components/Progress/Progress.stories.tsx
+++ b/src/components/Progress/Progress.stories.tsx
@@ -29,7 +29,16 @@ export default {
       ),
     },
   },
-  argTypes: {},
+  argTypes: {
+    size: {
+      options: [ProgressSize.Large, ProgressSize.Medium, ProgressSize.Small],
+      control: { type: 'radio' },
+    },
+    variant: {
+      options: [ProgressVariant.Default, ProgressVariant.Pill],
+      control: { type: 'inline-radio' },
+    },
+  },
 } as ComponentMeta<typeof Progress>;
 
 const Line_Story: ComponentStory<typeof Progress> = (args) => {
@@ -341,6 +350,7 @@ Line.args = {
 
 Line_Pill.args = {
   ...progressArgs,
+  pillBordered: true,
   variant: ProgressVariant.Pill,
 };
 
@@ -350,6 +360,7 @@ Small_Line.args = {
 
 Small_Line_Pill.args = {
   ...progressArgs,
+  pillBordered: true,
   variant: ProgressVariant.Pill,
 };
 
@@ -375,6 +386,7 @@ Steps.args = {
 
 Steps_Pill.args = {
   ...progressArgs,
+  pillBordered: true,
   variant: ProgressVariant.Pill,
 };
 

--- a/src/components/Progress/Progress.stories.tsx
+++ b/src/components/Progress/Progress.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Progress, { ProgressSize } from '.';
 import { Stack } from '../Stack';
 import { Tooltip, TooltipTheme } from '../Tooltip';
+import { ProgressVariant } from './Progress.types';
 
 export default {
   title: 'Progress',
@@ -169,7 +170,7 @@ const Steps_Story: ComponentStory<typeof Progress> = (args) => {
         size={ProgressSize.Small}
         steps={3}
         stepWidth={24}
-        width={82}
+        width={96}
       />
       <Progress {...args} percent={30} steps={5} showValueLabel />
       <Progress
@@ -289,12 +290,15 @@ const Gradient_Story: ComponentStory<typeof Progress> = (args) => {
 };
 
 export const Line = Line_Story.bind({});
+export const Line_Pill = Line_Story.bind({});
 export const Small_Line = Small_Line_Story.bind({});
+export const Small_Line_Pill = Small_Line_Story.bind({});
 export const Circle = Circle_Story.bind({});
 export const Small_Circle = Small_Circle_Story.bind({});
 export const Dashboard = Dashboard_Story.bind({});
 export const Line_Cap = Line_Cap_Story.bind({});
 export const Steps = Steps_Story.bind({});
+export const Steps_Pill = Steps_Story.bind({});
 export const Success_Segment = Success_Segment_Story.bind({});
 export const Gradient = Gradient_Story.bind({});
 
@@ -303,12 +307,15 @@ export const Gradient = Gradient_Story.bind({});
 // See https://www.npmjs.com/package/babel-plugin-named-exports-order
 export const __namedExportsOrder = [
   'Line',
+  'Line_Pill',
   'Small_Line',
+  'Small_Line_Pill',
   'Circle',
   'Small_Circle',
   'Dashboard',
   'Line_Cap',
   'Steps',
+  'Steps_Pill',
   'Success_Segment',
   'Gradient',
 ];
@@ -332,8 +339,18 @@ Line.args = {
   ...progressArgs,
 };
 
+Line_Pill.args = {
+  ...progressArgs,
+  variant: ProgressVariant.Pill,
+};
+
 Small_Line.args = {
   ...progressArgs,
+};
+
+Small_Line_Pill.args = {
+  ...progressArgs,
+  variant: ProgressVariant.Pill,
 };
 
 Circle.args = {
@@ -354,6 +371,11 @@ Line_Cap.args = {
 
 Steps.args = {
   ...progressArgs,
+};
+
+Steps_Pill.args = {
+  ...progressArgs,
+  variant: ProgressVariant.Pill,
 };
 
 Success_Segment.args = {

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -6,6 +6,7 @@ import {
   ProgressProps,
   ProgressSize,
   ProgressStatuses,
+  ProgressVariant,
   StringGradients,
 } from './Progress.types';
 import { getSuccessPercent, validProgress } from './Utils';
@@ -37,6 +38,7 @@ const Progress: FC<ProgressProps> = React.forwardRef(
       strokeColor,
       successLabel,
       type = 'line',
+      variant = ProgressVariant.Default,
       width,
       ...rest
     } = props;

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -28,6 +28,7 @@ const Progress: FC<ProgressProps> = React.forwardRef(
       maxLabel,
       minLabel,
       percent = 0,
+      pillBordered = true,
       showLabels = true,
       showPercentSymbol = true,
       showSuccessLabel = false,
@@ -240,7 +241,7 @@ const Progress: FC<ProgressProps> = React.forwardRef(
         }`
       ],
       (styles as any)[`progress-status-${progressStatus}`],
-      { [styles.progressSmall]: size === 'small' },
+      { [styles.progressSmall]: size === ProgressSize.Small },
       { [styles.progressRtl]: htmlDir === 'rtl' },
       classNames,
     ]);

--- a/src/components/Progress/Progress.types.ts
+++ b/src/components/Progress/Progress.types.ts
@@ -19,6 +19,7 @@ export type ProgressGradient = { direction?: string } & (
 );
 
 export enum ProgressSize {
+  Large = 'large',
   Medium = 'medium',
   Small = 'small',
 }
@@ -30,7 +31,7 @@ export enum ProgressVariant {
 
 export interface ProgressProps extends OcBaseProps<HTMLDivElement> {
   /**
-   * Whether to visually hide the Progress border.
+   * Whether to visually show/hide the Progress border.
    * @default true
    */
   bordered?: boolean;
@@ -81,6 +82,11 @@ export interface ProgressProps extends OcBaseProps<HTMLDivElement> {
    * @default 0
    */
   percent?: number;
+  /**
+   * Whether to visually show/hide the Progress Pill border.
+   * @default true
+   */
+  pillBordered?: boolean;
   /**
    * Whether the labels are visible or not
    * @default true

--- a/src/components/Progress/Progress.types.ts
+++ b/src/components/Progress/Progress.types.ts
@@ -23,6 +23,11 @@ export enum ProgressSize {
   Small = 'small',
 }
 
+export enum ProgressVariant {
+  Default = 'default',
+  Pill = 'pill',
+}
+
 export interface ProgressProps extends OcBaseProps<HTMLDivElement> {
   /**
    * Whether to visually hide the Progress border.
@@ -149,6 +154,11 @@ export interface ProgressProps extends OcBaseProps<HTMLDivElement> {
    * @default 'line'
    */
   type?: ProgressType;
+  /**
+   * Determines the progress variant.
+   * @default ProgressVariant.Default
+   */
+  variant?: ProgressVariant;
   /**
    * The Progress component width.
    */

--- a/src/components/Progress/Steps.tsx
+++ b/src/components/Progress/Steps.tsx
@@ -1,5 +1,9 @@
 import React, { FC, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { ProgressStepsProps, ProgressVariant } from './Progress.types';
+import {
+  ProgressSize,
+  ProgressStepsProps,
+  ProgressVariant,
+} from './Progress.types';
 import { MAX_PERCENT } from './Internal/Common';
 import { ResizeObserver } from '../../shared/ResizeObserver/ResizeObserver';
 import { mergeClasses } from '../../shared/utilities';
@@ -16,13 +20,14 @@ const Steps: FC<ProgressStepsProps> = (props) => {
     maxLabelRef,
     minLabelRef,
     percent = 0,
+    pillBordered,
     showLabels,
     showValueLabel,
     size,
     steps,
     stepWidth,
     strokeColor,
-    strokeWidth = 6,
+    strokeWidth,
     trailColor = null as any,
     valueLabelRef,
     variant,
@@ -34,6 +39,18 @@ const Steps: FC<ProgressStepsProps> = (props) => {
     useRef<HTMLDivElement>(null);
   const progressBgRef: React.MutableRefObject<HTMLDivElement> =
     useRef<HTMLDivElement>(null);
+
+  const getStrokeHeight = (): number => {
+    let height: number = 6;
+    if (size === ProgressSize.Large) {
+      height = 12;
+    } else if (size === ProgressSize.Medium) {
+      height = 6;
+    } else if (size === ProgressSize.Small) {
+      height = 4;
+    }
+    return height;
+  };
 
   for (let i: number = 0; i < steps; ++i) {
     const color: string = Array.isArray(strokeColor)
@@ -58,7 +75,7 @@ const Steps: FC<ProgressStepsProps> = (props) => {
               : trailColor
             : 'transparent',
           width: stepWidth ? stepWidth : calculatedWidth,
-          height: size === 'small' ? 4 : strokeWidth,
+          height: strokeWidth || getStrokeHeight(),
         }}
       />
     );
@@ -147,6 +164,7 @@ const Steps: FC<ProgressStepsProps> = (props) => {
         className={mergeClasses([
           styles.progressStepsOuter,
           { [styles.progressStepsOuterPill]: variant === ProgressVariant.Pill },
+          { [styles.progressStepsOuterPillBordered]: !!pillBordered },
         ])}
       >
         {styledSteps}

--- a/src/components/Progress/Steps.tsx
+++ b/src/components/Progress/Steps.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { ProgressStepsProps } from './Progress.types';
+import { ProgressStepsProps, ProgressVariant } from './Progress.types';
 import { MAX_PERCENT } from './Internal/Common';
 import { ResizeObserver } from '../../shared/ResizeObserver/ResizeObserver';
 import { mergeClasses } from '../../shared/utilities';
@@ -25,6 +25,7 @@ const Steps: FC<ProgressStepsProps> = (props) => {
     strokeWidth = 6,
     trailColor = null as any,
     valueLabelRef,
+    variant,
   } = props;
   const [calculatedWidth, setCalculatedWidth] = useState<string>('0');
   const current: number = Math.round(steps * (percent / MAX_PERCENT));
@@ -141,7 +142,13 @@ const Steps: FC<ProgressStepsProps> = (props) => {
 
   return (
     <ResizeObserver onResize={updateLayout}>
-      <div ref={flexContainerRef} className={styles.progressStepsOuter}>
+      <div
+        ref={flexContainerRef}
+        className={mergeClasses([
+          styles.progressStepsOuter,
+          { [styles.progressStepsOuterPill]: variant === ProgressVariant.Pill },
+        ])}
+      >
         {styledSteps}
       </div>
       {children}

--- a/src/components/Progress/Styles/rtl.scss
+++ b/src/components/Progress/Styles/rtl.scss
@@ -37,6 +37,11 @@
       .progress-steps-item {
         margin-left: $space-xxs;
         margin-right: unset;
+
+        &:last-of-type {
+          margin-left: 0;
+          margin-right: unset;
+        }
       }
 
       .progress-text-wrapper {

--- a/src/components/Progress/Tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/Progress/Tests/__snapshots__/index.test.tsx.snap
@@ -769,6 +769,45 @@ exports[`Progress render trailColor progress 1`] = `
 </div>
 `;
 
+exports[`Progress should support pill variant 1`] = `
+<div
+  class="progress progress-line progress-status-normal"
+>
+  <div
+    class="progress-outer progress-outer-pill"
+  >
+    <div
+      class="progress-inner bordered"
+    >
+      <div
+        class="progress-bg"
+        style="width: 20%; height: 4px;"
+      />
+    </div>
+  </div>
+  <div
+    class="progress-text-wrapper"
+  >
+    <span
+      class="extremity-label min-label progress-text"
+    >
+      20%
+    </span>
+    <span
+      class="extremity-label max-label progress-text"
+    >
+      100%
+    </span>
+    <span
+      class="value-label progress-text"
+    />
+    <span
+      class="value-label progress-text"
+    />
+  </div>
+</div>
+`;
+
 exports[`Progress should support steps 1`] = `
 <div
   class="progress progress-steps progress-status-normal"
@@ -816,4 +855,55 @@ exports[`Progress steps should have default percent 0 1`] = `
 <div
   class="progress-steps-outer"
 />
+`;
+
+exports[`Progress steps should support pill variant 1`] = `
+<div
+  class="progress progress-steps progress-status-normal"
+>
+  <div
+    class="progress-steps-outer progress-steps-outer-pill"
+  >
+    <div
+      class="progress-steps-item bordered progress-steps-item-active"
+      style="width: 0px; height: 6px;"
+    />
+    <div
+      class="progress-steps-item bordered"
+      style="background: rgb(24, 144, 238); border-color: #1890ee; width: 0px; height: 6px;"
+    />
+    <div
+      class="progress-steps-item bordered"
+      style="background: rgb(24, 144, 238); border-color: #1890ee; width: 0px; height: 6px;"
+    />
+    <div
+      class="progress-steps-item bordered"
+      style="background: rgb(24, 144, 238); border-color: #1890ee; width: 0px; height: 6px;"
+    />
+    <div
+      class="progress-steps-item bordered"
+      style="background: rgb(24, 144, 238); border-color: #1890ee; width: 0px; height: 6px;"
+    />
+  </div>
+  <div
+    class="progress-text-wrapper"
+  >
+    <span
+      class="extremity-label min-label progress-text"
+    >
+      20%
+    </span>
+    <span
+      class="extremity-label max-label progress-text"
+    >
+      100%
+    </span>
+    <span
+      class="value-label progress-text"
+    />
+    <span
+      class="value-label progress-text"
+    />
+  </div>
+</div>
 `;

--- a/src/components/Progress/Tests/__snapshots__/index.test.tsx.snap
+++ b/src/components/Progress/Tests/__snapshots__/index.test.tsx.snap
@@ -180,11 +180,11 @@ exports[`Progress render format 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 50%; height: 4px;"
+        style="width: 50%; height: 6px;"
       />
       <div
         class="progress-success-bg"
-        style="width: 10%; height: 4px;"
+        style="width: 10%; height: 6px;"
       />
     </div>
   </div>
@@ -223,7 +223,7 @@ exports[`Progress render negative progress 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 0%; height: 4px;"
+        style="width: 0%; height: 6px;"
       />
     </div>
   </div>
@@ -262,11 +262,11 @@ exports[`Progress render negative successPercent 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 50%; height: 4px;"
+        style="width: 50%; height: 6px;"
       />
       <div
         class="progress-success-bg"
-        style="width: 0%; height: 4px;"
+        style="width: 0%; height: 6px;"
       />
     </div>
   </div>
@@ -305,7 +305,7 @@ exports[`Progress render normal progress 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 0%; height: 4px;"
+        style="width: 0%; height: 6px;"
       />
     </div>
   </div>
@@ -344,7 +344,7 @@ exports[`Progress render out-of-range progress 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 100%; height: 4px;"
+        style="width: 100%; height: 6px;"
       />
     </div>
   </div>
@@ -398,7 +398,7 @@ exports[`Progress render out-of-range progress with info 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 100%; height: 4px;"
+        style="width: 100%; height: 6px;"
       />
     </div>
   </div>
@@ -508,7 +508,7 @@ exports[`Progress render strokeColor 2`] = `
     >
       <div
         class="progress-bg"
-        style="width: 50%; height: 4px;"
+        style="width: 50%; height: 6px;"
       />
     </div>
   </div>
@@ -547,7 +547,7 @@ exports[`Progress render strokeColor 3`] = `
     >
       <div
         class="progress-bg"
-        style="width: 50%; height: 4px;"
+        style="width: 50%; height: 6px;"
       />
     </div>
   </div>
@@ -586,11 +586,11 @@ exports[`Progress render successColor progress 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 60%; height: 4px;"
+        style="width: 60%; height: 6px;"
       />
       <div
         class="progress-success-bg"
-        style="width: 30%; height: 4px; background: rgb(255, 255, 255);"
+        style="width: 30%; height: 6px; background: rgb(255, 255, 255);"
       />
     </div>
   </div>
@@ -742,7 +742,7 @@ exports[`Progress render trailColor progress 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 0%; height: 4px;"
+        style="width: 0%; height: 6px;"
       />
     </div>
   </div>
@@ -781,7 +781,7 @@ exports[`Progress should support pill variant 1`] = `
     >
       <div
         class="progress-bg"
-        style="width: 20%; height: 4px;"
+        style="width: 20%; height: 6px;"
       />
     </div>
   </div>

--- a/src/components/Progress/Tests/index.test.tsx
+++ b/src/components/Progress/Tests/index.test.tsx
@@ -4,6 +4,7 @@ import type { ProgressProps } from '..';
 import ProgressSteps from '../Steps';
 import { handleGradient, sortGradient } from '../Line';
 import { render } from '../../../tests/Utilities';
+import { ProgressVariant } from '../Progress.types';
 
 describe('Progress', () => {
   test('successPercent should decide the progress status when it exists', () => {
@@ -207,6 +208,16 @@ describe('Progress', () => {
     errorSpy.mockRestore();
   });
 
+  test('should support pill variant', () => {
+    const { container: wrapper } = render(
+      <Progress percent={20} variant={ProgressVariant.Pill} />
+    );
+    expect(
+      wrapper.querySelector<HTMLDivElement>('.progress-outer-pill')
+    ).toBeTruthy();
+    expect(wrapper.firstChild).toMatchSnapshot();
+  });
+
   test('should support steps', () => {
     const { container: wrapper } = render(<Progress steps={3} />);
     expect(wrapper.firstChild).toMatchSnapshot();
@@ -266,6 +277,21 @@ describe('Progress', () => {
       <Progress steps={5} percent={20} trailColor="#1890ee" bordered={false} />
     );
     expect(wrapper.querySelector<HTMLDivElement>('.bordered')).toBeFalsy();
+  });
+
+  test('steps should support pill variant', () => {
+    const { container: wrapper } = render(
+      <Progress
+        steps={5}
+        percent={20}
+        trailColor="#1890ee"
+        variant={ProgressVariant.Pill}
+      />
+    );
+    expect(
+      wrapper.querySelector<HTMLDivElement>('.progress-steps-outer-pill')
+    ).toBeTruthy();
+    expect(wrapper.firstChild).toMatchSnapshot();
   });
 
   test('should display correct step', () => {

--- a/src/components/Progress/progress.module.scss
+++ b/src/components/Progress/progress.module.scss
@@ -13,11 +13,6 @@
     margin-top: $space-xxs;
   }
 
-  &-outer {
-    display: inline-block;
-    width: 100%;
-  }
-
   &-inner {
     background: var(--progress-incomplete-background-color);
     border-radius: 100px;
@@ -30,6 +25,28 @@
 
     &.bordered {
       border-color: var(--progress-border-color);
+    }
+  }
+
+  &-outer {
+    display: inline-block;
+    width: 100%;
+
+    &-pill {
+      background: var(--progress-pill-background-color);
+      border-radius: $space-l;
+      line-height: $space-xxs;
+      padding: $space-xs;
+
+      .progress-inner {
+        background: var(--progress-pill-inner-background-color);
+        border-color: var(--progress-pill-inner-default-border-color);
+
+        &.bordered {
+          background: var(--progress-pill-inner-incomplete-background-color);
+          border-color: var(--progress-pill-inner-border-color);
+        }
+      }
     }
   }
 
@@ -111,21 +128,18 @@
   &-steps {
     display: inline-block;
 
-    &-outer {
-      align-items: center;
-      display: flex;
-      flex-direction: row;
-    }
-
     &-item {
       background: var(--progress-incomplete-background-color);
       border-radius: 100px;
       border: 1px solid transparent;
-      flex-shrink: 0;
       margin-bottom: $space-xxs;
       margin-right: $space-xxs;
       min-width: $space-xxxs;
       transition: background $motion-duration-extra-fast;
+
+      &:last-of-type {
+        margin-right: 0;
+      }
 
       &.bordered {
         border-color: var(--progress-border-color);
@@ -133,6 +147,38 @@
 
       &-active {
         background: var(--progress-complete-background-color);
+      }
+    }
+
+    &-outer {
+      align-items: center;
+      display: flex;
+      flex-direction: row;
+
+      &-pill {
+        background: var(--progress-pill-background-color);
+        border-radius: $space-l;
+        line-height: $space-xxs;
+        padding: $space-xs;
+
+        .progress-steps-item {
+          background: var(--progress-pill-inner-background-color);
+          border-color: var(--progress-pill-inner-default-border-color);
+          margin-bottom: 0;
+
+          &.bordered {
+            background: var(--progress-pill-inner-incomplete-background-color);
+            border-color: var(--progress-pill-inner-border-color);
+
+            &.progress-steps-item-active {
+              background: var(--progress-pill-inner-complete-background-color);
+            }
+          }
+
+          &-active {
+            background: var(--progress-pill-inner-complete-background-color);
+          }
+        }
       }
     }
 
@@ -174,6 +220,34 @@
       }
     }
 
+    .progress-outer {
+      &-pill {
+        background: var(--progress-pill-error-background-color);
+
+        .progress-inner {
+          border-color: var(--progress-pill-error-inner-default-border-color);
+
+          &.bordered {
+            border-color: var(--progress-pill-error-inner-border-color);
+          }
+        }
+      }
+    }
+
+    .progress-steps-outer {
+      &-pill {
+        background: var(--progress-pill-error-background-color);
+
+        .progress-inner {
+          border-color: var(--progress-pill-error-inner-default-border-color);
+
+          &.bordered {
+            border-color: var(--progress-pill-error-inner-border-color);
+          }
+        }
+      }
+    }
+
     &.progress-circle {
       .bordered {
         filter: drop-shadow(1px 0px 0px var(--progress-error-border-color))
@@ -203,6 +277,34 @@
     .progress-inner {
       &.bordered {
         border-color: var(--progress-success-border-color);
+      }
+    }
+
+    .progress-outer {
+      &-pill {
+        background: var(--progress-pill-success-background-color);
+
+        .progress-inner {
+          border-color: var(--progress-pill-success-inner-default-border-color);
+
+          &.bordered {
+            border-color: var(--progress-pill-success-inner-border-color);
+          }
+        }
+      }
+    }
+
+    .progress-steps-outer {
+      &-pill {
+        background: var(--progress-pill-success-background-color);
+
+        .progress-inner {
+          border-color: var(--progress-pill-success-inner-default-border-color);
+
+          &.bordered {
+            border-color: var(--progress-pill-success-inner-border-color);
+          }
+        }
       }
     }
 
@@ -258,6 +360,18 @@
   &-small {
     &.progress-line {
       font-size: 6px;
+    }
+
+    .progress-outer {
+      &.progress-outer-pill {
+        padding: 6px;
+      }
+    }
+
+    .progress-steps-outer {
+      .progress-steps-outer-pill {
+        padding: 6px;
+      }
     }
 
     .progress-icon {

--- a/src/components/Progress/progress.module.scss
+++ b/src/components/Progress/progress.module.scss
@@ -34,9 +34,14 @@
 
     &-pill {
       background: var(--progress-pill-background-color);
+      border: 1px solid transparent;
       border-radius: $space-l;
       line-height: $space-xxs;
       padding: $space-xs;
+
+      &-bordered {
+        border-color: var(--progress-pill-outer-border-color);
+      }
 
       .progress-inner {
         background: var(--progress-pill-inner-background-color);
@@ -157,9 +162,14 @@
 
       &-pill {
         background: var(--progress-pill-background-color);
+        border: 1px solid transparent;
         border-radius: $space-l;
         line-height: $space-xxs;
         padding: $space-xs;
+
+        &-bordered {
+          border-color: var(--progress-pill-outer-border-color);
+        }
 
         .progress-steps-item {
           background: var(--progress-pill-inner-background-color);
@@ -213,7 +223,7 @@
     }
 
     .progress-inner {
-      background: var(--disruptive-background1-color);
+      background: var(--progress-error-inner-background-color);
 
       &.bordered {
         border-color: var(--progress-error-border-color);
@@ -224,7 +234,12 @@
       &-pill {
         background: var(--progress-pill-error-background-color);
 
+        &-bordered {
+          border-color: var(--progress-pill-error-outer-border-color);
+        }
+
         .progress-inner {
+          background: var(--progress-pill-error-inner-background-color);
           border-color: var(--progress-pill-error-inner-default-border-color);
 
           &.bordered {
@@ -238,11 +253,20 @@
       &-pill {
         background: var(--progress-pill-error-background-color);
 
-        .progress-inner {
+        &-bordered {
+          border-color: var(--progress-pill-error-outer-border-color);
+        }
+
+        .progress-steps-item {
+          background: var(--progress-pill-error-inner-background-color);
           border-color: var(--progress-pill-error-inner-default-border-color);
 
           &.bordered {
             border-color: var(--progress-pill-error-inner-border-color);
+          }
+
+          &.progress-steps-item-active {
+            background: var(--progress-error-background-color);
           }
         }
       }
@@ -275,6 +299,8 @@
     }
 
     .progress-inner {
+      background: var(--progress-success-inner-background-color);
+
       &.bordered {
         border-color: var(--progress-success-border-color);
       }
@@ -284,7 +310,12 @@
       &-pill {
         background: var(--progress-pill-success-background-color);
 
+        &-bordered {
+          border-color: var(--progress-pill-success-outer-border-color);
+        }
+
         .progress-inner {
+          background: var(--progress-pill-success-inner-background-color);
           border-color: var(--progress-pill-success-inner-default-border-color);
 
           &.bordered {
@@ -298,11 +329,20 @@
       &-pill {
         background: var(--progress-pill-success-background-color);
 
-        .progress-inner {
+        &-bordered {
+          border-color: var(--progress-pill-success-outer-border-color);
+        }
+
+        .progress-steps-item {
+          background: var(--progress-pill-success-inner-background-color);
           border-color: var(--progress-pill-success-inner-default-border-color);
 
           &.bordered {
             border-color: var(--progress-pill-success-inner-border-color);
+          }
+
+          &.progress-steps-item-active {
+            background: var(--progress-success-background-color);
           }
         }
       }
@@ -369,7 +409,7 @@
     }
 
     .progress-steps-outer {
-      .progress-steps-outer-pill {
+      &.progress-steps-outer-pill {
         padding: 6px;
       }
     }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -1378,10 +1378,32 @@
   --progress-error-background-color: var(--error-color);
   --progress-error-border-color: var(--error-color);
   --progress-error-text-color: var(--error-color);
+  --progress-pill-error-background-color: var(--error-background-color);
+  --progress-pill-error-inner-default-border-color: var(
+    --error-background-color
+  );
+  --progress-pill-error-inner-border-color: var(--progress-error-border-color);
   --progress-incomplete-background-color: var(--accent-background1-color);
+  --progress-pill-background-color: var(--accent-background1-color);
+  --progress-pill-inner-complete-background-color: var(
+    --progress-complete-background-color
+  );
+  --progress-pill-inner-incomplete-background-color: var(
+    --progress-incomplete-background-color
+  );
+  --progress-pill-inner-background-color: var(--background-color);
+  --progress-pill-inner-default-border-color: var(--accent-background1-color);
+  --progress-pill-inner-border-color: var(--progress-border-color);
   --progress-success-background-color: var(--success-color);
   --progress-success-border-color: var(--success-color);
   --progress-success-text-color: var(--success-color);
+  --progress-pill-success-background-color: var(--success-background-color);
+  --progress-pill-success-inner-default-border-color: var(
+    --success-background-color
+  );
+  --progress-pill-success-inner-border-color: var(
+    --progress-success-border-color
+  );
   --progress-text-color: var(--text-primary-color);
   // ------ Progress theme ------
 }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -1376,15 +1376,21 @@
   --progress-border-color: var(--primary-tertiary-color);
   --progress-complete-background-color: var(--primary-tertiary-color);
   --progress-error-background-color: var(--error-color);
+  --progress-error-inner-background-color: var(--disruptive-background1-color);
   --progress-error-border-color: var(--error-color);
   --progress-error-text-color: var(--error-color);
   --progress-pill-error-background-color: var(--error-background-color);
+  --progress-pill-error-inner-background-color: var(
+    --disruptive-background1-color
+  );
   --progress-pill-error-inner-default-border-color: var(
     --error-background-color
   );
   --progress-pill-error-inner-border-color: var(--progress-error-border-color);
-  --progress-incomplete-background-color: var(--accent-background1-color);
-  --progress-pill-background-color: var(--accent-background1-color);
+  --progress-pill-error-outer-border-color: var(--progress-error-border-color);
+  --progress-incomplete-background-color: var(--primary-background1-color);
+  --progress-pill-background-color: var(--primary-background1-color);
+  --progress-pill-outer-border-color: var(--primary-tertiary-color);
   --progress-pill-inner-complete-background-color: var(
     --progress-complete-background-color
   );
@@ -1392,14 +1398,21 @@
     --progress-incomplete-background-color
   );
   --progress-pill-inner-background-color: var(--background-color);
-  --progress-pill-inner-default-border-color: var(--accent-background1-color);
+  --progress-pill-inner-default-border-color: var(--primary-background1-color);
   --progress-pill-inner-border-color: var(--progress-border-color);
   --progress-success-background-color: var(--success-color);
+  --progress-success-inner-background-color: var(--green-background1-color);
   --progress-success-border-color: var(--success-color);
   --progress-success-text-color: var(--success-color);
   --progress-pill-success-background-color: var(--success-background-color);
+  --progress-pill-success-inner-background-color: var(
+    --green-background1-color
+  );
   --progress-pill-success-inner-default-border-color: var(
     --success-background-color
+  );
+  --progress-pill-success-outer-border-color: var(
+    --progress-success-border-color
   );
   --progress-pill-success-inner-border-color: var(
     --progress-success-border-color


### PR DESCRIPTION
## SUMMARY:
- Adds `ProgressVariant` enum with `Default` and `Pill`
- Adds `variant` prop support for `Line` and `Step` `ProgressType`
- Adds `Large` `ProgressSize`
- Adds `pillBordered` prop to show/hide a border on the outer element
- Adds CSS Variables
- Adds Unit tests
- Updates colors to latest spec
- Updates Storybook with additional Pill variant stories


https://github.com/EightfoldAI/octuple/assets/99700808/c40af8d2-0d91-4dfa-a7fa-04b05d770738


## JIRA TASK (Eightfold Employees Only):
ENG-61012

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Progress` stories behave as expected.