### PR TITLE
chore: tooltip: removes no longer existing disabled class name references

### DIFF
--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Breadcrumb Crumb should support string \`0\` and number \`0\` 1`] = `
         class="stack horizontal undefined gap-xxxs"
       >
         <div
-          class="reference-wrapper disabled"
+          class="reference-wrapper"
           id="tooltip-"
         >
           <a
@@ -54,7 +54,7 @@ exports[`Breadcrumb Crumb should support string \`0\` and number \`0\` 1`] = `
         class="stack horizontal undefined gap-xxxs"
       >
         <div
-          class="reference-wrapper disabled"
+          class="reference-wrapper"
           id="tooltip-"
         >
           <a
@@ -92,7 +92,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -170,7 +170,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <span
@@ -206,7 +206,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -245,7 +245,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -284,7 +284,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -323,7 +323,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -362,7 +362,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -401,7 +401,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -440,7 +440,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
           class="stack horizontal undefined gap-xxxs"
         >
           <div
-            class="reference-wrapper disabled"
+            class="reference-wrapper"
             id="tooltip-"
           >
             <a
@@ -494,7 +494,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
         class="stack horizontal undefined gap-xxxs"
       >
         <div
-          class="reference-wrapper disabled"
+          class="reference-wrapper"
           id="tooltip-"
         >
           <a
@@ -533,7 +533,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
         class="stack horizontal undefined gap-xxxs"
       >
         <div
-          class="reference-wrapper disabled"
+          class="reference-wrapper"
           id="tooltip-"
         >
           <a

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -331,7 +331,6 @@ export const Tooltip: FC<TooltipProps> = React.memo(
       const referenceWrapperClassNames: string = mergeClasses([
         styles.referenceWrapper,
         wrapperClassNames,
-        { [styles.disabled]: disabled },
       ]);
 
       // Only use the `placement` type's `Side` property to determine `staticSide`.
@@ -380,15 +379,11 @@ export const Tooltip: FC<TooltipProps> = React.memo(
               'data-reference-id': tooltipReferenceId?.current,
             };
 
-            const defaultMergedClasses: string = node.props?.disabled
-              ? mergeClasses([defaultReferenceClassNames, styles.disabled])
-              : defaultReferenceClassNames;
-
             // Compares for octuple react prop vs native react html classes.
             if (node.props?.className) {
-              clonedElementProps['className'] = defaultMergedClasses;
+              clonedElementProps['className'] = defaultReferenceClassNames;
             } else if (child.props.classNames) {
-              clonedElementProps['classNames'] = defaultMergedClasses;
+              clonedElementProps['classNames'] = defaultReferenceClassNames;
             }
 
             return cloneElement(child, clonedElementProps);
@@ -410,7 +405,6 @@ export const Tooltip: FC<TooltipProps> = React.memo(
             // Add any classnames added to the reference element
             { [child.props.className]: !!child.props.className },
             { [child.props.classNames]: !!child.props.classNames },
-            { [styles.disabled]: disabled },
             'tooltip-reference',
           ]);
 
@@ -466,10 +460,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
             aria-controls={tooltipId?.current}
             aria-expanded={mergedVisible}
             aria-haspopup={true}
-            className={mergeClasses([
-              { [styles.triggerAbove]: !!triggerAbove },
-              { [styles.disabled]: disabled },
-            ])}
+            className={!!triggerAbove ? styles.triggerAbove : ''}
             id={tooltipReferenceId?.current}
             key={tooltipId?.current}
             onClick={(


### PR DESCRIPTION
## SUMMARY:
Removes missed class name references to `styles.disabled`, no longer needed and causes compiler errors with a clean build.

## JIRA TASK (Eightfold Employees Only):
ENG-71954

## CHANGE TYPE:
N/A

## TEST COVERAGE:
N/A

## TEST PLAN:
N/A