### PR TITLE
chore: skill: revert custom menu item and replace with scoped change

### DIFF
--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -248,17 +248,14 @@
   margin-bottom: $space-m;
 
   &.large {
-    margin-bottom: $space-l;
     padding: 0 $space-l;
   }
 
   &.medium {
-    margin-bottom: $space-m;
     padding: 0 $space-m;
   }
 
   &.small {
-    margin-bottom: $space-s;
     padding: 0 $space-s;
   }
 }

--- a/src/components/Skill/SkillBlock.tsx
+++ b/src/components/Skill/SkillBlock.tsx
@@ -383,7 +383,7 @@ export const SkillBlock: FC<SkillBlockProps> = React.forwardRef(
             classNames:
               idx === 0 && item.type === MenuItemType.custom
                 ? styles.customMenuTopInset
-                : null,
+                : styles.customMenuInset,
             size: MenuSize.small,
             value: `menu ${idx}`,
             ...item,
@@ -395,7 +395,7 @@ export const SkillBlock: FC<SkillBlockProps> = React.forwardRef(
           classNames:
             idx === 0 && item.type === MenuItemType.custom
               ? styles.customMenuTopInset
-              : null,
+              : styles.customMenuInset,
           size: MenuSize.small,
           value: `menu ${idx}`,
           ...item,

--- a/src/components/Skill/skill.module.scss
+++ b/src/components/Skill/skill.module.scss
@@ -1094,6 +1094,11 @@
 
 .custom-menu-top-inset {
   margin-top: $space-s;
+  margin-bottom: $space-s;
+}
+
+.custom-menu-inset {
+  margin-bottom: $space-s;
 }
 
 :global(.focus-visible) {


### PR DESCRIPTION
## SUMMARY:
Reverts global inset change to `menuItem.module.scss` and scopes inset to `skill.module.scss`.

## JIRA TASK (Eightfold Employees Only):
ENG-53012

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Menu` and `SkillBlock` stories behaves as expected.