### PR TITLE
chore: tooltip: moves internal class to the end of each clone element class array

### DIFF
--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Breadcrumb Crumb should support string \`0\` and number \`0\` 1`] = `
         >
           <a
             aria-disabled="false"
-            class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+            class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
             data-reference-id="tooltip--reference"
             id="tooltip--reference"
             role="link"
@@ -59,7 +59,7 @@ exports[`Breadcrumb Crumb should support string \`0\` and number \`0\` 1`] = `
         >
           <a
             aria-disabled="false"
-            class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+            class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
             data-reference-id="tooltip--reference"
             id="tooltip--reference"
             role="link"
@@ -175,7 +175,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
           >
             <span
               aria-current="location"
-              class="tooltip-reference breadcrumb-link my-breadcrumb-links-class breadcrumb-link-read-only"
+              class="breadcrumb-link my-breadcrumb-links-class breadcrumb-link-read-only tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
             >
@@ -211,7 +211,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           >
             <a
               aria-disabled="false"
-              class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+              class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
               role="link"
@@ -250,7 +250,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           >
             <a
               aria-disabled="false"
-              class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+              class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
               role="link"
@@ -289,7 +289,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           >
             <a
               aria-disabled="false"
-              class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+              class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
               role="link"
@@ -328,7 +328,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           >
             <a
               aria-disabled="false"
-              class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+              class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
               role="link"
@@ -367,7 +367,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           >
             <a
               aria-disabled="false"
-              class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+              class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
               role="link"
@@ -406,7 +406,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           >
             <a
               aria-disabled="false"
-              class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+              class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
               role="link"
@@ -445,7 +445,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           >
             <a
               aria-disabled="false"
-              class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+              class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
               role="link"
@@ -499,7 +499,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
         >
           <a
             aria-disabled="false"
-            class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+            class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
             data-custom="custom-item"
             data-reference-id="tooltip--reference"
             id="tooltip--reference"
@@ -538,7 +538,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
         >
           <a
             aria-disabled="false"
-            class="link-style full-width primary tooltip-reference breadcrumb-link my-breadcrumb-links-class"
+            class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
             data-reference-id="tooltip--reference"
             id="tooltip--reference"
             role="link"

--- a/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
@@ -25,7 +25,7 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "class": "tooltip-reference table-column-sorters",
+                      "class": "table-column-sorters tooltip-reference",
                       "data-reference-id": "sortTip-reference",
                       "id": "sortTip-reference",
                     },
@@ -3183,7 +3183,7 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "tooltip-reference table-column-sorters",
+                                              "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
                                             },
@@ -4335,7 +4335,7 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "tooltip-reference table-column-sorters",
+                                            "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "id": "sortTip-reference",
                                           },
@@ -6258,7 +6258,7 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "tooltip-reference table-column-sorters",
+                                              "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
                                             },
@@ -6847,7 +6847,7 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "tooltip-reference table-column-sorters",
+                                            "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "id": "sortTip-reference",
                                           },
@@ -7294,7 +7294,7 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "class": "tooltip-reference table-column-sorters",
+                                          "class": "table-column-sorters tooltip-reference",
                                           "data-reference-id": "sortTip-reference",
                                           "id": "sortTip-reference",
                                         },
@@ -7804,7 +7804,7 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "tooltip-reference table-column-sorters",
+                                            "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "id": "sortTip-reference",
                                           },
@@ -8687,7 +8687,7 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "tooltip-reference table-column-sorters",
+                                              "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
                                             },
@@ -9134,7 +9134,7 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "class": "tooltip-reference table-column-sorters",
+                                            "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "id": "sortTip-reference",
                                           },
@@ -9644,7 +9644,7 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "class": "tooltip-reference table-column-sorters",
+                                              "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
                                             },

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -342,9 +342,9 @@ export const Tooltip: FC<TooltipProps> = React.memo(
           // Need this to handle disabled elements of default Tooltip.
           if (type === TooltipType.Default) {
             const defaultReferenceClassNames: string = mergeClasses([
-              'tooltip-reference',
               { [node.props.className]: !!node.props.className },
               { [node.props.classNames]: !!node.props.classNames },
+              'tooltip-reference',
             ]);
 
             const clonedElementProps: RenderProps = {
@@ -379,12 +379,12 @@ export const Tooltip: FC<TooltipProps> = React.memo(
           // Utilize a similar element clone pattern as Dropdown
           // for more complex Popup elements.
           const popupReferenceClassNames: string = mergeClasses([
-            'tooltip-reference',
             { [styles.triggerAbove]: !!triggerAbove },
             // Add any classnames added to the reference element
             { [child.props.className]: !!child.props.className },
             { [child.props.classNames]: !!child.props.classNames },
             { [styles.disabled]: disabled },
+            'tooltip-reference',
           ]);
 
           const clonedElementProps: RenderProps = {


### PR DESCRIPTION
## SUMMARY:
The internal class being at the beginning of the array potentially causes test bugs in production, moving `tooltip-reference` to the end of each array should fix the test bugs.

Updates 2 snaps

## JIRA TASK (Eightfold Employees Only):
N/A

## CHANGE TYPE:

- [x] Bugfix Pull Request (deferred test bug in host app)
- [ ] Feature Pull Request

## TEST COVERAGE:
N/A

## TEST PLAN:
N/A