### PR TITLE
feat: extend breadcrumb for custom divider and crumb

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -11,6 +11,7 @@ import {
   LinkButtonVariant,
   LinkButtonWidth,
 } from '../LinkButton';
+import { Avatar } from '../Avatar';
 
 export default {
   title: 'Breadcrumb',
@@ -80,6 +81,7 @@ export const No_Max = Breadcrumb_Story.bind({});
 export const Hide_Current = Breadcrumb_Story.bind({});
 export const With_Link_Tooltip = Breadcrumb_Story.bind({});
 export const With_Custom_Links = Breadcrumb_Story.bind({});
+export const With_Custom_Nodes = Breadcrumb_Story.bind({});
 
 const breadcrumbArgs: Object = {
   ariaLabel: 'Breadcrumbs',
@@ -288,6 +290,48 @@ With_Custom_Links.args = {
       readonly: true,
       title: 'Custom page 6',
       url: '#',
+    },
+  ],
+};
+
+With_Custom_Nodes.args = {
+  ...breadcrumbArgs,
+  links: [
+    {
+      customCrumb: (
+        <Avatar theme="green" type="round">
+          JD
+        </Avatar>
+      ),
+      tooltipprops: {
+        content: 'John Doe',
+      },
+      title: 'John Doe',
+      readonly: true,
+    },
+    {
+      customCrumb: (
+        <Avatar theme="blue" type="round">
+          AJ
+        </Avatar>
+      ),
+      tooltipprops: {
+        content: 'Adam John',
+      },
+      title: 'Adam John',
+      readonly: true,
+    },
+    {
+      customCrumb: (
+        <Avatar theme="red" type="round">
+          HG
+        </Avatar>
+      ),
+      tooltipprops: {
+        content: 'Hue Grant',
+      },
+      title: 'Hue Grant',
+      readonly: true,
     },
   ],
 };

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -33,7 +33,9 @@ export const Breadcrumb: FC<BreadcrumbProps> = React.forwardRef(
       ariaLabel: defaultAriaLabel,
       classNames,
       displayCurrent = true,
-      divider,
+      divider = {
+        path: IconName.mdiSlashForward,
+      },
       id,
       linkClassNames,
       links,
@@ -112,7 +114,7 @@ export const Breadcrumb: FC<BreadcrumbProps> = React.forwardRef(
 
     const getDivider = (item?: BreadcrumbLinkProps): JSX.Element => (
       <Icon
-        path={IconName.mdiSlashForward}
+        path={divider?.path}
         rotate={htmlDir === 'rtl' ? 180 : 0}
         size={IconSize.Small}
         {...item?.divider}
@@ -207,7 +209,7 @@ export const Breadcrumb: FC<BreadcrumbProps> = React.forwardRef(
                         item.classNames,
                       ])}
                     >
-                      {item.title}
+                      {item?.customCrumb ? item.customCrumb : item.title}
                     </span>
                   </Tooltip>
                   {idx < items.length - 1 && getDivider(item)}
@@ -238,7 +240,7 @@ export const Breadcrumb: FC<BreadcrumbProps> = React.forwardRef(
                           item.classNames,
                         ])}
                       >
-                        {item.title}
+                        {item?.customCrumb ? item.customCrumb : item.title}
                       </Link>
                     )}
                   </Tooltip>

--- a/src/components/Breadcrumb/Breadcrumb.types.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.types.tsx
@@ -43,6 +43,10 @@ export interface BreadcrumbLinkProps
    */
   dropdownChildren?: React.ReactNode;
   /**
+   * The Breadcrumb custom crumb.
+   */
+  customCrumb?: React.ReactNode;
+  /**
    * The Link is readonly (text)
    */
   readonly?: boolean;

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Breadcrumb Crumb should support string \`0\` and number \`0\` 1`] = `
             viewBox="0 0 24 24"
           >
             <path
-              d="M7 21L14.9 3H17L9.1 21H7Z"
+              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
               style="fill: currentColor;"
             />
           </svg>
@@ -119,7 +119,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -158,7 +158,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -233,7 +233,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -272,7 +272,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -311,7 +311,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -350,7 +350,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -389,7 +389,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -428,7 +428,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
               viewBox="0 0 24 24"
             >
               <path
-                d="M7 21L14.9 3H17L9.1 21H7Z"
+                d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
                 style="fill: currentColor;"
               />
             </svg>
@@ -521,7 +521,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
             viewBox="0 0 24 24"
           >
             <path
-              d="M7 21L14.9 3H17L9.1 21H7Z"
+              d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"
               style="fill: currentColor;"
             />
           </svg>


### PR DESCRIPTION
## SUMMARY:
- extend `Breadcrumb` to have custom divider and custom crumbs

## GITHUB ISSUE (Open Source Contributors)
N/A

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-68572

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run yarn and yarn storybook. Verify the Breadcrumb component has the following story:
<img width="1108" alt="image" src="https://github.com/EightfoldAI/octuple/assets/102243974/b3fa7272-802f-4182-9753-6a935ca9e447">