### PR TITLE
chore: usegesture: avoid unnecessary mousemove events

### DIFF
--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export enum Gestures {
   SwipeUp = 'SwipeUp',
@@ -17,13 +17,13 @@ const useGestures = (
   const [touchStartY, setTouchStartY] = useState<number>(0);
   const [gestureType, setGestureType] = useState<Gestures | null>(null);
 
-  const onMouseMove = (): void => {
+  const onMouseMove = useCallback((): void => {
     if (!swipeTarget) {
       return;
     }
 
     setGestureType(null);
-  };
+  }, []);
 
   const startTouchGesture = (e: any): void => {
     if (!swipeTarget) {


### PR DESCRIPTION
## SUMMARY:
Wraps `onMouseMove` in `useCallback`

## JIRA TASK (Eightfold Employees Only):


## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the Popup and Tooltip behave as expected when sppofing mobile in Storybook. Verify PR build on hybrid device.