### PR TITLE
fix: inlinesvg: memoized fetch and compare with previous url

### DIFF
--- a/src/components/InlineSvg/InlineSvg.test.tsx
+++ b/src/components/InlineSvg/InlineSvg.test.tsx
@@ -39,4 +39,29 @@ describe('InlineSvg', () => {
       ).toBeInTheDocument();
     });
   });
+
+  test('Should call fetchSvg only once', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => '<svg>Mock SVG</svg>' })
+    ) as jest.Mock;
+    const { rerender } = render(<InlineSvg url="mock-url" />);
+    rerender(<InlineSvg url="mock-url" />);
+    rerender(<InlineSvg url="mock-url" />);
+    rerender(<InlineSvg url="mock-url" />);
+    rerender(<InlineSvg url="mock-url" />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should call fetchSvg twice', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => '<svg>Mock SVG</svg>' })
+    ) as jest.Mock;
+    const { rerender } = render(<InlineSvg url="mock-url" />);
+    rerender(<InlineSvg url="mock-url" />);
+    rerender(<InlineSvg url="mock-url-diff" />);
+    rerender(<InlineSvg url="mock-url-diff" />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## SUMMARY:
- memoizes `fetchSvg` with managed url
- Only execute fetchSvg if the current url is different than the previous url

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/711

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `InlineSVG` story behaves as expected.