### PR TITLE
fix: link: align two hover colors with the latest design spec

### DIFF
--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -362,9 +362,9 @@
   --anchor-secondary-active-color: var(--grey-color-90);
   --anchor-hover-color: var(--primary-color-90);
   --anchor-disruptive-hover-color: var(--disruptive-secondary-color);
-  --anchor-neutral-hover-color: var(--primary-secondary-color);
+  --anchor-neutral-hover-color: var(--grey-secondary-color);
   --anchor-primary-hover-color: var(--primary-secondary-color);
-  --anchor-secondary-hover-color: var(--primary-secondary-color);
+  --anchor-secondary-hover-color: var(--grey-color-90);
   --anchor-visited-color: var(--violet-secondary-color);
   --anchor-disruptive-visited-color: var(--violet-secondary-color);
   --anchor-neutral-visited-color: var(--violet-secondary-color);


### PR DESCRIPTION
## SUMMARY:

- Updates `--anchor-neutral-hover-color` to `--grey-secondary-color`
- Updates `--anchor-secondary-hover-color` to `--grey-color-90`

## JIRA TASK (Eightfold Employees Only):
ENG-52998

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the above link colors.