### PR TITLE
feat: a11y: arrow key navigation support for list menu dropdown and select

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import {
+  Button,
   ButtonIconAlign,
   ButtonTextAlign,
   ButtonWidth,
-  DefaultButton,
+  ButtonVariant,
   TwoStateButton,
 } from '../Button';
 import { CheckBox } from '../CheckBox';
@@ -113,12 +114,16 @@ const sampleList: User[] = [1, 2, 3, 4, 5].map((i) => ({
   icon: IconName.mdiAccount,
 }));
 
+const sampleAdditionalItem: User = {
+  name: 'Additional user profile',
+  icon: IconName.mdiAccount,
+};
+
 const Overlay = () => (
   <List<User>
     items={sampleList}
     renderItem={(item) => (
-      <DefaultButton
-        text={item.name}
+      <Button
         alignText={ButtonTextAlign.Left}
         buttonWidth={ButtonWidth.fill}
         iconProps={{
@@ -128,6 +133,46 @@ const Overlay = () => (
         style={{
           margin: '4px 0',
         }}
+        text={item.name}
+        variant={ButtonVariant.Default}
+      />
+    )}
+    role="menu"
+  />
+);
+
+const OverlayWithAdditionalListItem = () => (
+  <List<User>
+    additionalItem={sampleAdditionalItem}
+    items={sampleList}
+    renderItem={(item) => (
+      <Button
+        alignText={ButtonTextAlign.Left}
+        buttonWidth={ButtonWidth.fill}
+        iconProps={{
+          path: item.icon,
+        }}
+        role="menuitem"
+        style={{
+          margin: '4px 0',
+        }}
+        text={item.name}
+        variant={ButtonVariant.Default}
+      />
+    )}
+    renderAdditionalItem={(item) => (
+      <Button
+        alignText={ButtonTextAlign.Left}
+        buttonWidth={ButtonWidth.fill}
+        iconProps={{
+          path: item.icon,
+        }}
+        role="menuitem"
+        style={{
+          margin: '4px 0',
+        }}
+        text={item.name}
+        variant={ButtonVariant.Secondary}
       />
     )}
     role="menu"
@@ -141,14 +186,15 @@ const Dropdown_Button_Story: ComponentStory<typeof Dropdown> = (args) => {
       {...args}
       onVisibleChange={(isVisible) => setVisibility(isVisible)}
     >
-      <DefaultButton
+      <Button
         alignIcon={ButtonIconAlign.Right}
-        text={'Click button start'}
         iconProps={{
           path: IconName.mdiChevronDown,
           rotate: visible ? 180 : 0,
         }}
         id="octuple-dropdown-button-id"
+        text={'Click button start'}
+        variant={ButtonVariant.Default}
       />
     </Dropdown>
   );
@@ -161,7 +207,7 @@ const Dropdown_IconButton_Story: ComponentStory<typeof Dropdown> = (args) => {
       {...args}
       onVisibleChange={(isVisible) => setVisibility(isVisible)}
     >
-      <DefaultButton
+      <Button
         iconProps={{
           path: IconName.mdiAccount,
         }}
@@ -169,6 +215,7 @@ const Dropdown_IconButton_Story: ComponentStory<typeof Dropdown> = (args) => {
           path: IconName.mdiChevronDown,
           rotate: visible ? 180 : 0,
         }}
+        variant={ButtonVariant.Default}
       />
     </Dropdown>
   );
@@ -193,25 +240,27 @@ const Dropdown_External_Story: ComponentStory<typeof Dropdown> = (args) => {
   const [visible, setVisibility] = useState(false);
   return (
     <Stack direction="horizontal" flexGap="xxl">
-      <DefaultButton
+      <Button
         alignIcon={ButtonIconAlign.Right}
         checked={visible}
         onClick={() => setVisibility(!visible)}
         text={'External Control'}
         toggle
+        variant={ButtonVariant.Default}
       />
       <Dropdown
         {...args}
         visible={visible}
         onVisibleChange={(isVisible) => setVisibility(isVisible)}
       >
-        <DefaultButton
+        <Button
           alignIcon={ButtonIconAlign.Right}
           text={'Click button start'}
           iconProps={{
             path: IconName.mdiChevronDown,
             rotate: visible ? 180 : 0,
           }}
+          variant={ButtonVariant.Default}
         />
       </Dropdown>
     </Stack>
@@ -380,6 +429,7 @@ export const Dropdown_IconButton = Dropdown_IconButton_Story.bind({});
 export const Dropdown_Div = Dropdown_Div_Story.bind({});
 export const Dropdown_External = Dropdown_External_Story.bind({});
 export const Dropdown_Advanced_Visible_State = Dropdown_Advanced_Story.bind({});
+export const Dropdown_Additional_Item = Dropdown_Button_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
@@ -390,6 +440,7 @@ export const __namedExportsOrder = [
   'Dropdown_Div',
   'Dropdown_External',
   'Dropdown_Advanced_Visible_State',
+  'Dropdown_Additional_Item',
 ];
 
 const dropdownArgs: Object = {
@@ -398,6 +449,7 @@ const dropdownArgs: Object = {
   style: {},
   dropdownClassNames: 'my-dropdown-class',
   dropdownStyle: {},
+  initialFocus: true,
   placement: 'bottom-start',
   overlay: Overlay(),
   offset: 0,
@@ -425,4 +477,9 @@ Dropdown_External.args = {
 
 Dropdown_Advanced_Visible_State.args = {
   ...dropdownArgs,
+};
+
+Dropdown_Additional_Item.args = {
+  ...dropdownArgs,
+  overlay: OverlayWithAdditionalListItem(),
 };

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -4,10 +4,10 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import { Dropdown } from './';
 import {
+  Button,
   ButtonIconAlign,
   ButtonTextAlign,
   ButtonWidth,
-  DefaultButton,
 } from '../Button';
 import { Icon, IconName } from '../Icon';
 import { List } from '../List';
@@ -16,6 +16,7 @@ import { TextInput } from '../Inputs';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
+import '@testing-library/jest-dom';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -35,10 +36,11 @@ const Overlay = () => (
   <List<User>
     items={sampleList}
     renderItem={(item) => (
-      <DefaultButton
+      <Button
         text={item.name}
         alignText={ButtonTextAlign.Left}
         buttonWidth={ButtonWidth.fill}
+        data-testid={item.name}
         iconProps={{
           path: item.icon,
         }}
@@ -75,7 +77,7 @@ const DropdownComponent = (): JSX.Element => {
       {...dropdownProps}
       onVisibleChange={(isVisible) => setVisibility(isVisible)}
     >
-      <DefaultButton
+      <Button
         alignIcon={ButtonIconAlign.Right}
         text={'Dropdown menu test'}
         iconProps={{
@@ -124,7 +126,7 @@ const ExternalElementDropdownComponent = (): JSX.Element => {
 
   return (
     <Stack direction="horizontal" flexGap="xxl">
-      <DefaultButton
+      <Button
         alignIcon={ButtonIconAlign.Right}
         checked={visible}
         data-testid="test-external-button-id"
@@ -137,7 +139,7 @@ const ExternalElementDropdownComponent = (): JSX.Element => {
         visible={visible}
         onVisibleChange={(isVisible) => setVisibility(isVisible)}
       >
-        <DefaultButton
+        <Button
           alignIcon={ButtonIconAlign.Right}
           text={'Dropdown menu test'}
           iconProps={{
@@ -155,7 +157,7 @@ const filterOverlay1 = () => (
   <List<User>
     items={sampleList}
     renderItem={(item) => (
-      <DefaultButton
+      <Button
         text={'Filter 1' + ' ' + item.name}
         alignText={ButtonTextAlign.Left}
         buttonWidth={ButtonWidth.fill}
@@ -174,7 +176,7 @@ const filterOverlay2 = () => (
   <List<User>
     items={sampleList}
     renderItem={(item) => (
-      <DefaultButton
+      <Button
         text={'Filter 2' + ' ' + item.name}
         alignText={ButtonTextAlign.Left}
         buttonWidth={ButtonWidth.fill}
@@ -193,7 +195,7 @@ const filterOverlay3 = () => (
   <List<User>
     items={sampleList}
     renderItem={(item) => (
-      <DefaultButton
+      <Button
         text={'Filter 3' + ' ' + item.name}
         alignText={ButtonTextAlign.Left}
         buttonWidth={ButtonWidth.fill}
@@ -270,7 +272,7 @@ const AdvancedVisibilityToggleDropdownComponent = (): JSX.Element => {
         overlay={filterOverlay1()}
         visible={filterOneVisible}
       >
-        <DefaultButton
+        <Button
           alignIcon={ButtonIconAlign.Right}
           data-testid="test-button-one-id"
           text={'Filter one'}
@@ -293,7 +295,7 @@ const AdvancedVisibilityToggleDropdownComponent = (): JSX.Element => {
         overlay={filterOverlay2()}
         visible={filterTwoVisible}
       >
-        <DefaultButton
+        <Button
           alignIcon={ButtonIconAlign.Right}
           data-testid="test-button-two-id"
           text={'Filter two'}
@@ -316,7 +318,7 @@ const AdvancedVisibilityToggleDropdownComponent = (): JSX.Element => {
         overlay={filterOverlay3()}
         visible={filterThreeVisible}
       >
-        <DefaultButton
+        <Button
           alignIcon={ButtonIconAlign.Right}
           data-testid="test-button-three-id"
           text={filterThreeText}
@@ -514,9 +516,11 @@ describe('Dropdown', () => {
     act(() => {
       userEvent.click(referenceElement);
     });
-    await waitFor(() => screen.getByText('User profile 1'));
-    const elementToFocus = document.activeElement as HTMLElement;
-    expect(elementToFocus).toBeTruthy();
+    await waitFor(() => screen.getByTestId('User profile 1'));
+    await waitFor(() =>
+      expect(screen.getByTestId('User profile 1').matches(':focus')).toBe(true)
+    );
+    expect(screen.getByTestId('User profile 1').matches(':focus')).toBe(true);
   });
 
   test('Focuses the reference element when not visible', async () => {
@@ -537,7 +541,6 @@ describe('Dropdown', () => {
       expect(referenceElement.getAttribute('aria-expanded')).toBe('false')
     );
     expect(container.querySelector('.dropdown-wrapper')).toBeFalsy();
-    const elementToFocus = document.activeElement as HTMLElement;
-    expect(elementToFocus).toBeTruthy();
+    expect(referenceElement).toHaveFocus();
   });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -32,6 +32,7 @@ import { usePreviousState } from '../../hooks/usePreviousState';
 import {
   ConditionalWrapper,
   eventKeys,
+  focusable,
   mergeClasses,
   SELECTORS,
   uniqueId,
@@ -102,10 +103,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
             ...(refs.floating?.current.querySelectorAll(
               SELECTORS
             ) as unknown as HTMLElement[]),
-          ].filter(
-            (el: HTMLElement) =>
-              !el?.hasAttribute('disabled') && !el?.getAttribute('aria-hidden')
-          );
+          ].filter((el: HTMLElement) => focusable(el));
         };
         const focusableElements: HTMLElement[] = refs.floating?.current
           ? getFocusableElements?.()

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -60,7 +60,7 @@ export interface DropdownProps {
   /**
    * Optionally place focus on the first focusable
    * selector when the Dropdown is first visible.
-   * When false, visibility will be placed on the Dropdown.
+   * When false, visibility will remain on the Dropdown.
    * @default true
    */
   initialFocus?: boolean;

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -58,6 +58,13 @@ export interface DropdownProps {
    */
   height?: number;
   /**
+   * Optionally place focus on the first focusable
+   * selector when the Dropdown is first visible.
+   * When false, visibility will be placed on the Dropdown.
+   * @default true
+   */
+  initialFocus?: boolean;
+  /**
    * The offset from the reference element
    * @default 0
    */
@@ -97,6 +104,12 @@ export interface DropdownProps {
    * @returns (event: React.MouseEvent) => void
    */
   referenceOnClick?: (event: React.MouseEvent) => void;
+  /**
+   * Callback executed on reference element keydown.
+   * @param event
+   * @returns (event: React.KeyboardEvent) => void
+   */
+  referenceOnKeydown?: (event: React.KeyboardEvent) => void;
   /**
    * Custom reference wrapper class names
    */

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -155,6 +155,14 @@ export interface DropdownProps {
 
 export type DropdownRef = {
   /**
+   * Helper to manually place focus on the first focusable selector of the Dropdwon.
+   */
+  focusFirstElement: () => void;
+  /**
+   * Helper to manually place focus on a selector of the Dropdwon.
+   */
+  focusOnElement: (elementToFocus: HTMLElement) => void;
+  /**
    * Helper method to manually update the position
    * of the dropdown
    */

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Dropdown Should render a dropdown button 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       class="button button-default button-medium pill-shape icon-right"
+      data-testid="dropdown-reference"
       id="test-button-id"
       role="button"
       tabindex="0"

--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -144,4 +144,17 @@ describe('List', () => {
     fireEvent.keyDown(item2, { key: 'ArrowRight' });
     expect(item1).toHaveFocus();
   });
+
+  test('handleItemKeyDown should not update activeIndex if disableArrowKeys is true', () => {
+    const { getByTestId } = render(
+      <List {...listProps} disableArrowKeys layout="horizontal" />
+    );
+    const item1 = getByTestId('User1');
+    const item2 = getByTestId('User2');
+    item1.focus();
+    expect(item1).toHaveFocus();
+    fireEvent.keyDown(item1, { key: 'ArrowRight' });
+    expect(item2).not.toHaveFocus();
+    expect(item1).toHaveFocus();
+  });
 });

--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
+import { Link } from '../Link';
 import { List, ListProps } from './';
-import { render, queryByAttribute } from '@testing-library/react';
+import { fireEvent, render, queryByAttribute } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -11,15 +13,12 @@ let matchMedia: any;
 
 interface User {
   name: string;
-  summary: string;
-  img: string;
-  id?: number;
+  id?: string;
 }
 
 const sampleList: User[] = [1, 2, 3, 4, 5].map((i) => ({
   name: `User ${i}`,
-  summary: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
-  img: '',
+  id: `User${i}`,
 }));
 
 const listProps: ListProps<User> = {
@@ -31,10 +30,9 @@ const listProps: ListProps<User> = {
   ),
   layout: 'vertical',
   renderItem: (item: User) => (
-    <div id={`${item.id}`}>
-      <p>{item.name}</p>
-      <div>{item.summary}</div>
-    </div>
+    <Link href="#" id={`${item.id}`} data-testid={`${item.id}`}>
+      {item.name}
+    </Link>
   ),
   header: (
     <div style={{ paddingLeft: '16px' }}>
@@ -86,12 +84,64 @@ describe('List', () => {
 
   test('Should call rowKey function and return a Key', () => {
     const mockRowKey = jest.fn((item) => item.id);
-    const testItem: User = { id: 123, img: '', name: 'Test', summary: 'test' };
+    const testItem: User = { id: '123', name: 'Test' };
     const { container } = render(
       <List {...listProps} rowKey={mockRowKey} items={[testItem]} />
     );
     const getById = queryByAttribute.bind(null, 'id');
     expect(mockRowKey).toHaveBeenCalledWith(testItem);
     expect(getById(container, `${testItem.id}`)).toBeTruthy();
+  });
+
+  test('handleItemKeyDown should update activeIndex correctly for vertical layout', () => {
+    const { getByTestId } = render(<List {...listProps} layout="vertical" />);
+    const item1 = getByTestId('User1');
+    const item2 = getByTestId('User2');
+    const item3 = getByTestId('User3');
+    item1.focus();
+    expect(item1).toHaveFocus();
+    fireEvent.keyDown(item1, { key: 'ArrowDown' });
+    expect(item2).toHaveFocus();
+    fireEvent.keyDown(item2, { key: 'ArrowDown' });
+    expect(item3).toHaveFocus();
+    fireEvent.keyDown(item3, { key: 'ArrowUp' });
+    expect(item2).toHaveFocus();
+    fireEvent.keyDown(item2, { key: 'ArrowUp' });
+    expect(item1).toHaveFocus();
+  });
+
+  test('handleItemKeyDown should update activeIndex correctly for horizontal layout', () => {
+    const { getByTestId } = render(<List {...listProps} layout="horizontal" />);
+    const item1 = getByTestId('User1');
+    const item2 = getByTestId('User2');
+    const item3 = getByTestId('User3');
+    item1.focus();
+    expect(item1).toHaveFocus();
+    fireEvent.keyDown(item1, { key: 'ArrowRight' });
+    expect(item2).toHaveFocus();
+    fireEvent.keyDown(item2, { key: 'ArrowRight' });
+    expect(item3).toHaveFocus();
+    fireEvent.keyDown(item3, { key: 'ArrowLeft' });
+    expect(item2).toHaveFocus();
+    fireEvent.keyDown(item2, { key: 'ArrowLeft' });
+    expect(item1).toHaveFocus();
+  });
+
+  test('handleItemKeyDown should update activeIndex correctly for horizontal layout in rtl canvas', () => {
+    document.documentElement.dir = 'rtl';
+    const { getByTestId } = render(<List {...listProps} layout="horizontal" />);
+    const item1 = getByTestId('User1');
+    const item2 = getByTestId('User2');
+    const item3 = getByTestId('User3');
+    item1.focus();
+    expect(item1).toHaveFocus();
+    fireEvent.keyDown(item1, { key: 'ArrowLeft' });
+    expect(item2).toHaveFocus();
+    fireEvent.keyDown(item2, { key: 'ArrowLeft' });
+    expect(item3).toHaveFocus();
+    fireEvent.keyDown(item3, { key: 'ArrowRight' });
+    expect(item2).toHaveFocus();
+    fireEvent.keyDown(item2, { key: 'ArrowRight' });
+    expect(item1).toHaveFocus();
   });
 });

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,6 +1,14 @@
-import React, { Key } from 'react';
+import React, { Key, useEffect, useRef, useState } from 'react';
 import { ListProps } from './List.types';
-import { mergeClasses } from '../../shared/utilities';
+import { useCanvasDirection } from '../../hooks/useCanvasDirection';
+import {
+  cloneElement,
+  eventKeys,
+  focusable,
+  mergeClasses,
+  SELECTORS,
+  uniqueId,
+} from '../../shared/utilities';
 
 import styles from './list.module.scss';
 
@@ -24,11 +32,91 @@ export const List = <T extends any>({
   getItem,
   ...rest
 }: ListProps<T>) => {
+  const htmlDir: string = useCanvasDirection();
+
   const containerClasses: string = mergeClasses([
     styles.listContainer,
     listClassNames,
     { [styles.vertical]: layout === 'vertical' },
   ]);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const itemRefs: React.MutableRefObject<HTMLElement[]> = useRef<
+    (HTMLElement | null)[]
+  >([]);
+
+  // Update the active item when the items or activeIndex change.
+  useEffect(() => {
+    // Ensure the active item index is within bounds.
+    if (activeIndex !== null && items && activeIndex >= items.length) {
+      setActiveIndex(items.length - 1);
+    }
+  }, [activeIndex, items]);
+
+  const handleItemKeyDown = (
+    event: KeyboardEvent | React.KeyboardEvent<HTMLElement>,
+    index: number,
+    external: boolean = false
+  ): void => {
+    const arrowDown: boolean = event?.key === eventKeys.ARROWDOWN;
+    const arrowLeft: boolean = event?.key === eventKeys.ARROWLEFT;
+    const arrowRight: boolean = event?.key === eventKeys.ARROWRIGHT;
+    const arrowUp: boolean = event?.key === eventKeys.ARROWUP;
+    const arrowDecrement: boolean = htmlDir === 'rtl' ? arrowRight : arrowLeft;
+    const arrowIncrement: boolean = htmlDir === 'rtl' ? arrowLeft : arrowRight;
+    if (
+      ((arrowDown || arrowUp) && layout === 'vertical') ||
+      ((arrowDecrement || arrowIncrement) && layout === 'horizontal')
+    ) {
+      event?.preventDefault();
+      setActiveIndex(index);
+      if (itemRefs.current[index]) {
+        const getFocusableElements = (): HTMLElement[] => {
+          const step: number =
+            (arrowDown && layout === 'vertical') ||
+            (arrowIncrement && layout === 'horizontal')
+              ? 1
+              : -1;
+          let nextIndex: number = index + step;
+          const additionalItemIndex: number = items ? items.length : 0;
+          if (
+            (renderAdditionalItem &&
+              ((arrowDown && layout === 'vertical') ||
+                (arrowIncrement && layout === 'horizontal')) &&
+              nextIndex === additionalItemIndex) ||
+            (((arrowUp && layout === 'vertical') ||
+              (arrowDecrement && layout === 'horizontal')) &&
+              nextIndex === additionalItemIndex + 1)
+          ) {
+            return [
+              ...(itemRefs.current[additionalItemIndex]?.querySelectorAll(
+                SELECTORS
+              ) as unknown as HTMLElement[]),
+            ].filter((el: HTMLElement) => focusable(el));
+          }
+          while (
+            (nextIndex >= 0 && nextIndex <= additionalItemIndex) ||
+            (nextIndex > additionalItemIndex && nextIndex < items.length)
+          ) {
+            const nextItem: HTMLElement | null = itemRefs.current[nextIndex];
+            if (nextItem && focusable(nextItem)) {
+              const nextFocusableItem: HTMLElement | null = external
+                ? nextItem.parentElement
+                : nextItem;
+              return [
+                ...(nextFocusableItem.querySelectorAll(
+                  SELECTORS
+                ) as unknown as HTMLElement[]),
+              ].filter((el: HTMLElement) => focusable(el));
+            }
+            nextIndex += step;
+          }
+          return [];
+        };
+        const focusableElements: HTMLElement[] = getFocusableElements();
+        focusableElements?.[0]?.focus();
+      }
+    }
+  };
 
   const itemClasses: string = mergeClasses([styles.listItem, itemClassNames]);
 
@@ -36,16 +124,26 @@ export const List = <T extends any>({
 
   const getFooter = (): JSX.Element => <>{footer}</>;
 
-  const getAdditionalItem = (): JSX.Element => (
-    <li
-      {...itemProps}
-      key={getItemKey(additionalItem, (items?.length + 1) | 1)}
-      className={itemClasses}
-      style={itemStyle}
-    >
-      {renderAdditionalItem?.(additionalItem)}
-    </li>
-  );
+  const getAdditionalItem = (): JSX.Element => {
+    const additionalItemIndex: number = items ? items.length : 0;
+    const itemRef = (el: HTMLElement | null) => {
+      itemRefs.current[additionalItemIndex] = el;
+    };
+    return (
+      <li
+        {...itemProps}
+        key={getItemKey(additionalItem, additionalItemIndex)}
+        className={itemClasses}
+        onKeyDown={(event: React.KeyboardEvent<HTMLElement>) =>
+          handleItemKeyDown(event, additionalItemIndex)
+        }
+        ref={itemRef}
+        style={itemStyle}
+      >
+        {renderAdditionalItem?.(additionalItem)}
+      </li>
+    );
+  };
 
   const getItemKey = (item: T, index: number): Key => {
     if (typeof rowKey === 'function') {
@@ -56,21 +154,62 @@ export const List = <T extends any>({
     return `oc-list-item-${index}`;
   };
 
-  const _getItem = (item: T, index: number): JSX.Element => (
+  const _getItem = (
+    item: T,
+    index: number,
+    itemRef: (el: HTMLElement | null) => void
+  ): JSX.Element => (
     <li
       {...itemProps}
       key={getItemKey(item, index)}
       className={itemClasses}
+      onKeyDown={(event: React.KeyboardEvent<HTMLElement>) =>
+        handleItemKeyDown(event, index)
+      }
+      ref={itemRef}
       style={itemStyle}
     >
       {renderItem(item)}
     </li>
   );
 
+  const externalItem = (
+    node: React.ReactNode,
+    index: number,
+    itemRef: (el: HTMLElement | null) => void
+  ): JSX.Element => {
+    if (!node) {
+      return null;
+    }
+    const item = React.Children.only(node) as React.ReactElement<HTMLElement>;
+    const itemId: string = item.props.id
+      ? item.props.id
+      : uniqueId(`listItem${index}-`);
+    const referenceElement: HTMLElement | null =
+      document.getElementById(itemId);
+    itemRef(referenceElement);
+    itemRefs.current[index] = referenceElement;
+    return cloneElement(item, {
+      id: itemId,
+      ref: itemRef,
+      tabIndex: 0,
+      onKeyDown: (event: KeyboardEvent) => {
+        item.props.onkeydown?.(event);
+        handleItemKeyDown(event, index, true);
+      },
+    });
+  };
+
   const getItems = (): React.ReactNode[] =>
-    items.map(
-      (item: T, index) => getItem?.(item, index) ?? _getItem(item, index)
-    );
+    items.map((item: T, index) => {
+      const itemRef = (el: HTMLElement | null) => {
+        itemRefs.current[index] = el;
+      };
+      return (
+        externalItem?.(getItem?.(item, index), index, itemRef) ??
+        _getItem(item, index, itemRef)
+      );
+    });
 
   return (
     <div {...rest} className={classNames} style={style}>

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -40,18 +40,18 @@ export const List = <T extends any>({
     listClassNames,
     { [styles.vertical]: layout === 'vertical' },
   ]);
-  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [focusIndex, setFocusIndex] = useState<number | null>(null);
   const itemRefs: React.MutableRefObject<HTMLElement[]> = useRef<
     (HTMLElement | null)[]
   >([]);
 
-  // Update the active item when the items or activeIndex change.
+  // Update the focused item when the items or focusIndex change.
   useEffect(() => {
-    // Ensure the active item index is within bounds.
-    if (activeIndex !== null && items && activeIndex >= items.length) {
-      setActiveIndex(items.length - 1);
+    // Ensure the focused item index is within bounds.
+    if (focusIndex !== null && items && focusIndex >= items.length) {
+      setFocusIndex(items.length - 1);
     }
-  }, [activeIndex, items]);
+  }, [focusIndex, items]);
 
   const handleItemKeyDown = (
     event: KeyboardEvent | React.KeyboardEvent<HTMLElement>,
@@ -72,7 +72,7 @@ export const List = <T extends any>({
       ((arrowDecrement || arrowIncrement) && layout === 'horizontal')
     ) {
       event?.preventDefault();
-      setActiveIndex(index);
+      setFocusIndex(index);
       if (itemRefs.current[index]) {
         const getFocusableElements = (): HTMLElement[] => {
           const step: number =

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -14,6 +14,7 @@ import styles from './list.module.scss';
 
 export const List = <T extends any>({
   additionalItem,
+  disableArrowKeys = false,
   items,
   footer,
   layout = 'vertical',
@@ -57,6 +58,9 @@ export const List = <T extends any>({
     index: number,
     external: boolean = false
   ): void => {
+    if (disableArrowKeys) {
+      return;
+    }
     const arrowDown: boolean = event?.key === eventKeys.ARROWDOWN;
     const arrowLeft: boolean = event?.key === eventKeys.ARROWLEFT;
     const arrowRight: boolean = event?.key === eventKeys.ARROWRIGHT;

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -13,6 +13,11 @@ export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
    */
   additionalItem?: T;
   /**
+   * Optionally disable default arrow key handling.
+   * @default false
+   */
+  disableArrowKeys?: boolean;
+  /**
    * List footer renderer
    */
   footer?: ReactNode;

--- a/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/src/components/List/__snapshots__/List.test.tsx.snap
@@ -21,76 +21,86 @@ exports[`List List is horizontal 1`] = `
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User1"
+          href="#"
+          id="User1"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 1
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 1
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User2"
+          href="#"
+          id="User2"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 2
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 2
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User3"
+          href="#"
+          id="User3"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 3
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 3
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User4"
+          href="#"
+          id="User4"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 4
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 4
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User5"
+          href="#"
+          id="User5"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 5
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 5
+        </a>
       </li>
     </ul>
     <div
@@ -125,76 +135,86 @@ exports[`List Renders without crashing 1`] = `
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User1"
+          href="#"
+          id="User1"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 1
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 1
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User2"
+          href="#"
+          id="User2"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 2
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 2
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User3"
+          href="#"
+          id="User3"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 3
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 3
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User4"
+          href="#"
+          id="User4"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 4
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 4
+        </a>
       </li>
       <li
         class="list-item my-list-item-class"
         style="padding: 8px 16px;"
       >
-        <div
-          id="undefined"
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User5"
+          href="#"
+          id="User5"
+          role="link"
+          target="_self"
+          title="undefined"
         >
-          <p>
-            User 5
-          </p>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
-          </div>
-        </div>
+          User 5
+        </a>
       </li>
     </ul>
     <div

--- a/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/src/components/List/__snapshots__/List.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`List List is horizontal 1`] = `
           id="User1"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 1
         </a>
@@ -46,7 +45,6 @@ exports[`List List is horizontal 1`] = `
           id="User2"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 2
         </a>
@@ -63,7 +61,6 @@ exports[`List List is horizontal 1`] = `
           id="User3"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 3
         </a>
@@ -80,7 +77,6 @@ exports[`List List is horizontal 1`] = `
           id="User4"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 4
         </a>
@@ -97,7 +93,6 @@ exports[`List List is horizontal 1`] = `
           id="User5"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 5
         </a>
@@ -143,7 +138,6 @@ exports[`List Renders without crashing 1`] = `
           id="User1"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 1
         </a>
@@ -160,7 +154,6 @@ exports[`List Renders without crashing 1`] = `
           id="User2"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 2
         </a>
@@ -177,7 +170,6 @@ exports[`List Renders without crashing 1`] = `
           id="User3"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 3
         </a>
@@ -194,7 +186,6 @@ exports[`List Renders without crashing 1`] = `
           id="User4"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 4
         </a>
@@ -211,7 +202,6 @@ exports[`List Renders without crashing 1`] = `
           id="User5"
           role="link"
           target="_self"
-          title="undefined"
         >
           User 5
         </a>

--- a/src/components/Menu/CascadingMenu.test.tsx
+++ b/src/components/Menu/CascadingMenu.test.tsx
@@ -5,9 +5,10 @@ import MatchMediaMock from 'jest-matchmedia-mock';
 import { MenuItemIconAlign, MenuItemType } from './MenuItem/MenuItem.types';
 import { MenuVariant } from './Menu.types';
 import { CascadingMenu } from './CascadingMenu';
-import { DefaultButton } from '../Button';
+import { Button } from '../Button';
 import { IconName } from '../Icon';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -35,6 +36,7 @@ const cascadingMenuItems = [
     text: 'Button',
     value: 'menu 1',
     counter: '8',
+    'data-testid': 'firstMenuElement',
     secondaryButtonProps: {
       iconProps: {
         path: IconName.mdiTrashCan,
@@ -124,7 +126,7 @@ const menuProps: Object = {
 
 const CascadingMenuComponent = (): JSX.Element => (
   <CascadingMenu {...menuProps} items={cascadingMenuItems}>
-    <DefaultButton text={'Cascading menu'} />
+    <Button data-testid="menu-reference" text={'Cascading menu'} />
   </CascadingMenu>
 );
 
@@ -197,5 +199,71 @@ describe('Menu', () => {
     expect(menuitem1).toBeTruthy();
     expect(menuitem2).toBeTruthy();
     expect(menuitem3).toBeTruthy();
+  });
+
+  test('Calls the referenceOnClick function when a key is pressed', () => {
+    const referenceOnClick = jest.fn();
+    const { getByTestId } = render(
+      <CascadingMenu
+        {...menuProps}
+        items={cascadingMenuItems}
+        referenceOnClick={referenceOnClick}
+      >
+        <Button data-testid="menu-reference" text={'Cascading menu'} />
+      </CascadingMenu>
+    );
+    const referenceElement = getByTestId('menu-reference');
+    fireEvent.click(referenceElement);
+    expect(referenceOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('Calls the referenceOnKeydown function when a key is pressed', () => {
+    const referenceOnKeydown = jest.fn();
+    const { getByTestId } = render(
+      <CascadingMenu
+        {...menuProps}
+        items={cascadingMenuItems}
+        referenceOnKeydown={referenceOnKeydown}
+      >
+        <Button data-testid="menu-reference" text={'Cascading menu'} />
+      </CascadingMenu>
+    );
+    const referenceElement = getByTestId('menu-reference');
+    fireEvent.keyDown(referenceElement, { key: 'ArrowDown' });
+    expect(referenceOnKeydown).toHaveBeenCalledTimes(1);
+  });
+
+  test('Arrow down key opens the menu and places focus on the first item', async () => {
+    render(<CascadingMenuComponent />);
+    const referenceButton = screen.getByTestId('menu-reference');
+    referenceButton.focus();
+    fireEvent.keyDown(referenceButton, { key: 'ArrowDown' });
+    const firstMenuItem = screen.getByTestId('firstMenuElement');
+    await waitFor(() => expect(firstMenuItem).toBeInTheDocument());
+    expect(firstMenuItem).toHaveFocus();
+  });
+
+  test('Arrow up key closes the menu and places focus back on the reference element', async () => {
+    render(<CascadingMenuComponent />);
+    const referenceButton = screen.getByTestId('menu-reference');
+    fireEvent.keyDown(referenceButton, { key: 'ArrowDown' });
+    const menu = screen.getAllByRole('menu')[0];
+    expect(menu).toBeInTheDocument();
+    referenceButton.focus();
+    fireEvent.keyDown(referenceButton, { key: 'ArrowUp' });
+    await waitFor(() => expect(menu).not.toBeInTheDocument());
+    expect(referenceButton).toHaveFocus();
+  });
+
+  test('Escape key closes the menu and places focus back on the reference element', async () => {
+    render(<CascadingMenuComponent />);
+    const referenceButton = screen.getByTestId('menu-reference');
+    fireEvent.keyDown(referenceButton, { key: 'ArrowDown' });
+    const menu = screen.getAllByRole('menu')[0];
+    expect(menu).toBeInTheDocument();
+    const firstMenuItem = screen.getByText('Button');
+    fireEvent.keyDown(firstMenuItem, { key: 'Escape' });
+    await waitFor(() => expect(menu).not.toBeInTheDocument());
+    expect(referenceButton).toHaveFocus();
   });
 });

--- a/src/components/Menu/CascadingMenu.tsx
+++ b/src/components/Menu/CascadingMenu.tsx
@@ -3,6 +3,7 @@ import React, {
   FC,
   forwardRef,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -26,17 +27,18 @@ import {
   useFloatingTree,
   useHover,
   useInteractions,
+  useListNavigation,
   useMergeRefs,
   useRole,
 } from '@floating-ui/react';
 import { DropdownMenuProps, MenuItemTypes, MenuSize } from './Menu.types';
 import { MenuItemType } from './MenuItem/MenuItem.types';
 import { MenuItem } from './MenuItem/MenuItem';
-import { ButtonSize, NeutralButton, PrimaryButton } from '../Button';
+import { Button, ButtonSize, ButtonVariant } from '../Button';
 import { List } from '../List';
 import { Stack } from '../Stack';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
-import { mergeClasses } from '../../shared/utilities';
+import { eventKeys, mergeClasses, RenderProps } from '../../shared/utilities';
 
 import dropdownStyles from '../Dropdown/dropdown.module.scss';
 import menuStyles from './menu.module.scss';
@@ -71,6 +73,16 @@ export const MenuComponent: FC<DropdownMenuProps> = forwardRef<
     whileElementsMounted: autoUpdate,
   });
 
+  const listRef: React.MutableRefObject<any[]> = useRef([]);
+
+  const listNavigation: ElementProps = useListNavigation(context, {
+    listRef,
+    activeIndex: activeIndex,
+    nested: isNested,
+    onNavigate: setActiveIndex,
+    scrollItemIntoView: true,
+  });
+
   const hover: ElementProps = useHover<ReferenceType>(context, {
     enabled: isNested && allowHover,
     delay: { open: 75 },
@@ -92,13 +104,12 @@ export const MenuComponent: FC<DropdownMenuProps> = forwardRef<
 
   const dismiss: ElementProps = useDismiss<ReferenceType>(context);
 
-  // TODO: ENG-46500 Implement `listNavigation` and `typeahead` in `useInteractions` via
-  // `useListNavigation` and `useTypeahead` floating-ui helpers.
-  // Need to figure out how to `useRef` `MenuItemType` to get each ref `HTMLElement`.
-  // See floatging-ui API reference implementation at:
+  // TODO: ENG-46500 Implement `typeahead` in `useInteractions` via
+  // `useTypeahead` floating-ui helper.
+  // See floating-ui API reference implementation at:
   // https://codesandbox.io/s/bold-panna-9tf226?file=/src/DropdownMenu.tsx
   const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions(
-    [hover, click, role, dismiss]
+    [hover, click, role, dismiss, listNavigation]
   );
 
   // Event emitter allows you to communicate across tree components.
@@ -167,24 +178,80 @@ export const MenuComponent: FC<DropdownMenuProps> = forwardRef<
   const reference: (instance: ReferenceType) => void =
     useMergeRefs<ReferenceType>([refs.setReference, ref]);
 
-  const getReference = (): React.ReactElement => {
-    const child = React.Children.only(children) as React.ReactElement<any>;
-    const referenceClassNames: string = mergeClasses([
-      // Add any classnames added to the reference element
-      { [child.props.className]: child.props.className },
-    ]);
+  const handleReferenceKeyDown = (event: React.KeyboardEvent): void => {
+    event?.stopPropagation();
+    if (props.disabled) {
+      return;
+    }
+    if (!isNested) {
+      props.referenceOnKeydown?.(event);
+    }
+    if (
+      event?.key === eventKeys.ARROWDOWN &&
+      document.activeElement === event.target &&
+      !isNested &&
+      !isOpen
+    ) {
+      event?.preventDefault();
+      setIsOpen(true);
+    }
+    if (
+      event?.key === eventKeys.ARROWUP &&
+      document.activeElement === event.target &&
+      !isNested &&
+      isOpen
+    ) {
+      event?.preventDefault();
+      setIsOpen(false);
+    }
+    if (
+      event?.key === eventKeys.ESCAPE ||
+      (event?.key === eventKeys.TAB &&
+        event.shiftKey &&
+        !(event.target as HTMLElement).matches(':focus-within'))
+    ) {
+      setIsOpen(false);
+    }
+  };
 
-    return cloneElement(child, {
-      ref: reference,
-      role: 'button',
-      'data-open': isOpen ? '' : undefined,
-      ...getReferenceProps({
-        className: referenceClassNames,
-        onClick(event) {
-          event.stopPropagation();
-        },
-      }),
-    });
+  const getReference = (): JSX.Element | React.ReactNode => {
+    if (React.isValidElement(children)) {
+      const child = React.Children.only(children) as React.ReactElement<any>;
+      const referenceClassNames: string = mergeClasses([
+        // Add any classnames added to the reference element
+        { [child.props.className]: !!child.props.className },
+        { [child.props.classNames]: !!child.props.classNames },
+      ]);
+
+      const clonedElementProps: RenderProps = {
+        ref: reference,
+        role: 'button',
+        'data-open': isOpen ? '' : undefined,
+        ...getReferenceProps({
+          className: referenceClassNames,
+          onClick(event) {
+            event.stopPropagation();
+            if (!isNested) {
+              props.referenceOnClick?.(event);
+            }
+          },
+          onKeyDown: handleReferenceKeyDown,
+          ...(isNested && {
+            role: 'menuitem',
+          }),
+        }),
+      };
+
+      // Compares for octuple react prop vs native react html classes.
+      if (child.props?.className) {
+        clonedElementProps['className'] = referenceClassNames;
+      } else if (child.props.classNames) {
+        clonedElementProps['classNames'] = referenceClassNames;
+      }
+
+      return cloneElement(child, clonedElementProps);
+    }
+    return children;
   };
 
   const footerClassNames: string = mergeClasses([
@@ -240,6 +307,9 @@ export const MenuComponent: FC<DropdownMenuProps> = forwardRef<
           setActiveIndex(index);
         }
       }}
+      ref={(item: HTMLElement) => {
+        listRef.current[index] = item;
+      }}
       size={props.size}
       tabIndex={activeIndex === index && 0}
       type={item.type ?? MenuItemType.button}
@@ -265,14 +335,16 @@ export const MenuComponent: FC<DropdownMenuProps> = forwardRef<
         classNames={footerClassNames}
       >
         {props.cancelButtonProps && (
-          <NeutralButton
+          <Button
+            variant={ButtonVariant.Neutral}
             {...props.cancelButtonProps}
             size={menuSizeToButtonSizeMap.get(props.size)}
             onClick={props.onCancel}
           />
         )}
         {props.okButtonProps && (
-          <PrimaryButton
+          <Button
+            variant={ButtonVariant.Primary}
             {...props.okButtonProps}
             size={menuSizeToButtonSizeMap.get(props.size)}
             onClick={props.onOk}
@@ -290,8 +362,7 @@ export const MenuComponent: FC<DropdownMenuProps> = forwardRef<
             context={context}
             // Prevent outside content interference.
             modal={false}
-            // Only initially focus the root floating menu.
-            initialFocus={isNested ? -1 : 0}
+            initialFocus={0}
             // Only return focus to the root menu's reference when menus close.
             returnFocus={!isNested}
           >

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -9,7 +9,7 @@ import {
   MenuVariant,
 } from './';
 import { Dropdown } from '../Dropdown';
-import { DefaultButton } from '../Button';
+import { Button } from '../Button';
 import { RadioGroup } from '../RadioButton';
 import { IconName } from '../Icon';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
@@ -204,8 +204,9 @@ const SubHeaderOverlay = (args: any) => {
         },
         {
           type: MenuItemType.custom,
-          render: ({ onChange }) => (
+          render: ({ onChange, ...rest }) => (
             <RadioGroup
+              {...rest}
               {...{
                 ariaLabel: 'Radio Group',
                 value: 'Radio1',
@@ -244,26 +245,31 @@ const SubHeaderOverlay = (args: any) => {
 };
 
 const Basic_Menu_Story: ComponentStory<typeof Menu> = (args) => (
-  <Dropdown overlay={BasicOverlay(args)}>
-    <DefaultButton text={'Menu dropdown'} />
+  <Dropdown initialFocus overlay={BasicOverlay(args)}>
+    <Button text={'Menu dropdown'} />
   </Dropdown>
 );
 
 const Menu_Story: ComponentStory<typeof Menu> = (args) => (
-  <Dropdown overlay={LinkOverlay(args)}>
-    <DefaultButton text={'Menu dropdown'} />
+  <Dropdown initialFocus overlay={LinkOverlay(args)}>
+    <Button text={'Menu dropdown'} />
   </Dropdown>
 );
 
 const Menu_Header_Story: ComponentStory<typeof Menu> = (args) => (
-  <Dropdown overlay={BasicOverlay(args)}>
-    <DefaultButton text={'Menu dropdown'} />
+  <Dropdown initialFocus overlay={BasicOverlay(args)}>
+    <Button text={'Menu dropdown'} />
   </Dropdown>
 );
 
 const Menu_Sub_Header_Story: ComponentStory<typeof Menu> = (args) => (
-  <Dropdown overlay={SubHeaderOverlay(args)}>
-    <DefaultButton text={'Menu dropdown'} />
+  // When hosting selectors, do not close dropdown on click :)
+  <Dropdown
+    closeOnDropdownClick={false}
+    initialFocus
+    overlay={SubHeaderOverlay(args)}
+  >
+    <Button text={'Menu dropdown'} />
   </Dropdown>
 );
 
@@ -340,8 +346,9 @@ const Cascading_Menu_Story: ComponentStory<typeof Menu> = (args) => {
                 },
                 {
                   type: MenuItemType.custom,
-                  render: ({ onChange }) => (
+                  render: ({ onChange, ...rest }) => (
                     <RadioGroup
+                      {...rest}
                       {...{
                         ariaLabel: 'Radio Group',
                         value: 'Radio1',
@@ -414,7 +421,7 @@ const Cascading_Menu_Story: ComponentStory<typeof Menu> = (args) => {
         console.log(item);
       }}
     >
-      <DefaultButton text={'Cascading menu'} />
+      <Button text={'Cascading menu'} />
     </CascadingMenu>
   );
 };

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -6,7 +6,7 @@ import { MenuItemType } from './MenuItem/MenuItem.types';
 import { MenuSize, MenuVariant } from './Menu.types';
 import { Menu } from './Menu';
 import { Dropdown } from '../Dropdown';
-import { DefaultButton } from '../Button';
+import { Button } from '../Button';
 import { IconName } from '../Icon';
 import { RadioGroup } from '../RadioButton';
 import { SelectorSize } from '../CheckBox';
@@ -52,8 +52,9 @@ const MenuOverlay = (args: any) => {
         },
         {
           type: MenuItemType.custom,
-          render: ({ onChange }) => (
+          render: ({ onChange, ...rest }) => (
             <RadioGroup
+              {...rest}
               {...{
                 ariaLabel: 'Radio Group',
                 value: 'Radio1',
@@ -92,7 +93,7 @@ const menuProps: object = {
 const MenuComponent = (): JSX.Element => {
   return (
     <Dropdown overlay={MenuOverlay(menuProps)}>
-      <DefaultButton text={'Menu dropdown'} />
+      <Button text={'Menu dropdown'} />
     </Dropdown>
   );
 };
@@ -105,7 +106,7 @@ const LargeMenuComponent = (): JSX.Element => {
 
   return (
     <Dropdown overlay={MenuOverlay(_menuProps)}>
-      <DefaultButton text={'Menu dropdown'} />
+      <Button text={'Menu dropdown'} />
     </Dropdown>
   );
 };
@@ -118,7 +119,7 @@ const MediumMenuComponent = (): JSX.Element => {
 
   return (
     <Dropdown overlay={MenuOverlay(_menuProps)}>
-      <DefaultButton text={'Menu dropdown'} />
+      <Button text={'Menu dropdown'} />
     </Dropdown>
   );
 };
@@ -131,7 +132,7 @@ const SmallMenuComponent = (): JSX.Element => {
 
   return (
     <Dropdown overlay={MenuOverlay(_menuProps)}>
-      <DefaultButton text={'Menu dropdown'} />
+      <Button text={'Menu dropdown'} />
     </Dropdown>
   );
 };

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -4,7 +4,7 @@ import { List } from '../List';
 import { MenuItem } from './MenuItem/MenuItem';
 import { MenuItemType } from './MenuItem/MenuItem.types';
 import { Stack } from '../Stack';
-import { ButtonSize, NeutralButton, PrimaryButton } from '../Button';
+import { Button, ButtonSize, ButtonVariant } from '../Button';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 import { mergeClasses } from '../../shared/utilities';
 
@@ -26,7 +26,7 @@ export const Menu: FC<MenuProps> = ({
   role = 'menu',
   size = MenuSize.medium,
   style,
-  subHeader,
+  subHeader, // TODO: Remove in v3.0.0
   variant = MenuVariant.neutral,
   ...rest
 }) => {
@@ -99,14 +99,16 @@ export const Menu: FC<MenuProps> = ({
         classNames={footerClassNames}
       >
         {cancelButtonProps && (
-          <NeutralButton
+          <Button
+            variant={ButtonVariant.Neutral}
             {...cancelButtonProps}
             size={menuSizeToButtonSizeMap.get(size)}
             onClick={onCancel}
           />
         )}
         {okButtonProps && (
-          <PrimaryButton
+          <Button
+            variant={ButtonVariant.Primary}
             {...okButtonProps}
             size={menuSizeToButtonSizeMap.get(size)}
             onClick={onOk}

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -66,6 +66,7 @@ export interface MenuProps
   size?: MenuSize;
   /**
    * SubHeader of the menu
+   * @deprecated 'Unused prop'
    */
   subHeader?: string;
   /**
@@ -75,4 +76,21 @@ export interface MenuProps
   variant?: MenuVariant;
 }
 
-export interface DropdownMenuProps extends MenuProps {}
+export interface DropdownMenuProps extends MenuProps {
+  /**
+   * If the dropdown is disabled or not
+   */
+  disabled?: boolean;
+  /**
+   * Callback executed on reference element click.
+   * @param event
+   * @returns (event: React.MouseEvent) => void
+   */
+  referenceOnClick?: (event: React.MouseEvent) => void;
+  /**
+   * Callback executed on reference element keydown.
+   * @param event
+   * @returns (event: React.KeyboardEvent) => void
+   */
+  referenceOnKeydown?: (event: React.KeyboardEvent) => void;
+}

--- a/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/src/components/Menu/MenuItem/MenuItem.tsx
@@ -1,4 +1,9 @@
-import React, { FC, JSXElementConstructor } from 'react';
+import React, {
+  FC,
+  ForwardedRef,
+  forwardRef,
+  JSXElementConstructor,
+} from 'react';
 import { MenuItemProps, MenuItemType } from './MenuItem.types';
 import { MenuItemButton } from './MenuItemButton';
 import { MenuItemCustom } from './MenuItemCustom';
@@ -15,7 +20,9 @@ const TYPE_TO_MENU_ITEM_MAP: Record<
   [MenuItemType.subHeader]: MenuItemSubHeader,
 };
 
-export const MenuItem: FC<MenuItemProps> = ({ type, ...rest }) => {
-  const Component = TYPE_TO_MENU_ITEM_MAP?.[type] ?? null;
-  return <Component {...rest} />;
-};
+export const MenuItem: FC<MenuItemProps> = forwardRef(
+  ({ type, ...rest }, ref: ForwardedRef<any>) => {
+    const Component = TYPE_TO_MENU_ITEM_MAP?.[type] ?? null;
+    return <Component ref={ref} {...rest} />;
+  }
+);

--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -156,6 +156,7 @@ export interface IMenuItemRender {
   value: any;
   index: number;
   onChange: (value: any) => void;
+  ref?: React.ForwardedRef<any>;
 }
 
 export interface MenuItemCustomProps

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -1,161 +1,174 @@
-import React, { FC } from 'react';
+import React, { FC, forwardRef } from 'react';
 import { MenuItemButtonProps, MenuItemIconAlign } from '../MenuItem.types';
 import { MenuSize, MenuVariant } from '../../Menu.types';
-import { ButtonShape, ButtonSize, NeutralButton } from '../../../Button';
+import {
+  Button,
+  ButtonShape,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../Button';
 import { CascadingMenu } from '../../CascadingMenu';
 import { Icon, IconSize } from '../../../Icon';
 import { mergeClasses } from '../../../../shared/utilities';
 
 import styles from '../menuItem.module.scss';
 
-export const MenuItemButton: FC<MenuItemButtonProps> = ({
-  active,
-  alignIcon = MenuItemIconAlign.Left,
-  classNames,
-  counter,
-  direction,
-  disabled,
-  dropdownMenuItems,
-  dropdownMenuProps,
-  htmlType = 'button',
-  iconProps,
-  onClick,
-  role = 'menuitem',
-  secondaryButtonProps,
-  size = MenuSize.medium,
-  subText,
-  tabIndex = 0,
-  text,
-  type,
-  value,
-  variant = MenuVariant.neutral,
-  wrap = false,
-  ...rest
-}) => {
-  const menuItemClassNames: string = mergeClasses([
-    styles.menuItem,
+export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
+  (
     {
-      [styles.menuItemRtl]: direction === 'rtl',
-      [styles.wrap]: !!wrap,
-      [styles.small]: size === MenuSize.small,
-      [styles.medium]: size === MenuSize.medium,
-      [styles.large]: size === MenuSize.large,
-      [styles.neutral]: variant === MenuVariant.neutral,
-      [styles.primary]: variant === MenuVariant.primary,
-      [styles.disruptive]: variant === MenuVariant.disruptive,
-      [styles.active]: active,
-      [styles.disabled]: disabled,
+      active,
+      alignIcon = MenuItemIconAlign.Left,
+      classNames,
+      counter,
+      direction,
+      disabled,
+      dropdownMenuItems,
+      dropdownMenuProps,
+      htmlType = 'button',
+      iconProps,
+      onClick,
+      role = 'menuitem',
+      secondaryButtonProps,
+      size = MenuSize.medium,
+      subText,
+      tabIndex = 0,
+      text,
+      type,
+      value,
+      variant = MenuVariant.neutral,
+      wrap = false,
+      ...rest
     },
-    classNames,
-  ]);
+    ref: React.ForwardedRef<HTMLButtonElement>
+  ) => {
+    const menuItemClassNames: string = mergeClasses([
+      styles.menuItem,
+      {
+        [styles.menuItemRtl]: direction === 'rtl',
+        [styles.wrap]: !!wrap,
+        [styles.small]: size === MenuSize.small,
+        [styles.medium]: size === MenuSize.medium,
+        [styles.large]: size === MenuSize.large,
+        [styles.neutral]: variant === MenuVariant.neutral,
+        [styles.primary]: variant === MenuVariant.primary,
+        [styles.disruptive]: variant === MenuVariant.disruptive,
+        [styles.active]: active,
+        [styles.disabled]: disabled,
+      },
+      classNames,
+    ]);
 
-  const itemSubTextClassNames: string = mergeClasses([
-    styles.itemSubText,
-    {
-      [styles.small]: size === MenuSize.small,
-      [styles.medium]: size === MenuSize.medium,
-      [styles.large]: size === MenuSize.large,
-    },
-  ]);
+    const itemSubTextClassNames: string = mergeClasses([
+      styles.itemSubText,
+      {
+        [styles.small]: size === MenuSize.small,
+        [styles.medium]: size === MenuSize.medium,
+        [styles.large]: size === MenuSize.large,
+      },
+    ]);
 
-  const handleOnClick = (
-    event: React.MouseEvent<HTMLButtonElement | MouseEvent>
-  ): void => {
-    if (disabled) {
-      event.preventDefault();
-      return;
-    }
-    onClick?.(value);
-  };
+    const handleOnClick = (
+      event: React.MouseEvent<HTMLButtonElement | MouseEvent>
+    ): void => {
+      if (disabled) {
+        event.preventDefault();
+        return;
+      }
+      onClick?.(value);
+    };
 
-  const getIcon = (): JSX.Element => (
-    <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-  );
+    const getIcon = (): JSX.Element => (
+      <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
+    );
 
-  const menuSizeToIconSizeMap: Map<MenuSize, IconSize> = new Map<
-    MenuSize,
-    IconSize
-  >([
-    [MenuSize.large, IconSize.Large],
-    [MenuSize.medium, IconSize.Medium],
-    [MenuSize.small, IconSize.Small],
-  ]);
+    const menuSizeToIconSizeMap: Map<MenuSize, IconSize> = new Map<
+      MenuSize,
+      IconSize
+    >([
+      [MenuSize.large, IconSize.Large],
+      [MenuSize.medium, IconSize.Medium],
+      [MenuSize.small, IconSize.Small],
+    ]);
 
-  const menuButton = (): JSX.Element => (
-    <button
-      className={styles.menuItemButton}
-      disabled={disabled}
-      tabIndex={tabIndex}
-      type={htmlType}
-      {...rest}
-      onClick={handleOnClick}
-      role={role}
-    >
-      {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
-      <span className={styles.menuItemWrapper}>
-        <span className={styles.itemText}>
-          <span className={styles.label}>{text}</span>
-          {counter && <span>{counter}</span>}
+    const menuButton = (isNested: boolean = false): JSX.Element => (
+      <button
+        className={styles.menuItemButton}
+        disabled={disabled}
+        tabIndex={tabIndex}
+        type={htmlType}
+        {...rest}
+        onClick={!isNested ? handleOnClick : null}
+        ref={ref}
+        role={role}
+      >
+        {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
+        <span className={styles.menuItemWrapper}>
+          <span className={styles.itemText}>
+            <span className={styles.label}>{text}</span>
+            {counter && <span>{counter}</span>}
+          </span>
+          {subText && <span className={itemSubTextClassNames}>{subText}</span>}
+        </span>
+        {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
+      </button>
+    );
+
+    const secondaryButton = (): JSX.Element => (
+      <>
+        <span className={styles.menuSecondaryWrapper} role={role}>
+          <button
+            className={styles.menuOuterButton}
+            disabled={disabled}
+            tabIndex={tabIndex}
+            type={htmlType}
+            {...rest}
+            ref={ref}
+            role={role}
+          >
+            {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
+            <span className={styles.menuItemWrapper}>
+              <span className={styles.itemText}>
+                <span className={styles.label}>{text}</span>
+              </span>
+            </span>
+            {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
+          </button>
+          <span className={styles.menuInnerButton}>
+            {counter && <span>{counter}</span>}
+            {secondaryButtonProps && (
+              <Button
+                disabled={disabled}
+                size={ButtonSize.Small}
+                shape={ButtonShape.Round}
+                variant={ButtonVariant.Neutral}
+                {...secondaryButtonProps}
+              />
+            )}
+          </span>
         </span>
         {subText && <span className={itemSubTextClassNames}>{subText}</span>}
-      </span>
-      {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
-    </button>
-  );
+      </>
+    );
 
-  const secondaryButton = (): JSX.Element => (
-    <>
-      <span className={styles.menuSecondaryWrapper} role={role}>
-        <button
-          className={styles.menuOuterButton}
-          disabled={disabled}
-          tabIndex={tabIndex}
-          type={htmlType}
-          {...rest}
-          onClick={handleOnClick}
-        >
-          {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
-          <span className={styles.menuItemWrapper}>
-            <span className={styles.itemText}>
-              <span className={styles.label}>{text}</span>
-            </span>
-          </span>
-          {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
-        </button>
-        <span className={styles.menuInnerButton}>
-          {counter && <span>{counter}</span>}
-          {secondaryButtonProps && (
-            <NeutralButton
-              disabled={disabled}
-              size={ButtonSize.Small}
-              shape={ButtonShape.Round}
-              {...secondaryButtonProps}
-            />
-          )}
-        </span>
-      </span>
-      {subText && <span className={itemSubTextClassNames}>{subText}</span>}
-    </>
-  );
+    const dropdownMenuButton = (): JSX.Element => (
+      <CascadingMenu
+        {...dropdownMenuProps}
+        items={dropdownMenuItems}
+        size={size}
+        variant={variant}
+      >
+        <div className={styles.menuItemWrapper}>{menuButton(true)}</div>
+      </CascadingMenu>
+    );
 
-  const dropdownMenuButton = (): JSX.Element => (
-    <CascadingMenu
-      {...dropdownMenuProps}
-      items={dropdownMenuItems}
-      size={size}
-      variant={variant}
-    >
-      {menuButton()}
-    </CascadingMenu>
-  );
+    const renderedItem = (): JSX.Element => {
+      if (secondaryButtonProps) {
+        return secondaryButton();
+      }
 
-  const renderedItem = (): JSX.Element => {
-    if (secondaryButtonProps) {
-      return secondaryButton();
-    }
+      return dropdownMenuItems ? dropdownMenuButton() : menuButton();
+    };
 
-    return dropdownMenuItems ? dropdownMenuButton() : menuButton();
-  };
-
-  return <li className={menuItemClassNames}>{renderedItem()}</li>;
-};
+    return <li className={menuItemClassNames}>{renderedItem()}</li>;
+  }
+);

--- a/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
+++ b/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
@@ -1,30 +1,29 @@
-import React, { FC } from 'react';
+import React, { FC, forwardRef } from 'react';
 import { MenuItemCustomProps } from '../MenuItem.types';
 import { mergeClasses } from '../../../../shared/utilities';
 import { MenuSize } from '../../Menu.types';
 
 import styles from '../menuItem.module.scss';
 
-export const MenuItemCustom: FC<MenuItemCustomProps> = ({
-  classNames,
-  index,
-  onChange,
-  size = MenuSize.medium,
-  ...item
-}) => {
-  const menuItemClassNames: string = mergeClasses([
-    styles.menuItemCustom,
-    {
-      [styles.large]: size === MenuSize.large,
-      [styles.medium]: size === MenuSize.medium,
-      [styles.small]: size === MenuSize.small,
-    },
-    classNames,
-  ]);
+export const MenuItemCustom: FC<MenuItemCustomProps> = forwardRef(
+  (
+    { classNames, index, onChange, size = MenuSize.medium, ...item },
+    ref: React.ForwardedRef<any>
+  ) => {
+    const menuItemClassNames: string = mergeClasses([
+      styles.menuItemCustom,
+      {
+        [styles.large]: size === MenuSize.large,
+        [styles.medium]: size === MenuSize.medium,
+        [styles.small]: size === MenuSize.small,
+      },
+      classNames,
+    ]);
 
-  return (
-    <li className={menuItemClassNames}>
-      {item.render({ index, value: item, onChange })}
-    </li>
-  );
-};
+    return (
+      <li className={menuItemClassNames}>
+        {item.render({ index, value: item, onChange, ref: ref })}
+      </li>
+    );
+  }
+);

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, forwardRef } from 'react';
 import { MenuItemIconAlign, MenuItemLinkProps } from '../MenuItem.types';
 import { Link } from '../../../Link';
 import { mergeClasses } from '../../../../shared/utilities';
@@ -7,82 +7,90 @@ import { Icon, IconSize } from '../../../Icon';
 
 import styles from '../menuItem.module.scss';
 
-export const MenuItemLink: FC<MenuItemLinkProps> = ({
-  active,
-  alignIcon = MenuItemIconAlign.Left,
-  classNames,
-  counter,
-  direction,
-  disabled,
-  iconProps,
-  role = 'menuitem',
-  size = MenuSize.medium,
-  subText,
-  tabIndex = 0,
-  text,
-  variant = MenuVariant.neutral,
-  wrap = false,
-  ...rest
-}) => {
-  const menuItemClassNames: string = mergeClasses([
-    styles.menuItem,
+export const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
+  (
     {
-      [styles.menuItemRtl]: direction === 'rtl',
-      [styles.wrap]: !!wrap,
-      [styles.small]: size === MenuSize.small,
-      [styles.medium]: size === MenuSize.medium,
-      [styles.large]: size === MenuSize.large,
-      [styles.neutral]: variant === MenuVariant.neutral,
-      [styles.primary]: variant === MenuVariant.primary,
-      [styles.disruptive]: variant === MenuVariant.disruptive,
-      [styles.active]: active,
-      [styles.disabled]: disabled,
+      active,
+      alignIcon = MenuItemIconAlign.Left,
+      classNames,
+      counter,
+      direction,
+      disabled,
+      iconProps,
+      role = 'menuitem',
+      size = MenuSize.medium,
+      subText,
+      tabIndex = 0,
+      text,
+      variant = MenuVariant.neutral,
+      wrap = false,
+      ...rest
     },
-    classNames,
-  ]);
+    ref: React.ForwardedRef<HTMLAnchorElement>
+  ) => {
+    const menuItemClassNames: string = mergeClasses([
+      styles.menuItem,
+      {
+        [styles.menuItemRtl]: direction === 'rtl',
+        [styles.wrap]: !!wrap,
+        [styles.small]: size === MenuSize.small,
+        [styles.medium]: size === MenuSize.medium,
+        [styles.large]: size === MenuSize.large,
+        [styles.neutral]: variant === MenuVariant.neutral,
+        [styles.primary]: variant === MenuVariant.primary,
+        [styles.disruptive]: variant === MenuVariant.disruptive,
+        [styles.active]: active,
+        [styles.disabled]: disabled,
+      },
+      classNames,
+    ]);
 
-  const itemSubTextClassNames: string = mergeClasses([
-    styles.itemSubText,
-    {
-      [styles.small]: size === MenuSize.small,
-      [styles.medium]: size === MenuSize.medium,
-      [styles.large]: size === MenuSize.large,
-    },
-  ]);
+    const itemSubTextClassNames: string = mergeClasses([
+      styles.itemSubText,
+      {
+        [styles.small]: size === MenuSize.small,
+        [styles.medium]: size === MenuSize.medium,
+        [styles.large]: size === MenuSize.large,
+      },
+    ]);
 
-  const menuSizeToIconSizeMap: Map<MenuSize, IconSize> = new Map<
-    MenuSize,
-    IconSize
-  >([
-    [MenuSize.large, IconSize.Large],
-    [MenuSize.medium, IconSize.Medium],
-    [MenuSize.small, IconSize.Small],
-  ]);
+    const menuSizeToIconSizeMap: Map<MenuSize, IconSize> = new Map<
+      MenuSize,
+      IconSize
+    >([
+      [MenuSize.large, IconSize.Large],
+      [MenuSize.medium, IconSize.Medium],
+      [MenuSize.small, IconSize.Small],
+    ]);
 
-  const getIcon = (): JSX.Element => (
-    <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
-  );
+    const getIcon = (): JSX.Element => (
+      <Icon size={menuSizeToIconSizeMap.get(size)} {...iconProps} />
+    );
 
-  return (
-    <li className={menuItemClassNames}>
-      <Link
-        classNames={styles.menuLink}
-        disabled={disabled}
-        fullWidth
-        role={role}
-        tabIndex={tabIndex}
-        {...rest}
-      >
-        {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
-        <span className={styles.menuItemWrapper}>
-          <span className={styles.itemText}>
-            <span className={styles.label}>{text}</span>
-            {counter && <span>{counter}</span>}
+    return (
+      <li className={menuItemClassNames}>
+        <Link
+          classNames={styles.menuLink}
+          disabled={disabled}
+          fullWidth
+          ref={ref}
+          role={role}
+          tabIndex={tabIndex}
+          {...rest}
+        >
+          {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
+          <span className={styles.menuItemWrapper}>
+            <span className={styles.itemText}>
+              <span className={styles.label}>{text}</span>
+              {counter && <span>{counter}</span>}
+            </span>
+            {subText && (
+              <span className={itemSubTextClassNames}>{subText}</span>
+            )}
           </span>
-          {subText && <span className={itemSubTextClassNames}>{subText}</span>}
-        </span>
-        {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
-      </Link>
-    </li>
-  );
-};
+          {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
+        </Link>
+      </li>
+    );
+  }
+);

--- a/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
+++ b/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
@@ -1,25 +1,32 @@
-import React, { FC } from 'react';
+import React, { FC, forwardRef } from 'react';
 import { MenuItemSubHeaderProps } from '../MenuItem.types';
 import { mergeClasses } from '../../../../shared/utilities';
 import { MenuSize } from '../../Menu.types';
 
 import styles from '../menuItem.module.scss';
 
-export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = ({
-  direction,
-  size,
-  text,
-  wrap,
-}) => {
-  const subHeaderClassNames: string = mergeClasses([
-    styles.menuItemSubHeader,
-    {
-      [styles.menuItemRtl]: direction === 'rtl',
-      [styles.wrap]: !!wrap,
-      [styles.large]: size === MenuSize.large,
-      [styles.medium]: size === MenuSize.medium,
-      [styles.small]: size === MenuSize.small,
-    },
-  ]);
-  return <span className={subHeaderClassNames}>{text}</span>;
-};
+export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = forwardRef(
+  (
+    { classNames, direction, size, text, wrap, ...rest },
+    ref: React.ForwardedRef<HTMLSpanElement>
+  ) => {
+    const subHeaderClassNames: string = mergeClasses([
+      styles.menuItemSubHeader,
+      {
+        [styles.menuItemRtl]: direction === 'rtl',
+        [styles.wrap]: !!wrap,
+        [styles.large]: size === MenuSize.large,
+        [styles.medium]: size === MenuSize.medium,
+        [styles.small]: size === MenuSize.small,
+      },
+      classNames,
+    ]);
+    return (
+      <li className={subHeaderClassNames}>
+        <span data-disabled {...rest} tabIndex={-1} ref={ref}>
+          {text}
+        </span>
+      </li>
+    );
+  }
+);

--- a/src/components/Menu/__snapshots__/CascadingMenu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/CascadingMenu.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Menu Should render a menu button 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="button button-default button-medium pill-shape"
+    data-testid="menu-reference"
     id="floating-ui-3"
     role="button"
   >

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`Menu Menu is large 1`] = `
           >
             <button
               class="menu-item-button"
+              id="listItem0-"
               role="menuitem"
               tabindex="0"
               type="button"
@@ -85,6 +86,7 @@ exports[`Menu Menu is large 1`] = `
             <button
               class="menu-item-button"
               disabled=""
+              id="listItem1-"
               role="menuitem"
               tabindex="0"
               type="button"
@@ -104,11 +106,18 @@ exports[`Menu Menu is large 1`] = `
               </span>
             </button>
           </li>
-          <span
-            class="menu-item-sub-header large"
+          <li
+            class="menu-item-sub-header large my-menu-item-class"
           >
-            Sub header
-          </span>
+            <span
+              data-disabled="true"
+              id="listItem2-"
+              tabindex="-1"
+              variant="neutral"
+            >
+              Sub header
+            </span>
+          </li>
           <li
             class="menu-item large neutral my-menu-item-class"
           >
@@ -116,6 +125,7 @@ exports[`Menu Menu is large 1`] = `
               aria-disabled="false"
               class="link-style full-width menu-link"
               href="https://twitter.com"
+              id="listItem3-"
               role="menuitem"
               tabindex="0"
               target="_blank"
@@ -273,6 +283,7 @@ exports[`Menu Menu is medium 1`] = `
           >
             <button
               class="menu-item-button"
+              id="listItem0-"
               role="menuitem"
               tabindex="0"
               type="button"
@@ -317,6 +328,7 @@ exports[`Menu Menu is medium 1`] = `
             <button
               class="menu-item-button"
               disabled=""
+              id="listItem1-"
               role="menuitem"
               tabindex="0"
               type="button"
@@ -336,11 +348,18 @@ exports[`Menu Menu is medium 1`] = `
               </span>
             </button>
           </li>
-          <span
-            class="menu-item-sub-header medium"
+          <li
+            class="menu-item-sub-header medium my-menu-item-class"
           >
-            Sub header
-          </span>
+            <span
+              data-disabled="true"
+              id="listItem2-"
+              tabindex="-1"
+              variant="neutral"
+            >
+              Sub header
+            </span>
+          </li>
           <li
             class="menu-item medium neutral my-menu-item-class"
           >
@@ -348,6 +367,7 @@ exports[`Menu Menu is medium 1`] = `
               aria-disabled="false"
               class="link-style full-width menu-link"
               href="https://twitter.com"
+              id="listItem3-"
               role="menuitem"
               tabindex="0"
               target="_blank"
@@ -505,6 +525,7 @@ exports[`Menu Menu is small 1`] = `
           >
             <button
               class="menu-item-button"
+              id="listItem0-"
               role="menuitem"
               tabindex="0"
               type="button"
@@ -549,6 +570,7 @@ exports[`Menu Menu is small 1`] = `
             <button
               class="menu-item-button"
               disabled=""
+              id="listItem1-"
               role="menuitem"
               tabindex="0"
               type="button"
@@ -568,11 +590,18 @@ exports[`Menu Menu is small 1`] = `
               </span>
             </button>
           </li>
-          <span
-            class="menu-item-sub-header small"
+          <li
+            class="menu-item-sub-header small my-menu-item-class"
           >
-            Sub header
-          </span>
+            <span
+              data-disabled="true"
+              id="listItem2-"
+              tabindex="-1"
+              variant="neutral"
+            >
+              Sub header
+            </span>
+          </li>
           <li
             class="menu-item small neutral my-menu-item-class"
           >
@@ -580,6 +609,7 @@ exports[`Menu Menu is small 1`] = `
               aria-disabled="false"
               class="link-style full-width menu-link"
               href="https://twitter.com"
+              id="listItem3-"
               role="menuitem"
               tabindex="0"
               target="_blank"

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -8,6 +8,7 @@ import { sleep } from '../../tests/Utilities';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
+import '@testing-library/jest-dom';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -44,9 +45,9 @@ describe('Select', () => {
   }
 
   const options = [
-    { text: 'Option 1', value: 'option1' },
-    { text: 'Option 2', value: 'option2' },
-    { text: 'Option 3', value: 'option3' },
+    { text: 'Option 1', value: 'option1', 'data-testid': 'option1-test-id' },
+    { text: 'Option 2', value: 'option2', 'data-testid': 'option2-test-id' },
+    { text: 'Option 3', value: 'option3', 'data-testid': 'option3-test-id' },
   ];
 
   test('Renders without crashing', () => {
@@ -162,6 +163,7 @@ describe('Select', () => {
       ['option1'],
       [
         {
+          'data-testid': 'option1-test-id',
           hideOption: false,
           id: 'Option 1-0',
           object: undefined,
@@ -194,6 +196,7 @@ describe('Select', () => {
       ['option1', 'option2'],
       [
         {
+          'data-testid': 'option1-test-id',
           hideOption: false,
           id: 'Option 1-0',
           object: undefined,
@@ -203,6 +206,7 @@ describe('Select', () => {
           value: 'option1',
         },
         {
+          'data-testid': 'option2-test-id',
           hideOption: false,
           id: 'Option 2-1',
           object: undefined,
@@ -256,6 +260,7 @@ describe('Select', () => {
       ['option2'],
       [
         {
+          'data-testid': 'option2-test-id',
           hideOption: false,
           id: 'Option 2-1',
           object: undefined,
@@ -270,6 +275,7 @@ describe('Select', () => {
       ['option1'],
       [
         {
+          'data-testid': 'option1-test-id',
           hideOption: false,
           id: 'Option 1-0',
           object: undefined,
@@ -314,6 +320,7 @@ describe('Select', () => {
       ['option1', 'option2', 'option3'],
       [
         {
+          'data-testid': 'option1-test-id',
           hideOption: false,
           id: 'Option 1-0',
           object: undefined,
@@ -323,6 +330,7 @@ describe('Select', () => {
           value: 'option1',
         },
         {
+          'data-testid': 'option2-test-id',
           hideOption: false,
           id: 'Option 2-1',
           object: undefined,
@@ -332,6 +340,7 @@ describe('Select', () => {
           value: 'option2',
         },
         {
+          'data-testid': 'option3-test-id',
           hideOption: false,
           id: 'Option 3-2',
           object: undefined,
@@ -375,6 +384,7 @@ describe('Select', () => {
       ['option2'],
       [
         {
+          'data-testid': 'option2-test-id',
           hideOption: false,
           id: 'Option 2-1',
           object: undefined,
@@ -590,16 +600,115 @@ describe('Select', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  test('Focuses the first focusable element when visible', async () => {
+  test('Focuses the first focusable element when dropdown is visible and not filterable and initialFocus is not set', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select options={options} placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    select.focus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    await waitFor(() =>
+      expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true)
+    );
+    expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true);
+  });
+
+  test('Focuses the first focusable element when dropdown is visible and not filterable and initialFocus is true', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select options={options} initialFocus placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    select.focus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    await waitFor(() =>
+      expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true)
+    );
+    expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true);
+  });
+
+  test('Focuses the first focusable element when dropdown is visible and filterable and initialFocus is true', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        options={options}
+        initialFocus
+        filterable
+        placeholder="Select test"
+      />
+    );
+    const select = getByPlaceholderText('Select test');
+    select.focus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    await waitFor(() =>
+      expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true)
+    );
+    expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true);
+  });
+
+  test('Focuses the first focusable element when dropdown is visible and filterable and arrowDown is pressed', async () => {
     const { getAllByRole, getByPlaceholderText } = render(
       <Select options={options} filterable placeholder="Select test" />
     );
     const select = getByPlaceholderText('Select test');
-    fireEvent.click(select);
+    select.focus();
+    fireEvent.click(select, { key: 'Enter' });
     const listbox = await waitFor(() => getAllByRole('option'));
     expect(listbox).toHaveLength(options.length);
-    const elementToFocus = document.activeElement as HTMLElement;
-    expect(elementToFocus).toBeTruthy();
+    fireEvent.keyDown(select, { key: 'ArrowDown' });
+    await waitFor(() =>
+      expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true)
+    );
+    expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true);
+  });
+
+  test('Does not focus the first focusable element when dropdown is visible and not filterable and initialFocus is false', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        options={options}
+        initialFocus={false}
+        placeholder="Select test"
+      />
+    );
+    const select = getByPlaceholderText('Select test');
+    select.focus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    expect(select).toHaveFocus();
+  });
+
+  test('Does not focus the first focusable element when dropdown is visible and filterable and initialFocus is not set', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select options={options} filterable placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    select.focus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    expect(select).toHaveFocus();
+  });
+
+  test('Does not focus the first focusable element when dropdown is visible and filterable and initialFocus is false', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        options={options}
+        initialFocus={false}
+        filterable
+        placeholder="Select test"
+      />
+    );
+    const select = getByPlaceholderText('Select test');
+    select.focus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    expect(select).toHaveFocus();
   });
 
   test('Focuses the reference element when not visible', async () => {
@@ -617,7 +726,6 @@ describe('Select', () => {
       userEvent.type(listbox[0], mockEventKeys.ESCAPE);
     });
     expect(container.querySelector('.dropdown')).toBeFalsy();
-    const elementToFocus = document.activeElement as HTMLElement;
-    expect(elementToFocus).toBeTruthy();
+    expect(select).toHaveFocus();
   });
 });

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -5,8 +5,9 @@ import MatchMediaMock from 'jest-matchmedia-mock';
 import { SelectShape, SelectSize } from './Select.types';
 import { Select } from './';
 import { sleep } from '../../tests/Utilities';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -587,5 +588,36 @@ describe('Select', () => {
       <Select options={options} shape={SelectShape.Underline} />
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('Focuses the first focusable element when visible', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select options={options} filterable placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    fireEvent.click(select);
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    const elementToFocus = document.activeElement as HTMLElement;
+    expect(elementToFocus).toBeTruthy();
+  });
+
+  test('Focuses the reference element when not visible', async () => {
+    const mockEventKeys = {
+      ESCAPE: 'Escape',
+    };
+    const { container, getAllByRole, getByPlaceholderText } = render(
+      <Select options={options} filterable placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    fireEvent.click(select);
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    act(() => {
+      userEvent.type(listbox[0], mockEventKeys.ESCAPE);
+    });
+    expect(container.querySelector('.dropdown')).toBeFalsy();
+    const elementToFocus = document.activeElement as HTMLElement;
+    expect(elementToFocus).toBeTruthy();
   });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -266,7 +266,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (readonly && dropdownVisible) {
         setDropdownVisibility(false);
       }
-    }, [readonly, dropdownVisible]);
+      if (!dropdownVisible && prevDropdownVisible) {
+        inputRef.current?.focus();
+      }
+    }, [readonly, dropdownVisible, prevDropdownVisible]);
 
     const toggleOption = (option: SelectOption): void => {
       setSearchQuery('');
@@ -751,6 +754,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
           {!dropdownVisible && showPills() ? getPills() : null}
           <Dropdown
             ariaRef={inputRef}
+            initialFocus
             width={dropdownWidth}
             closeOnReferenceClick={closeOnReferenceClick}
             {...dropdownProps}

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -101,14 +101,16 @@ export interface SelectProps
    */
   formItemInput?: boolean;
   /**
+   * Optionally place focus on the first focusable
+   * selector when the Dropdown is first visible.
+   * When false, visibility will be placed on the Dropdown.
+   * @default `filterable ? false : true`
+   */
+  initialFocus?: boolean;
+  /**
    * The Select input custom class names.
    */
   inputClassNames?: string;
-  /**
-   * The Select input is readonly.
-   * @default false
-   */
-  readonly?: boolean;
   /**
    * Width of the Select text input.
    * @default TextInputWidth.fitContent
@@ -165,6 +167,11 @@ export interface SelectProps
    * @default {}
    */
   pillProps?: PillProps;
+  /**
+   * The Select input is readonly.
+   * @default false
+   */
+  readonly?: boolean;
   /**
    * Shape of the select.
    * @default SelectShape.Rectangle

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -74,7 +74,7 @@ import {
 
 import { Dialog, DialogHelper, DialogSize } from './components/Dialog';
 
-import { Dropdown } from './components/Dropdown';
+import { Dropdown, DropdownRef } from './components/Dropdown';
 
 import { Empty, EmptyMode } from './components/Empty';
 
@@ -348,6 +348,7 @@ export {
   DialogHelper,
   DialogSize,
   Dropdown,
+  DropdownRef,
   Empty,
   EmptyMode,
   ExceedLargeImg,

--- a/src/shared/FocusTrap/hooks/useFocusTrap.ts
+++ b/src/shared/FocusTrap/hooks/useFocusTrap.ts
@@ -1,9 +1,7 @@
 // Based on https://hiddedevries.nl/en/blog/2017-01-29-using-javascript-to-trap-focus-in-an-element
 import { useRef, useEffect } from 'react';
 import { eventKeys } from '../../utilities/eventKeys';
-
-const SELECTORS =
-  'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), iframe, object, embed';
+import { focusable, SELECTORS } from '../../utilities';
 
 const FOCUS_DELAY_INTERVAL: number = 100;
 
@@ -20,8 +18,7 @@ export function useFocusTrap(
 
   const getFocusableElements = (): HTMLElement[] => {
     return [...elRef.current.querySelectorAll(SELECTORS)].filter(
-      (el: HTMLElement) =>
-        !el?.hasAttribute('disabled') && !el?.getAttribute('aria-hidden')
+      (el: HTMLElement) => focusable(el)
     );
   };
 

--- a/src/shared/utilities/types.ts
+++ b/src/shared/utilities/types.ts
@@ -1,3 +1,14 @@
+export const SELECTORS: string =
+  'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]), iframe, object, embed';
+
+export const focusable = (el: HTMLElement | null): boolean => {
+  return (
+    !el?.hasAttribute('data-disabled') && // optionally use a data attribute as a way to exclude certain elements without hiding them from screen readers to improve usability.
+    !el?.hasAttribute('disabled') &&
+    !el?.getAttribute('aria-hidden')
+  );
+};
+
 // https://stackoverflow.com/questions/46176165/ways-to-get-string-literal-type-of-array-values-without-enum-overhead
 export const tuple = <T extends string[]>(...args: T) => args;
 


### PR DESCRIPTION
## SUMMARY:
This change adds `ArrowDown`, `ArrowLeft`, `ArrowRight`, and `ArrowUp` keyboard navigation support to address existing usability bugs in `List`, `Dropdown`, `Menu`, `CascadingMenu`, and `Select` components.

- Moves `SELECTOR` string from `useFocusTrap` scope to utility scope so that it may be used by `List`
- Adds `focusable` function that returns true if certain attributes exist on element passed into it via args
- Adds arrow key support to `List` component via its new `handleItemKeyDown` function
- Updates `List` `getItem` prop implementation to be wrapped in `externalItem` so that we can access its properties
- Updates `List` `getAdditionalItem` such that it may be included in the focus loop
- Updates `List` to include an option to disable default arrow key handling via `disableArrowKeys` prop
- Updates `Dropdown` to support `ArrowDown` and `ArrowUp` keys via its `handleReferenceKeyDown` to open and close the `Dropdown`, when the `Dropdown` is open we place focus on the first focusable selector, when closed we place focus back on the reference element
- Adds new `Dropdown` story demonstrating `additionalItem` and `renderAdditionalItem`
- Adds `initialFocus` and `referenceOnKeydown` props to `Dropdown`
- Adds `focusFirstElement` and `focusOnElement` helpers to `DropdownRef`
- Exports `DropdownRef` via `octuple.ts` to assist with strict type implementations
- Updates `Select` to place focus back on its reference element when its `Dropdown` is closed
- Updates `Select` to include `initialFocus` prop to enable granular control of how its `Dropdown` steals focus
- Adds forwardRef support to `MenuItemButton`, `MenuItemCustom`, `MenuItemLink`, `MenuItemSubHeader`, and `MenuItem` components
- Updates `MenuItemSubHeader` to work with keyboard navigation, preserves current behavior
- Updates `MenuProps`, marking `subHeader` as deprecated because its not used
- Adds `floating-ui` `useListNavigation` support to `CascadingMenu` as its supported there by its canonical `floating-ui` implementation
- Updates related `Button` implementations to use `variant` prop
- Updates Stories
- Adds UTs


https://github.com/EightfoldAI/octuple/assets/99700808/55067a16-a82a-4cd5-af1f-f60bf8014bc7


## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/757

## JIRA TASK (Eightfold Employees Only):
ENG-72532
ENG-72534
ENG-72536

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and `yarn` and then `yarn storybook`. Verify the `List`, `Dropdown`, `Menu`, and `Select` stories behave as expected.