### PR TITLE
fix: avatar: update background theme colors from tertiary to secondary

### DIFF
--- a/src/components/Avatar/Styles/group.scss
+++ b/src/components/Avatar/Styles/group.scss
@@ -40,7 +40,7 @@
   }
 
   &-max-count {
-    background-color: var(--grey-background2-color);
+    background: var(--grey-background2-color);
     color: var(--text-secondary-color);
   }
 }

--- a/src/components/Avatar/avatar.module.scss
+++ b/src/components/Avatar/avatar.module.scss
@@ -11,51 +11,51 @@
   justify-content: center;
 
   &.red {
-    background-color: var(--red-tertiary-color);
+    background: var(--red-secondary-color);
   }
 
   &.orange {
-    background-color: var(--orange-tertiary-color);
+    background: var(--orange-secondary-color);
   }
 
   &.red-orange {
-    background-color: var(--redorange-tertiary-color);
+    background: var(--redorange-secondary-color);
   }
 
   &.yellow {
-    background-color: var(--yellow-tertiary-color);
+    background: var(--yellow-secondary-color);
   }
 
   &.yellow-green {
-    background-color: var(--yellowgreen-tertiary-color);
+    background: var(--yellowgreen-secondary-color);
   }
 
   &.green {
-    background-color: var(--green-tertiary-color);
+    background: var(--green-secondary-color);
   }
 
   &.blue-green {
-    background-color: var(--bluegreen-tertiary-color);
+    background: var(--bluegreen-secondary-color);
   }
 
   &.blue {
-    background-color: var(--blue-tertiary-color);
+    background: var(--blue-secondary-color);
   }
 
   &.blue-violet {
-    background-color: var(--blueviolet-tertiary-color);
+    background: var(--blueviolet-secondary-color);
   }
 
   &.violet {
-    background-color: var(--violet-tertiary-color);
+    background: var(--violet-secondary-color);
   }
 
   &.violet-red {
-    background-color: var(--violetred-tertiary-color);
+    background: var(--violetred-secondary-color);
   }
 
   &.grey {
-    background-color: var(--grey-tertiary-color);
+    background: var(--grey-secondary-color);
   }
 }
 


### PR DESCRIPTION
## SUMMARY:

- Updates css selector property `background-color` to `background` to support more theme possibilities
- Updates theme color set from `tertiary` to `secondary` base palette to ensure 4:5:1 conformance

![avatarBgColor](https://github.com/EightfoldAI/octuple/assets/99700808/8a5a1e13-099b-4e41-96cb-f495cd386a17)

## JIRA TASK (Eightfold Employees Only):
ENG-63968

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (css only)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Avatar` and `AvatarGroup` stories behave as expected.