### PR TITLE
fix: focustrap: improve reliability of use focus trap hook

### DIFF
--- a/src/shared/FocusTrap/hooks/useFocusTrap.test.tsx
+++ b/src/shared/FocusTrap/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { FocusTrap } from '../FocusTrap';
+
+describe('useFocusTrap', () => {
+  const FC = () => {
+    return (
+      <FocusTrap trap>
+        <>
+          <button className="button-1" id="button1">
+            Button 1
+          </button>
+          <button className="button-2" id="button2">
+            Button 2
+          </button>
+        </>
+      </FocusTrap>
+    );
+  };
+
+  test('handleFocus moves focus to the first focusable element when Tab is pressed', async () => {
+    const { container } = render(<FC />);
+    container.focus();
+    const firstButton = container.getElementsByClassName('button-1')[0];
+    await waitFor(() => expect(firstButton.matches(':focus')).toBe(true));
+    fireEvent.keyDown(container, { key: 'Tab' });
+    expect(firstButton.matches(':focus')).toBe(true);
+  });
+
+  test('handleFocus moves focus to the last focusable element when Shift + Tab is pressed', async () => {
+    const { container } = render(<FC />);
+    container.focus();
+    const firstButton = container.getElementsByClassName('button-1')[0];
+    await waitFor(() => expect(firstButton.matches(':focus')).toBe(true));
+    fireEvent.keyDown(container, { key: 'Tab' });
+    expect(firstButton.matches(':focus')).toBe(true);
+    fireEvent.keyDown(firstButton, { key: 'Tab', shiftKey: true });
+    const lastButton = container.getElementsByClassName('button-2')[0];
+    expect(lastButton.matches(':focus')).toBe(true);
+  });
+
+  test('setUpFocus sets up the initial focus', async () => {
+    const { container } = render(<FC />);
+    container.focus();
+    const firstButton = container.getElementsByClassName('button-1')[0];
+    await waitFor(() => expect(firstButton.matches(':focus')).toBe(true));
+    expect(firstButton.matches(':focus')).toBe(true);
+  });
+});


### PR DESCRIPTION
## SUMMARY:
- Move away from `setTimeout` to a commonly used `setInterval` with `clearInterval` with `useEffect` cleanup when the `activeElement` requirement is fulfilled pattern, this greatly improves the reliability because waiting for 100ms only and executing `focus()` once is not very robust in `async`
- Updates `isShiftPressed` to actually do its job
- Adds optional chaining
- Adds missing types
- Adds Unit Tests

## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/733

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Dialog`, `Modal` and `Panel` stories behave as expected using keyboard only. Be sure to visit the `ConfigProvider` `Theming` story first, tab around to active `focus-visible`