### PR TITLE
feat: carousel: exports autoscrollapi and updates story to include custom buttons example

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -74,7 +74,6 @@ export const Carousel: FC<CarouselProps> = React.forwardRef(
       pause = 'hover',
       previousIconButtonAriaLabel: defaultPreviousIconButtonAriaLabel,
       single = false,
-      style,
       transition = 'push',
       type = 'slide',
       'data-test-id': dataTestId,

--- a/src/components/Carousel/index.ts
+++ b/src/components/Carousel/index.ts
@@ -1,3 +1,4 @@
+export * from './autoScrollApi';
 export * from './Carousel.types';
 export * from './Carousel';
 export { Slide } from './Slide';

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -36,7 +36,13 @@ import {
 
 import { Card, CardSize, CardType } from './components/Card';
 
-import { Carousel, Slide, VisibilityContext } from './components/Carousel';
+import {
+  autoScrollApi,
+  autoScrollApiType,
+  Carousel,
+  Slide,
+  VisibilityContext,
+} from './components/Carousel';
 
 import {
   CheckBox,
@@ -271,6 +277,8 @@ export {
   Accordion,
   AccordionShape,
   AccordionSize,
+  autoScrollApi,
+  autoScrollApiType,
   AVATAR_THEME_SET,
   Avatar,
   AvatarGroup,


### PR DESCRIPTION
## SUMMARY:
- Adds `autoScrollApi` and `autoScrollApiType` to exports, improving advanced scenario support for `Carousel` `scroll` mode
- Updates existing `Carousel` `scroll` mode stories to use `Card` component at a size commonly used in Eightfold applications
- Adds story demonstrating custom next/previous button implementation using `autoScrollApi` and `autoScrollApiType`  in a constrained `Card` layout
- Removes unreferenced `style` prop from `Carousel`

https://github.com/EightfoldAI/octuple/assets/99700808/f86b2c55-df10-4765-a8b6-865066f727c5

## JIRA TASK (Eightfold Employees Only):
ENG-72093

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Carousel` stories behave as expected.

This [Codesandbox](https://codesandbox.io/p/sandbox/eager-haze-mg3t48?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clpkhkyn300063b6ibso7pvwq%2522%252C%2522sizes%2522%253A%255B74.21545667447307%252C25.784543325526926%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clpkhkyn300023b6iuz525hyt%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clpkhkyn300033b6i00gng0j4%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clpkhkyn300053b6i2f19t8yx%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clpkhkyn300023b6iuz525hyt%2522%253A%257B%2522id%2522%253A%2522clpkhkyn300023b6iuz525hyt%2522%252C%2522tabs%2522%253A%255B%255D%257D%252C%2522clpkhkyn300053b6i2f19t8yx%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clpkhkyn300043b6iyeslkq3m%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%2522%257D%255D%252C%2522id%2522%253A%2522clpkhkyn300053b6i2f19t8yx%2522%252C%2522activeTabId%2522%253A%2522clpkhkyn300043b6iyeslkq3m%2522%257D%252C%2522clpkhkyn300033b6i00gng0j4%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clpkhkyn300033b6i00gng0j4%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D) may also be used to test.