### PR TITLE
fix: dropzone: ensures tab key event is not prevented

### DIFF
--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -22,7 +22,7 @@ import LocaleReceiver, {
 } from '../LocaleProvider/LocaleReceiver';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 import { useMergedState } from '../../hooks/useMergedState';
-import { mergeClasses, warning } from '../../shared/utilities';
+import { eventKeys, mergeClasses, warning } from '../../shared/utilities';
 import enUS from './Locale/en_US';
 
 import styles from './upload.module.scss';
@@ -554,7 +554,11 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (
         classNames={styles.uploadDropButton}
         disabled={mergedDisabled}
         htmlType={'button'}
-        onKeyDown={(event) => event.preventDefault()}
+        onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>) => {
+          if (event.key !== eventKeys.TAB) {
+            event.preventDefault();
+          }
+        }}
         text={maxCount === 1 ? selectFileText : selectMultipleFilesText}
       />
     );

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -555,7 +555,10 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (
         disabled={mergedDisabled}
         htmlType={'button'}
         onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>) => {
-          if (event.key !== eventKeys.TAB) {
+          if (
+            event?.key !== eventKeys.TAB ||
+            (event?.key !== eventKeys.TAB && !event?.shiftKey)
+          ) {
             event.preventDefault();
           }
         }}


### PR DESCRIPTION
## SUMMARY:
Compares for tab key on button keydown

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/725

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the Dropzone does not trap keyboard focus upon tabbing around.