### PR TITLE
fix: tooltip: escape to dismiss default tooltip on hover only

### DIFF
--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -84,6 +84,39 @@ describe('Tooltip', () => {
     expect(container.querySelector('.tooltip')).toBeFalsy();
   });
 
+  test('Tooltip is dismissed on escape when hover only', async () => {
+    const { container } = render(
+      <Tooltip
+        content={<div data-testid="tooltip">This is a tooltip.</div>}
+        trigger="hover"
+      >
+        <div className="test-div">test</div>
+      </Tooltip>
+    );
+    fireEvent.mouseOver(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+    fireEvent.keyDown(container, { key: 'Escape' });
+    await waitForElementToBeRemoved(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeFalsy();
+  });
+
+  test('Tooltip is not dismissed on random key when hover only', async () => {
+    const { container } = render(
+      <Tooltip
+        content={<div data-testid="tooltip">This is a tooltip.</div>}
+        trigger="hover"
+      >
+        <div className="test-div">test</div>
+      </Tooltip>
+    );
+    fireEvent.mouseOver(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+    fireEvent.keyDown(container, { key: 'Enter' });
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+  });
+
   test('Tooltip reference element is clickable when Tooltip is disabled', () => {
     let testCounter = 0;
     const { container } = render(

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -179,6 +179,20 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         );
       }, [refs.reference, refs.floating, update]);
 
+      useEffect(() => {
+        const escapeTooltip = (event: KeyboardEvent): void => {
+          if (event?.key === eventKeys.ESCAPE) {
+            toggle(false)(event);
+          }
+        };
+        if (type === TooltipType.Default) {
+          document.addEventListener('keydown', escapeTooltip);
+        }
+        return () => {
+          document.removeEventListener('keydown', escapeTooltip);
+        };
+      }, [type]);
+
       useImperativeHandle(ref, () => ({
         update,
       }));


### PR DESCRIPTION
## SUMMARY:

- Adds event listener to trigger toggle upon escape keydown
- Adds unit tests


https://github.com/EightfoldAI/octuple/assets/99700808/0666a92f-3a74-47bc-a0f2-85d05aab34dd


## JIRA TASK (Eightfold Employees Only):
ENG-63973

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Tooltip` story behaves as expected.