### PR TITLE
fix: button: fixes counter position when button only contains an icon

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -332,9 +332,20 @@ export const Button: FC<ButtonProps> = React.forwardRef(
               {getPrefixIcon()}
             </span>
           )}
-          {iconExists && !textExists && !prefixIconExists && getButtonIcon()}
-          {counterExists && !textExists && !loading && (
+          {iconExists &&
+            !textExists &&
+            !prefixIconExists &&
+            !counterExists &&
+            getButtonIcon()}
+          {counterExists && !textExists && !loading && !iconExists && (
             <Badge classNames={badgeClassNames}>{counter}</Badge>
+          )}
+          {iconExists && counterExists && !textExists && !loading && (
+            <span>
+              {getButtonIcon()}
+              <Badge classNames={badgeClassNames}>{counter}</Badge>
+              {prefixIconExists && getPrefixIcon()}
+            </span>
           )}
           {iconExists && textExists && (
             <span>


### PR DESCRIPTION
## SUMMARY:

Before:
![counterBroken](https://github.com/EightfoldAI/octuple/assets/99700808/6be2f6d5-0e39-4013-a724-afa354191f78)

After:
![counterFixed](https://github.com/EightfoldAI/octuple/assets/99700808/adc42113-f560-47a3-ab18-5a98adef0fab)

## JIRA TASK (Eightfold Employees Only):
ENG-65559

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Button` `Counter` story by removing the button text.