### PR TITLE
fix: button: fixes round icon only secondary buttons padding to consider its border

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -604,16 +604,28 @@
   &.button-large {
     padding: calc($button-padding-vertical-large - 1px)
       $button-padding-horizontal-large;
+
+    &.round-shape {
+      padding: calc($button-padding-vertical-large - 1px);
+    }
   }
 
   &.button-medium {
     padding: calc($button-padding-vertical-medium - 1px)
       $button-padding-horizontal-medium;
+
+    &.round-shape {
+      padding: calc($button-padding-vertical-medium - 1px);
+    }
   }
 
   &.button-small {
     padding: calc($button-padding-vertical-small - 1px)
       $button-padding-horizontal-small;
+
+    &.round-shape {
+      padding: calc($button-padding-vertical-small - 1px);
+    }
   }
 }
 


### PR DESCRIPTION
## SUMMARY:
Prior to this change Icon-only `Button` of `variant` `ButtonVariant.Secondary`, with a `shape` of `ButtonShape.Round` were distorting by 1px in all sizes. This change updates this flavor of button so its perfectly round.

https://github.com/EightfoldAI/octuple/assets/99700808/46114994-e56c-4c03-92e0-f8cce6d1d45b

## JIRA TASK (Eightfold Employees Only):
ENG-69418

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (Storybook/Chromatic)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Button` `Secondary` story behaves as expected with only an icon and round shape in all sizes.