### PR TITLE
chore: usegestures: test for touch start positions in onmousemove

### DIFF
--- a/src/hooks/useGestures.test.tsx
+++ b/src/hooks/useGestures.test.tsx
@@ -5,7 +5,7 @@ import MatchMediaMock from 'jest-matchmedia-mock';
 import '@testing-library/jest-dom/extend-expect';
 import useGestures, { Gestures } from './useGestures';
 import { fireEvent } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -115,17 +115,31 @@ describe('useGestures Hook', () => {
   });
 
   test('onMouseMove sets the Gesture to null', () => {
+    jest.useFakeTimers();
     const { result } = renderHook(() => useGestures(swipeTarget));
-
-    fireEvent.touchStart(swipeTarget, {
-      touches: [{ screenX: 100, screenY: 100 }],
-    });
-    jest.advanceTimersByTime(50);
-    fireEvent.touchEnd(swipeTarget, {
-      touches: [{ screenX: 100, screenY: 100 }],
+    act(() => {
+      fireEvent.touchStart(swipeTarget, {
+        touches: [{ screenX: 100, screenY: 100 }],
+      });
+      jest.advanceTimersByTime(50);
+      fireEvent.touchEnd(swipeTarget, {
+        touches: [{ screenX: 100, screenY: 100 }],
+      });
     });
     expect(result.current).toBe(Gestures.Tap);
-    fireEvent.mouseMove(swipeTarget);
+    act(() => {
+      fireEvent.touchStart(swipeTarget, {
+        changedTouches: [{ screenX: 0, screenY: 0 }],
+      });
+    });
+    act(() => {
+      fireEvent.mouseMove(swipeTarget, { clientX: 100, clientY: 100 });
+      jest.advanceTimersByTime(50);
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
     expect(result.current).toBe(null);
+    jest.useRealTimers();
   });
 });

--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -14,11 +14,16 @@ const useGestures = (
   const touchStartXRef = useRef<number>(0);
   const touchStartYRef = useRef<number>(0);
   const [gestureType, setGestureType] = useState<Gestures | null>(null);
+  // For hybrid scenarios where a person uses both finger and mouse.
+  // Set gesture back to null upon mouse move.
   const onMouseMove = useCallback((): void => {
     if (!swipeTarget) {
       return;
     }
-    setGestureType(null);
+    // Check if touch start, if not then set gesture to null.
+    if (touchStartXRef?.current === 0 && touchStartYRef?.current === 0) {
+      setGestureType(null);
+    }
   }, [swipeTarget]);
   const startTouchGesture = useCallback(
     (e: any): void => {


### PR DESCRIPTION
## SUMMARY:
Test for touch start positions before setting gesture to null on mouse move.

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
ENG-70944

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Popup` and `Tooltip` stories behave as expected.