### PR TITLE
fix: tooltip: defer cursor style to implementation in host app

### DIFF
--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -1,7 +1,6 @@
 $tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
 
 .referenceWrapper {
-  cursor: pointer;
   display: inline-block;
 
   // Ensure portaled tooltip triggers are above when triggerAbove.
@@ -11,10 +10,6 @@ $tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
     &.tooltip {
       z-index: $z-index-400;
     }
-  }
-
-  &.disabled {
-    cursor: auto;
   }
 
   // Hides the browser default keyboard focus-visible styles.
@@ -59,10 +54,6 @@ $tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
       top: -$space-xs;
       z-index: -2; // Place below the arrow
     }
-  }
-
-  &.popup {
-    cursor: default;
   }
 
   // Hides the browser default keyboard focus-visible styles.


### PR DESCRIPTION
## SUMMARY:
Removes cursor styles from `Tooltip` and `Popup` such that they are deferred to implementation.

## JIRA TASK (Eightfold Employees Only):
ENG-71954

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (CSS only change)
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Popup` and `Tooltip` stories behave as expected.