### PR TITLE
feat: tooltip: adds touch api support with hover a11y fixup

### DIFF
--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { ButtonSize, PrimaryButton } from '../Button';
+import { Button, ButtonSize, ButtonVariant } from '../Button';
 import { Icon, IconName, IconSize } from '../Icon';
 import { Link } from '../Link';
 import { Stack } from '../Stack';
-import { Popup, PopupTheme } from './';
+import { Popup, PopupTheme, PopupTouchInteraction } from './';
 
 export default {
   title: 'Popup',
@@ -80,12 +80,13 @@ const Popup_Story: ComponentStory<typeof Popup> = (args) => {
   const [visible, setVisibility] = useState(false);
   return (
     <Popup {...args} onVisibleChange={(isVisible) => setVisibility(isVisible)}>
-      <PrimaryButton
+      <Button
         onClick={() => {
           console.log('clicked');
         }}
         size={ButtonSize.Medium}
         text={visible ? 'Hide Popup' : 'Show Popup'}
+        variant={ButtonVariant.Primary}
       />
     </Popup>
   );
@@ -144,6 +145,7 @@ Popups.args = {
     </>
   ),
   placement: 'bottom-start',
+  disableContextMenu: false,
   disabled: false,
   visibleArrow: true,
   classNames: 'my-popup-class',
@@ -153,6 +155,7 @@ Popups.args = {
   tabIndex: 0,
   trigger: 'click',
   triggerAbove: false,
+  touchInteraction: PopupTouchInteraction.Tap,
   positionStrategy: 'absolute',
   portal: false,
   portalId: 'my-portal-id',

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -1,6 +1,18 @@
 import React, { FC } from 'react';
-import { PopupProps, PopupRef, PopupSize, PopupTheme } from './Popup.types';
-import { Tooltip, TooltipSize, TooltipTheme, TooltipType } from '../Tooltip';
+import {
+  PopupProps,
+  PopupRef,
+  PopupSize,
+  PopupTheme,
+  PopupTouchInteraction,
+} from './Popup.types';
+import {
+  Tooltip,
+  TooltipSize,
+  TooltipTheme,
+  TooltipType,
+  TooltipTouchInteraction,
+} from '../Tooltip';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 import { mergeClasses, uniqueId } from '../../shared/utilities';
 
@@ -24,6 +36,7 @@ export const Popup: FC<PopupProps> = React.forwardRef<PopupRef, PopupProps>(
       tabIndex = 0,
       theme = PopupTheme.light,
       trigger = 'click',
+      touchInteraction = PopupTouchInteraction.Tap,
       popupStyle,
       ...rest
     },
@@ -51,6 +64,14 @@ export const Popup: FC<PopupProps> = React.forwardRef<PopupRef, PopupProps>(
       [PopupTheme.light, TooltipTheme.light],
     ]);
 
+    const popupTouchToTooltipTouchMap = new Map<
+      PopupTouchInteraction,
+      TooltipTouchInteraction
+    >([
+      [PopupTouchInteraction.Tap, TooltipTouchInteraction.Tap],
+      [PopupTouchInteraction.TapAndHold, TooltipTouchInteraction.TapAndHold],
+    ]);
+
     return (
       <Tooltip
         {...rest}
@@ -71,6 +92,7 @@ export const Popup: FC<PopupProps> = React.forwardRef<PopupRef, PopupProps>(
         tooltipOnKeydown={popupOnKeydown}
         tooltipStyle={popupStyle}
         trigger={trigger}
+        touchInteraction={popupTouchToTooltipTouchMap.get(touchInteraction)}
         type={TooltipType.Popup}
       />
     );

--- a/src/components/Popup/Popup.types.ts
+++ b/src/components/Popup/Popup.types.ts
@@ -11,6 +11,11 @@ export enum PopupTheme {
   dark = 'dark',
 }
 
+export enum PopupTouchInteraction {
+  Tap = 'Tap',
+  TapAndHold = 'TapAndHold',
+}
+
 export interface PopupProps
   extends Omit<
     TooltipProps,
@@ -20,6 +25,7 @@ export interface PopupProps
     | 'theme'
     | 'tooltipOnKeydown'
     | 'tooltipStyle'
+    | 'touchInteraction'
     | 'type'
   > {
   /**
@@ -54,6 +60,12 @@ export interface PopupProps
    * @default light
    */
   theme?: PopupTheme;
+  /**
+   * Determines the interaction that triggers
+   * the equivalent of hover on touch interfaces.
+   * @default PopupTouchInteraction.Tap
+   */
+  touchInteraction?: PopupTouchInteraction;
 }
 
 export type PopupRef = {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { ButtonSize, PrimaryButton } from '../Button';
-import { Tooltip, TooltipTheme } from './';
+import { Button, ButtonSize, ButtonVariant } from '../Button';
+import { Tooltip, TooltipTheme, TooltipTouchInteraction } from './';
 
 export default {
   title: 'Tooltip',
@@ -135,6 +135,7 @@ Tooltips.args = {
   closeOnReferenceClick: true,
   closeOnTooltipClick: false,
   placement: 'bottom',
+  disableContextMenu: false,
   disabled: false,
   visibleArrow: true,
   animate: true,
@@ -146,18 +147,20 @@ Tooltips.args = {
   tabIndex: 0,
   trigger: 'hover',
   triggerAbove: false,
+  touchInteraction: TooltipTouchInteraction.TapAndHold,
   positionStrategy: 'absolute',
   portal: false,
   portalId: 'my-portal-id',
   portalRoot: null,
   children: (
-    <PrimaryButton
+    <Button
       ariaLabel="Show Tooltip"
-      size={ButtonSize.Medium}
-      text="Show Tooltip"
       onClick={() => {
         console.log('clicked');
       }}
+      size={ButtonSize.Medium}
+      text="Show Tooltip"
+      variant={ButtonVariant.Primary}
     />
   ),
   height: null,

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -3,7 +3,8 @@ import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import { Tooltip, TooltipSize } from './';
-import { PrimaryButton } from '../Button';
+import { Button, ButtonVariant } from '../Button';
+import useGestures, { Gestures } from '../../hooks/useGestures';
 import {
   fireEvent,
   getByTestId,
@@ -12,6 +13,8 @@ import {
   waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import '@testing-library/jest-dom/extend-expect';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -23,6 +26,8 @@ const mockNavigator = (agent: string): void => {
     return agent;
   });
 };
+
+jest.useFakeTimers();
 
 describe('Tooltip', () => {
   beforeAll(() => {
@@ -101,6 +106,25 @@ describe('Tooltip', () => {
     expect(container.querySelector('.tooltip')).toBeFalsy();
   });
 
+  test('Tooltip is dismissed on escape when move hover on tooltip element only', async () => {
+    const { container } = render(
+      <Tooltip
+        content={<div data-testid="tooltip">This is a tooltip.</div>}
+        trigger="hover"
+      >
+        <div className="test-div">test</div>
+      </Tooltip>
+    );
+    fireEvent.mouseOver(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+    fireEvent.mouseOver(container.querySelector('.tooltip'));
+    expect(container.querySelector('.tooltip')).toBeTruthy();
+    fireEvent.keyDown(container, { key: 'Escape' });
+    await waitForElementToBeRemoved(() => screen.getByTestId('tooltip'));
+    expect(container.querySelector('.tooltip')).toBeFalsy();
+  });
+
   test('Tooltip is not dismissed on random key when hover only', async () => {
     const { container } = render(
       <Tooltip
@@ -126,10 +150,11 @@ describe('Tooltip', () => {
         disabled
         trigger="hover"
       >
-        <PrimaryButton
+        <Button
           data-testid="test-button"
           onClick={() => (testCounter += 1)}
           text="Test button"
+          variant={ButtonVariant.Primary}
         />
       </Tooltip>
     );
@@ -339,30 +364,45 @@ describe('Tooltip', () => {
     expect(container.querySelector('.tooltip')).toBeFalsy();
   });
 
-  test('Tooltip uses mobile trigger, show, hide and show again', async () => {
+  test('Tooltip uses touch to show, hide and show again', async () => {
     mockNavigator(
       `Mozilla/5.0 (iPad; CPU OS 10_2_1 like Mac OS X)
       AppleWebKit/602.4.6 (KHTML, like Gecko)
       Version/10.0 Mobile/14D27 Safari/602.1`
     );
-
     const { container } = render(
       <Tooltip
         data-testid="tooltip-test"
         content={<div data-testid="tooltip">This is a tooltip.</div>}
       >
-        <div className="test-div">test</div>
+        <Button
+          data-testid="test-button"
+          text="Test button"
+          variant={ButtonVariant.Primary}
+        />
       </Tooltip>
     );
-    fireEvent.mouseOver(container.querySelector('.test-div'));
-    expect(container.querySelector('.tooltip')).toBeFalsy();
-    fireEvent.click(container.querySelector('.test-div'));
+    const swipeTarget = screen.getByTestId('test-button');
+    const { result } = renderHook(() => useGestures(window));
+    fireEvent.touchStart(swipeTarget);
+    jest.advanceTimersByTime(300);
+    fireEvent.touchEnd(swipeTarget);
+    fireEvent.click(swipeTarget);
+    expect(result.current).toBe(Gestures.TapAndHold);
     await waitFor(() => screen.getByTestId('tooltip'));
     expect(container.querySelector('.tooltip')).toBeTruthy();
-    fireEvent.click(container.querySelector('.test-div'));
+    fireEvent.touchStart(swipeTarget);
+    jest.advanceTimersByTime(50);
+    fireEvent.touchEnd(swipeTarget);
+    fireEvent.click(swipeTarget);
+    expect(result.current).toBe(Gestures.Tap);
     await waitForElementToBeRemoved(() => screen.getByTestId('tooltip'));
     expect(container.querySelector('.tooltip')).toBeFalsy();
-    fireEvent.click(container.querySelector('.test-div'));
+    fireEvent.touchStart(swipeTarget);
+    jest.advanceTimersByTime(300);
+    fireEvent.touchEnd(swipeTarget);
+    fireEvent.click(swipeTarget);
+    expect(result.current).toBe(Gestures.TapAndHold);
     await waitFor(() => screen.getByTestId('tooltip'));
     expect(container.querySelector('.tooltip')).toBeTruthy();
   });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -28,16 +28,15 @@ import {
   TOOLTIP_DEFAULT_OFFSET,
   TRIGGER_TO_HANDLER_MAP_ON_ENTER,
   TRIGGER_TO_HANDLER_MAP_ON_LEAVE,
+  TooltipTouchInteraction,
 } from './Tooltip.types';
+import useGestures, { Gestures } from '../../hooks/useGestures';
 import { useMergedState } from '../../hooks/useMergedState';
 import { useOnClickOutside } from '../../hooks/useOnClickOutside';
 import {
   cloneElement,
   ConditionalWrapper,
   eventKeys,
-  isAndroid,
-  isIOS,
-  isTouchSupported,
   mergeClasses,
   RenderProps,
   uniqueId,
@@ -57,6 +56,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         closeOnReferenceClick = true,
         closeOnTooltipClick = false,
         content,
+        disableContextMenu = false,
         disabled,
         dropShadow = true,
         height,
@@ -83,6 +83,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         tooltipStyle,
         trigger = 'hover',
         triggerAbove = false,
+        touchInteraction = TooltipTouchInteraction.TapAndHold,
         type = TooltipType.Default,
         visible,
         visibleArrow = true,
@@ -108,18 +109,6 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         `${tooltipId?.current}-reference`
       );
 
-      const isMobile: boolean = isIOS() || isAndroid();
-      let mergedTrigger: 'click' | 'hover' | 'contextmenu';
-
-      // First use the most reliable way of detecting iOS or Android,
-      // then test for touch interaction as a somewhat less reliable
-      // way to detect other hybrid devices.
-      if (isMobile || (!isMobile && isTouchSupported())) {
-        mergedTrigger = 'click';
-      } else {
-        mergedTrigger = trigger;
-      }
-
       let timeout: ReturnType<typeof setTimeout>;
       const {
         x,
@@ -144,6 +133,10 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         ],
       });
 
+      const gestureType: Gestures = useGestures(
+        refs.reference?.current as HTMLElement
+      );
+
       const toggle: Function =
         (show: boolean, showTooltip = (show: boolean) => show): Function =>
         (e: SyntheticEvent): void => {
@@ -152,8 +145,8 @@ export const Tooltip: FC<TooltipProps> = React.memo(
           }
           // to control the toggle behaviour
           const updatedShow: boolean = showTooltip(show);
-          if (PREVENT_DEFAULT_TRIGGERS.includes(mergedTrigger)) {
-            e.preventDefault();
+          if (PREVENT_DEFAULT_TRIGGERS.includes(trigger)) {
+            e?.preventDefault();
           }
           setHiding(!updatedShow);
           timeout && clearTimeout(timeout);
@@ -192,6 +185,24 @@ export const Tooltip: FC<TooltipProps> = React.memo(
           document.removeEventListener('keydown', escapeTooltip);
         };
       }, [type]);
+
+      useEffect(() => {
+        const referenceElement: HTMLElement = document.querySelector(
+          `.tooltip-reference[data-reference-id="${tooltipReferenceId?.current}"]`
+        );
+        if (disableContextMenu) {
+          referenceElement?.addEventListener('contextmenu', (e) =>
+            e?.preventDefault()
+          );
+        }
+        return () => {
+          if (disableContextMenu) {
+            referenceElement?.removeEventListener('contextmenu', (e) =>
+              e?.preventDefault()
+            );
+          }
+        };
+      }, [disableContextMenu]);
 
       useImperativeHandle(ref, () => ({
         update,
@@ -405,18 +416,32 @@ export const Tooltip: FC<TooltipProps> = React.memo(
 
           const clonedElementProps: RenderProps = {
             ...{
-              [TRIGGER_TO_HANDLER_MAP_ON_ENTER[mergedTrigger]]: toggle(true),
+              [TRIGGER_TO_HANDLER_MAP_ON_ENTER[trigger]]: toggle(!gestureType),
             },
             id: child.props?.id ? child.props?.id : tooltipReferenceId?.current,
             key: child.props?.key ? child.props?.key : tooltipId?.current,
-            onClick: (event: React.MouseEvent<Element, MouseEvent>) => {
-              child.props.onClick?.(event);
-              handleReferenceClick(event);
+            onClick: (event: React.MouseEvent<Element, MouseEvent>): void => {
+              if (!trigger.includes('hover')) {
+                child.props.onClick?.(event);
+                handleReferenceClick(event);
+              } else if (
+                trigger.includes('hover') &&
+                gestureType?.includes(touchInteraction)
+              ) {
+                event?.preventDefault();
+                handleReferenceClick(event);
+              }
             },
-            onKeyDown: (event: React.KeyboardEvent<Element>) => {
+            onKeyDown: (event: React.KeyboardEvent<Element>): void => {
               child.props.onKeyDown?.(event);
-              if (!isMobile && !isTouchSupported()) {
+              if (!gestureType) {
                 handleReferenceKeyDown(event);
+              }
+            },
+            onFocus: (event: React.FocusEvent<Element, FocusEvent>): void => {
+              child.props.onFocus?.(event);
+              if (trigger.includes('hover') && !mergedVisible && !gestureType) {
+                toggle(true, showTooltip)(event);
               }
             },
             'aria-controls': tooltipId?.current,
@@ -447,8 +472,25 @@ export const Tooltip: FC<TooltipProps> = React.memo(
             ])}
             id={tooltipReferenceId?.current}
             key={tooltipId?.current}
-            onClick={handleReferenceClick}
-            onKeyDown={handleReferenceKeyDown}
+            onClick={(
+              event: React.MouseEvent<HTMLDivElement, MouseEvent>
+            ): void => {
+              if (!trigger.includes('hover')) {
+                handleReferenceClick(event);
+              } else if (
+                trigger.includes('hover') &&
+                gestureType?.includes(touchInteraction)
+              ) {
+                event?.preventDefault();
+                handleReferenceClick(event);
+              }
+            }}
+            onKeyDown={!gestureType ? handleReferenceKeyDown : null}
+            onFocus={
+              trigger.includes('hover') && !mergedVisible && !gestureType
+                ? toggle(true, showTooltip)
+                : null
+            }
             role="button"
             tab-index={tabIndex}
           >
@@ -486,6 +528,29 @@ export const Tooltip: FC<TooltipProps> = React.memo(
               onKeyDown={
                 type === TooltipType.Popup ? handleFloatingKeyDown : null
               }
+              onMouseEnter={
+                trigger.includes('hover') && mergedVisible && !gestureType
+                  ? toggle(true, showTooltip)
+                  : null
+              }
+              onMouseLeave={(
+                event: React.MouseEvent<HTMLDivElement, MouseEvent>
+              ): void => {
+                const referenceElement: HTMLElement = document.querySelector(
+                  `.tooltip-reference[data-reference-id="${tooltipReferenceId?.current}"]`
+                );
+                if (
+                  trigger.includes('hover') &&
+                  mergedVisible &&
+                  !gestureType
+                ) {
+                  toggle(
+                    !event.currentTarget &&
+                      event.relatedTarget !== referenceElement,
+                    showTooltip
+                  )(event);
+                }
+              }}
               ref={floating}
               role="tooltip"
               style={tooltipStyles}
@@ -522,29 +587,44 @@ export const Tooltip: FC<TooltipProps> = React.memo(
             className={referenceWrapperClassNames}
             style={wrapperStyle}
             id={tooltipId?.current}
-            onClick={
-              !mergedTrigger.includes('hover') ? handleReferenceClick : null
-            }
-            onKeyDown={
-              !isMobile && !isTouchSupported() ? handleReferenceKeyDown : null
-            }
+            onClick={(
+              event: React.MouseEvent<HTMLDivElement, MouseEvent>
+            ): void => {
+              if (!trigger.includes('hover')) {
+                handleReferenceClick(event);
+              } else if (
+                trigger.includes('hover') &&
+                gestureType?.includes(touchInteraction)
+              ) {
+                event?.preventDefault();
+                handleReferenceClick(event);
+              }
+            }}
+            onKeyDown={!gestureType ? handleReferenceKeyDown : null}
             onMouseEnter={
-              mergedTrigger.includes('hover') && !mergedVisible
+              trigger.includes('hover') && !mergedVisible && !gestureType
                 ? toggle(true, showTooltip)
                 : null
             }
-            onMouseLeave={
-              mergedTrigger.includes('hover') && mergedVisible
-                ? toggle(false, showTooltip)
-                : null
-            }
+            onMouseLeave={(
+              event: React.MouseEvent<HTMLDivElement, MouseEvent>
+            ): void => {
+              const floatingElement: HTMLElement = refs.floating.current;
+              if (trigger.includes('hover') && mergedVisible && !gestureType) {
+                toggle(
+                  !event.currentTarget &&
+                    event.relatedTarget !== floatingElement,
+                  showTooltip
+                )(event);
+              }
+            }}
             onFocus={
-              mergedTrigger.includes('hover') && !mergedVisible
+              trigger.includes('hover') && !mergedVisible && !gestureType
                 ? toggle(true, showTooltip)
                 : null
             }
             onBlur={
-              mergedTrigger.includes('hover') && mergedVisible
+              trigger.includes('hover') && mergedVisible && !gestureType
                 ? toggle(false, showTooltip)
                 : null
             }
@@ -562,9 +642,9 @@ export const Tooltip: FC<TooltipProps> = React.memo(
           id={tooltipId?.current}
           style={wrapperStyle}
           ref={reference}
-          {...(TRIGGER_TO_HANDLER_MAP_ON_LEAVE[mergedTrigger]
+          {...(TRIGGER_TO_HANDLER_MAP_ON_LEAVE[trigger] && !gestureType
             ? {
-                [TRIGGER_TO_HANDLER_MAP_ON_LEAVE[mergedTrigger]]: toggle(
+                [TRIGGER_TO_HANDLER_MAP_ON_LEAVE[trigger]]: toggle(
                   false,
                   showTooltip
                 ),

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -34,6 +34,11 @@ export enum TooltipType {
   Popup = 'popup',
 }
 
+export enum TooltipTouchInteraction {
+  Tap = 'Tap',
+  TapAndHold = 'TapAndHold',
+}
+
 export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
   /**
    * Should animate the Tooltip transitions.
@@ -64,6 +69,12 @@ export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
    * Content to show in the Tooltip.
    */
   content: React.ReactNode;
+  /**
+   * Whether to disable the browser contextual menu on the reference element.
+   * Useful for some touch (`Gestures.TapAndHold`) implementations.
+   * @default false
+   */
+  disableContextMenu?: boolean;
   /**
    * Whether to disable the Tooltip.
    * @default false
@@ -193,6 +204,12 @@ export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
    * @default false
    */
   triggerAbove?: boolean;
+  /**
+   * Determines the interaction that triggers
+   * the equivalent of hover on touch interfaces.
+   * @default TooltipTouchInteraction.Tap
+   */
+  touchInteraction?: TooltipTouchInteraction;
   /**
    * The type of Tooltip
    * @default TooltipType.Default

--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -45,23 +45,24 @@ $tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
     box-shadow: $shadow-object-s;
   }
 
-  // When Popup, adds a pixel buffer equal to the width of the arrow to prevent
+  // Adds a pixel buffer equal to the width of the arrow to prevent
   // floating ui dismiss when hovering from reference to floating element.
   // Especially helpful when trigger is hover.
+  &.visible-arrow {
+    &:after {
+      bottom: -$space-xs;
+      content: '';
+      left: -$space-xs;
+      padding: $space-xs;
+      position: absolute;
+      right: -$space-xs;
+      top: -$space-xs;
+      z-index: -2; // Place below the arrow
+    }
+  }
+
   &.popup {
     cursor: default;
-    &.visible-arrow {
-      &:after {
-        bottom: -$space-xs;
-        content: '';
-        left: -$space-xs;
-        padding: $space-xs;
-        position: absolute;
-        right: -$space-xs;
-        top: -$space-xs;
-        z-index: -2; // Place below the arrow
-      }
-    }
   }
 
   // Hides the browser default keyboard focus-visible styles.

--- a/src/hooks/useGestures.test.tsx
+++ b/src/hooks/useGestures.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import MatchMediaMock from 'jest-matchmedia-mock';
+import '@testing-library/jest-dom/extend-expect';
+import useGestures, { Gestures } from './useGestures';
+import { fireEvent } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+let matchMedia: any;
+
+jest.useFakeTimers();
+
+describe('useGestures Hook', () => {
+  let swipeTarget: HTMLElement;
+
+  beforeAll(() => {
+    matchMedia = new MatchMediaMock();
+  });
+
+  beforeEach(() => {
+    swipeTarget = document.createElement('div');
+    document.body.appendChild(swipeTarget);
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+    document.body.removeChild(swipeTarget);
+  });
+
+  test('Detects SwipeDown gesture', () => {
+    const { result } = renderHook(() => useGestures(swipeTarget));
+
+    fireEvent.touchStart(swipeTarget, {
+      changedTouches: [{ screenX: 100, screenY: 100 }],
+    });
+    jest.advanceTimersByTime(500);
+    fireEvent.touchEnd(swipeTarget, {
+      changedTouches: [{ screenX: 100, screenY: 140 }],
+    });
+
+    expect(result.current).toBe(Gestures.SwipeDown);
+  });
+
+  test('Detects SwipeLeft gesture', () => {
+    const { result } = renderHook(() => useGestures(swipeTarget));
+
+    fireEvent.touchStart(swipeTarget, {
+      changedTouches: [{ screenX: 100, screenY: 100 }],
+    });
+    jest.advanceTimersByTime(500);
+    fireEvent.touchEnd(swipeTarget, {
+      changedTouches: [{ screenX: 60, screenY: 100 }],
+    });
+
+    expect(result.current).toBe(Gestures.SwipeLeft);
+  });
+
+  test('Detects SwipeRight gesture', () => {
+    const { result } = renderHook(() => useGestures(swipeTarget));
+
+    fireEvent.touchStart(swipeTarget, {
+      changedTouches: [{ screenX: 100, screenY: 100 }],
+    });
+    jest.advanceTimersByTime(500);
+    fireEvent.touchEnd(swipeTarget, {
+      changedTouches: [{ screenX: 140, screenY: 100 }],
+    });
+
+    expect(result.current).toBe(Gestures.SwipeRight);
+  });
+
+  test('Detects SwipeUp gesture', () => {
+    const { result } = renderHook(() => useGestures(swipeTarget));
+
+    fireEvent.touchStart(swipeTarget, {
+      changedTouches: [{ screenX: 100, screenY: 100 }],
+    });
+    jest.advanceTimersByTime(500);
+    fireEvent.touchEnd(swipeTarget, {
+      changedTouches: [{ screenX: 100, screenY: 60 }],
+    });
+
+    expect(result.current).toBe(Gestures.SwipeUp);
+  });
+
+  test('Detects Tap gesture', () => {
+    const { result } = renderHook(() => useGestures(swipeTarget));
+
+    fireEvent.touchStart(swipeTarget, {
+      touches: [{ screenX: 100, screenY: 100 }],
+    });
+    jest.advanceTimersByTime(50);
+    fireEvent.touchEnd(swipeTarget, {
+      touches: [{ screenX: 100, screenY: 100 }],
+    });
+
+    expect(result.current).toBe(Gestures.Tap);
+  });
+
+  test('Detects TapAndHold gesture', () => {
+    const { result } = renderHook(() => useGestures(swipeTarget));
+
+    fireEvent.touchStart(swipeTarget, {
+      touches: [{ screenX: 100, screenY: 100 }],
+    });
+    jest.advanceTimersByTime(300);
+    fireEvent.touchEnd(swipeTarget, {
+      touches: [{ screenX: 100, screenY: 100 }],
+    });
+
+    expect(result.current).toBe(Gestures.TapAndHold);
+  });
+});

--- a/src/hooks/useGestures.test.tsx
+++ b/src/hooks/useGestures.test.tsx
@@ -113,4 +113,19 @@ describe('useGestures Hook', () => {
 
     expect(result.current).toBe(Gestures.TapAndHold);
   });
+
+  test('onMouseMove sets the Gesture to null', () => {
+    const { result } = renderHook(() => useGestures(swipeTarget));
+
+    fireEvent.touchStart(swipeTarget, {
+      touches: [{ screenX: 100, screenY: 100 }],
+    });
+    jest.advanceTimersByTime(50);
+    fireEvent.touchEnd(swipeTarget, {
+      touches: [{ screenX: 100, screenY: 100 }],
+    });
+    expect(result.current).toBe(Gestures.Tap);
+    fireEvent.mouseMove(swipeTarget);
+    expect(result.current).toBe(null);
+  });
 });

--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -17,6 +17,14 @@ const useGestures = (
   const [touchStartY, setTouchStartY] = useState<number>(0);
   const [gestureType, setGestureType] = useState<Gestures | null>(null);
 
+  const onMouseMove = (): void => {
+    if (!swipeTarget) {
+      return;
+    }
+
+    setGestureType(null);
+  };
+
   const startTouchGesture = (e: any): void => {
     if (!swipeTarget) {
       return;
@@ -84,6 +92,10 @@ const useGestures = (
       capture: false,
       passive: false,
     });
+    swipeTarget?.addEventListener('mousemove', onMouseMove, {
+      capture: false,
+      passive: false,
+    });
   };
 
   const detachGestures = (): void => {
@@ -94,6 +106,7 @@ const useGestures = (
     swipeTarget?.removeEventListener('touchstart', startTouchGesture);
     swipeTarget?.removeEventListener('touchend', endTouchGesture);
     swipeTarget?.removeEventListener('touchmove', touchMoveGesture);
+    swipeTarget?.removeEventListener('mousemove', onMouseMove);
   };
 
   useEffect(() => {

--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+
+export enum Gestures {
+  SwipeUp = 'SwipeUp',
+  SwipeDown = 'SwipeDown',
+  SwipeLeft = 'SwipeLeft',
+  SwipeRight = 'SwipeRight',
+  Tap = 'Tap',
+  TapAndHold = 'TapAndHold',
+}
+
+const useGestures = (
+  swipeTarget: HTMLElement | Window | null
+): Gestures | null => {
+  const [startTime, setStartTime] = useState<number>(0);
+  const [touchStartX, setTouchStartX] = useState<number>(0);
+  const [touchStartY, setTouchStartY] = useState<number>(0);
+  const [gestureType, setGestureType] = useState<Gestures | null>(null);
+
+  const startTouchGesture = (e: any): void => {
+    if (!swipeTarget) {
+      return;
+    }
+
+    setStartTime(new Date().getTime());
+    setTouchStartX(e?.changedTouches[0]?.screenX);
+    setTouchStartY(e?.changedTouches[0]?.screenY);
+  };
+
+  const endTouchGesture = (e: any): void => {
+    if (!swipeTarget) {
+      return;
+    }
+
+    const currentTime: number = new Date().getTime();
+    const touchEndX: number = e?.changedTouches[0]?.screenX;
+    const touchEndY: number = e?.changedTouches[0]?.screenY;
+    const count: number = touchEndX - touchStartX;
+    const next: number = touchEndY - touchStartY;
+    const latch: number = Math.abs(count);
+    const timeout: number = Math.abs(next);
+
+    let gesture: Gestures;
+    let timer: number = 0;
+
+    timer = currentTime - startTime;
+
+    if (timer < 1000) {
+      if (latch >= 40 && timeout <= 40) {
+        gesture = count > 0 ? Gestures.SwipeRight : Gestures.SwipeLeft;
+        setGestureType(gesture);
+      } else if (timeout >= 40) {
+        gesture = next > 0 ? Gestures.SwipeDown : Gestures.SwipeUp;
+        setGestureType(gesture);
+      } else {
+        gesture = timer < 100 ? Gestures.Tap : Gestures.TapAndHold;
+        setGestureType(gesture);
+      }
+    }
+  };
+
+  const touchMoveGesture = (e: any): void => {
+    if (!swipeTarget) {
+      return;
+    }
+
+    e.preventDefault();
+  };
+
+  const attachGestures = (): void => {
+    if (!swipeTarget) {
+      return;
+    }
+
+    swipeTarget?.addEventListener('touchstart', startTouchGesture, {
+      capture: false,
+      passive: false,
+    });
+    swipeTarget?.addEventListener('touchend', endTouchGesture, {
+      capture: false,
+      passive: false,
+    });
+    swipeTarget?.addEventListener('touchmove', touchMoveGesture, {
+      capture: false,
+      passive: false,
+    });
+  };
+
+  const detachGestures = (): void => {
+    if (!swipeTarget) {
+      return;
+    }
+
+    swipeTarget?.removeEventListener('touchstart', startTouchGesture);
+    swipeTarget?.removeEventListener('touchend', endTouchGesture);
+    swipeTarget?.removeEventListener('touchmove', touchMoveGesture);
+  };
+
+  useEffect(() => {
+    attachGestures();
+
+    return () => {
+      detachGestures();
+    };
+  });
+
+  return gestureType;
+};
+
+export default useGestures;

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -200,7 +200,12 @@ import {
 
 import TimePicker from './components/DateTimePicker/TimePicker/TimePicker';
 
-import { Tooltip, TooltipTheme, TooltipSize } from './components/Tooltip';
+import {
+  Tooltip,
+  TooltipTheme,
+  TooltipSize,
+  TooltipTouchInteraction,
+} from './components/Tooltip';
 
 import { Loader, LoaderSize } from './components/Loader';
 
@@ -213,7 +218,12 @@ import {
   PanelHeader,
 } from './components/Panel';
 
-import { Popup, PopupSize, PopupTheme } from './components/Popup';
+import {
+  Popup,
+  PopupSize,
+  PopupTheme,
+  PopupTouchInteraction,
+} from './components/Popup';
 
 import { Portal } from './components/Portal';
 
@@ -367,6 +377,7 @@ export {
   Popup,
   PopupSize,
   PopupTheme,
+  PopupTouchInteraction,
   Portal,
   PrimaryButton,
   Progress,
@@ -438,6 +449,7 @@ export {
   Tooltip,
   TooltipTheme,
   TooltipSize,
+  TooltipTouchInteraction,
   TwoStateButton,
   Upload,
   UploadFile,

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -247,6 +247,8 @@ import { useBoolean } from './hooks/useBoolean';
 
 import { useCanvasDirection } from './hooks/useCanvasDirection';
 
+import useGestures, { Gestures } from './hooks/useGestures';
+
 import { Breakpoints, useMatchMedia } from './hooks/useMatchMedia';
 
 import { useOnClickOutside } from './hooks/useOnClickOutside';
@@ -307,6 +309,7 @@ export {
   FocusTrap,
   Form,
   FormInstance,
+  Gestures,
   Grid,
   Icon,
   IconName,
@@ -444,6 +447,7 @@ export {
   useBoolean,
   useCanvasDirection,
   useFocusTrap,
+  useGestures,
   useMatchMedia,
   useMaxVisibleSections,
   useOnClickOutside,


### PR DESCRIPTION
## SUMMARY:
Fixes `Popup` and `Tooltip` with a `trigger` of `hover` interaction on mobile and Hybrid devices. `Popup` defaults to `Tap`, `Tooltip` to `TapAndHold` when using a finger, hover when using mouse on hybrid. Also fixes some additional A11y bugs.

- Adds and exports `useGestures` Hook and its `Gestures` enum to include `SwipeDown`, `SwipeLeft`, `SwipeRight`, `SwipeUp`, `Tap`, and `TapAndHold`
- Adds `touchInteraction`, `disableContextMenu` props to `Tooltip` and `Popup`
- Adds `TooltipTouchInteraction`, and `PopupTouchInteraction` and exports them so the touch trigger may be determined at implementation time
- Updates `Tooltip` so that when its trigger is `hover` and a user is touching the `touchInteraction` will determine whether `Tap` or `TapAndHold` will toggle the `Tooltip` or `Popup`, when `disableContextMenu` is `true`, the browser `contextmenu` of the reference element will be handled if it's detrimental to the UX
- Fixes A11y bug where users could not hover over the Tooltip
- Fixes a usability keyboard navigation bug where if a `Popup` has a `trigger` of `hover`, keyboard focus on the reference element was not showing the `Popup`
- Adds `useGestures` hook UTs
- Adds `Tooltip` hover and touch UTs


https://github.com/EightfoldAI/octuple/assets/99700808/c00f9a0f-39e1-4ad6-8d86-d907d4f29e50


## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/652

## JIRA TASK (Eightfold Employees Only):
ENG-70944

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Popup` and `Tooltip` stories behave as expected.