### PR TITLE
chore: i18n: additional eightfold supported locales

### DIFF
--- a/src/components/Breadcrumb/Locale/ar_SA.tsx
+++ b/src/components/Breadcrumb/Locale/ar_SA.tsx
@@ -1,0 +1,11 @@
+import type { BreadcrumbLocale } from '../Breadcrumb.types';
+
+const locale: BreadcrumbLocale = {
+  lang: {
+    locale: 'ar_SA',
+    ariaLabelText: 'فتات الخبز',
+    overflowAriaLabelText: 'المزيد من الروابط',
+  },
+};
+
+export default locale;

--- a/src/components/Breadcrumb/Locale/bg_BG.tsx
+++ b/src/components/Breadcrumb/Locale/bg_BG.tsx
@@ -1,0 +1,11 @@
+import type { BreadcrumbLocale } from '../Breadcrumb.types';
+
+const locale: BreadcrumbLocale = {
+  lang: {
+    locale: 'bg_BG',
+    ariaLabelText: 'Навигационни трошки',
+    overflowAriaLabelText: 'Още връзки',
+  },
+};
+
+export default locale;

--- a/src/components/Breadcrumb/Locale/ro_RO.tsx
+++ b/src/components/Breadcrumb/Locale/ro_RO.tsx
@@ -1,0 +1,11 @@
+import type { BreadcrumbLocale } from '../Breadcrumb.types';
+
+const locale: BreadcrumbLocale = {
+  lang: {
+    locale: 'ro_RO',
+    ariaLabelText: 'Breadcrumb-uri',
+    overflowAriaLabelText: 'Mai multe link-uri',
+  },
+};
+
+export default locale;

--- a/src/components/Breadcrumb/Locale/sk_SK.tsx
+++ b/src/components/Breadcrumb/Locale/sk_SK.tsx
@@ -1,0 +1,11 @@
+import type { BreadcrumbLocale } from '../Breadcrumb.types';
+
+const locale: BreadcrumbLocale = {
+  lang: {
+    locale: 'sk_SK',
+    ariaLabelText: 'Navigačné drobky',
+    overflowAriaLabelText: 'Viac odkazov',
+  },
+};
+
+export default locale;

--- a/src/components/Breadcrumb/Locale/sr_RS.tsx
+++ b/src/components/Breadcrumb/Locale/sr_RS.tsx
@@ -1,0 +1,11 @@
+import type { BreadcrumbLocale } from '../Breadcrumb.types';
+
+const locale: BreadcrumbLocale = {
+  lang: {
+    locale: 'sr_RS',
+    ariaLabelText: 'Putokazi',
+    overflowAriaLabelText: 'Više linkova',
+  },
+};
+
+export default locale;

--- a/src/components/Breadcrumb/Locale/te_IN.tsx
+++ b/src/components/Breadcrumb/Locale/te_IN.tsx
@@ -1,0 +1,11 @@
+import type { BreadcrumbLocale } from '../Breadcrumb.types';
+
+const locale: BreadcrumbLocale = {
+  lang: {
+    locale: 'te_IN',
+    ariaLabelText: 'బ్రెడ్క్రమ్స్',
+    overflowAriaLabelText: 'మరిన్ని లింకులు',
+  },
+};
+
+export default locale;

--- a/src/components/Breadcrumb/Locale/vi_VN.tsx
+++ b/src/components/Breadcrumb/Locale/vi_VN.tsx
@@ -1,0 +1,11 @@
+import type { BreadcrumbLocale } from '../Breadcrumb.types';
+
+const locale: BreadcrumbLocale = {
+  lang: {
+    locale: 'vi_VN',
+    ariaLabelText: 'Breadcrumb',
+    overflowAriaLabelText: 'Thêm liên kết',
+  },
+};
+
+export default locale;

--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -47,6 +47,8 @@ import dayjs, { Dayjs } from 'dayjs';
 
 // locales
 import type { Locale as OcLocale } from '../LocaleProvider'; // Need to alias because story name declaration conflicts with the type
+import arSA from '../Locale/ar_SA'; // العربية
+import bgBG from '../Locale/bg_BG'; // български
 import csCZ from '../Locale/cs_CZ'; // čeština
 import daDK from '../Locale/da_DK'; // Dansk
 import deDE from '../Locale/de_DE'; // Deutsch
@@ -75,15 +77,22 @@ import nlNL from '../Locale/nl_NL'; // Nederlands
 import plPL from '../Locale/pl_PL'; // Polski
 import ptBR from '../Locale/pt_BR'; // Português (Brazil)
 import ptPT from '../Locale/pt_PT'; // Português
+import roRO from '../Locale/ro_RO'; // Română
 import ruRU from '../Locale/ru_RU'; // Pусский
+import skSK from '../Locale/sk_SK'; // Slovenčina
+import srRS from '../Locale/sr_RS'; // Srpski
 import svSE from '../Locale/sv_SE'; // Svenska
+import teIN from '../Locale/te_IN'; // తెలుగు
 import thTH from '../Locale/th_TH'; // ภาษาไทย
 import trTR from '../Locale/tr_TR'; // Türkçe
 import ukUA from '../Locale/uk_UA'; // Yкраїнська
+import viVN from '../Locale/vi_VN'; // Tiếng Việt
 import zhCN from '../Locale/zh_CN'; // 中文 (简体)
 import zhTW from '../Locale/zh_TW'; // 中文 (繁體)
 
 // Dayjs locales
+import 'dayjs/locale/ar';
+import 'dayjs/locale/bg';
 import 'dayjs/locale/cs';
 import 'dayjs/locale/da';
 import 'dayjs/locale/de';
@@ -111,11 +120,16 @@ import 'dayjs/locale/nl';
 import 'dayjs/locale/pl';
 import 'dayjs/locale/pt';
 import 'dayjs/locale/pt-br';
+import 'dayjs/locale/ro';
 import 'dayjs/locale/ru';
+import 'dayjs/locale/sk';
+import 'dayjs/locale/sr';
 import 'dayjs/locale/sv';
+import 'dayjs/locale/te';
 import 'dayjs/locale/th';
 import 'dayjs/locale/tr';
 import 'dayjs/locale/uk';
+import 'dayjs/locale/vi';
 import 'dayjs/locale/zh-cn';
 import 'dayjs/locale/zh-tw';
 
@@ -747,6 +761,8 @@ const Theming_Story: ComponentStory<typeof ConfigProvider> = (args) => {
 };
 
 const localeValues: string[] = [
+  'ar_SA',
+  'bg_BG',
   'cs_CZ',
   'da_DK',
   'de_DE',
@@ -775,11 +791,16 @@ const localeValues: string[] = [
   'pl_PL',
   'pt_BR',
   'pt_PT',
+  'ro_RO',
   'ru_RU',
+  'sk_SK',
+  'sr_RS',
   'sv_SE',
+  'te_IN',
   'th_TH',
   'tr_TR',
   'uk_UA',
+  'vi_VN',
   'zh_CN',
   'zh_TW',
 ];
@@ -811,6 +832,8 @@ const Locale_Story: ComponentStory<typeof ConfigProvider> = (args) => {
   const [localeValue, setLocaleValue] = useState<string>('en_US');
 
   const locales: Record<string, OcLocale> = {
+    ar_SA: arSA,
+    bg_BG: bgBG,
     cs_CZ: csCZ,
     da_DK: daDK,
     de_DE: deDE,
@@ -839,17 +862,24 @@ const Locale_Story: ComponentStory<typeof ConfigProvider> = (args) => {
     pl_PL: plPL,
     pt_BR: ptBR,
     pt_PT: ptPT,
+    ro_RO: roRO,
     ru_RU: ruRU,
+    sk_SK: skSK,
+    sr_RS: srRS,
     sv_SE: svSE,
+    te_IN: teIN,
     th_TH: thTH,
     tr_TR: trTR,
     uk_UA: ukUA,
+    vi_VN: viVN,
     zh_CN: zhCN,
     zh_TW: zhTW,
   };
 
   const localeToDayJsLocale = (locale: string): string => {
     const localeMap: { [key: string]: string } = {
+      ar_SA: 'ar',
+      bg_BG: 'bg',
       cs_CZ: 'cs',
       da_DK: 'da',
       de_DE: 'de',
@@ -878,11 +908,16 @@ const Locale_Story: ComponentStory<typeof ConfigProvider> = (args) => {
       pl_PL: 'pl',
       pt_BR: 'pt-br',
       pt_PT: 'pt',
+      ro_RO: 'ro',
       ru_RU: 'ru',
+      sk_SK: 'sk',
+      sr_RS: 'sr',
       sv_SE: 'sv',
+      te_IN: 'te',
       th_TH: 'th',
       tr_TR: 'tr',
       uk_UA: 'uk',
+      vi_VN: 'vi',
       zh_CN: 'zh-cn',
       zh_TW: 'zh-tw',
     };

--- a/src/components/DateTimePicker/DatePicker/Locale/ar_SA.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/ar_SA.tsx
@@ -1,0 +1,24 @@
+import CalendarLocale from '../../Internal/Locale/ar_SA';
+import TimePickerLocale from '../../TimePicker/Locale/ar_SA';
+import type { PickerLocale } from '../Generate/Generate.types';
+
+const locale: PickerLocale = {
+  lang: {
+    placeholder: 'اختر التاريخ',
+    yearPlaceholder: 'اختر السنة',
+    quarterPlaceholder: 'اختر الربع',
+    monthPlaceholder: 'اختر الشهر',
+    weekPlaceholder: 'اختر الأسبوع',
+    rangePlaceholder: ['تاريخ البداية', 'تاريخ النهاية'],
+    rangeYearPlaceholder: ['سنة البداية', 'سنة النهاية'],
+    rangeQuarterPlaceholder: ['ربع البداية', 'ربع النهاية'],
+    rangeMonthPlaceholder: ['شهر البداية', 'شهر النهاية'],
+    rangeWeekPlaceholder: ['أسبوع البداية', 'أسبوع النهاية'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+export default locale;

--- a/src/components/DateTimePicker/DatePicker/Locale/bg_BG.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/bg_BG.tsx
@@ -1,0 +1,24 @@
+import CalendarLocale from '../../Internal/Locale/bg_BG';
+import TimePickerLocale from '../../TimePicker/Locale/bg_BG';
+import type { PickerLocale } from '../Generate/Generate.types';
+
+const locale: PickerLocale = {
+  lang: {
+    placeholder: 'Изберете дата',
+    yearPlaceholder: 'Изберете година',
+    quarterPlaceholder: 'Изберете тримесечие',
+    monthPlaceholder: 'Изберете месец',
+    weekPlaceholder: 'Изберете седмица',
+    rangePlaceholder: ['Начална дата', 'Крайна дата'],
+    rangeYearPlaceholder: ['Начална година', 'Крайна година'],
+    rangeQuarterPlaceholder: ['Начално тримесечие', 'Крайно тримесечие'],
+    rangeMonthPlaceholder: ['Начален месец', 'Краен месец'],
+    rangeWeekPlaceholder: ['Начална седмица', 'Крайна седмица'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+export default locale;

--- a/src/components/DateTimePicker/DatePicker/Locale/ro_RO.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/ro_RO.tsx
@@ -1,0 +1,24 @@
+import CalendarLocale from '../../Internal/Locale/ro_RO';
+import TimePickerLocale from '../../TimePicker/Locale/ro_RO';
+import type { PickerLocale } from '../Generate/Generate.types';
+
+const locale: PickerLocale = {
+  lang: {
+    placeholder: 'Selectați data',
+    yearPlaceholder: 'Selectați anul',
+    quarterPlaceholder: 'Selectați trimestrul',
+    monthPlaceholder: 'Selectați luna',
+    weekPlaceholder: 'Selectați săptămâna',
+    rangePlaceholder: ['Data de început', 'Data de sfârșit'],
+    rangeYearPlaceholder: ['Anul de început', 'Anul de sfârșit'],
+    rangeQuarterPlaceholder: ['Trimestrul de început', 'Trimestrul de sfârșit'],
+    rangeMonthPlaceholder: ['Luna de început', 'Luna de sfârșit'],
+    rangeWeekPlaceholder: ['Săptămâna de început', 'Săptămâna de sfârșit'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+export default locale;

--- a/src/components/DateTimePicker/DatePicker/Locale/sk_SK.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/sk_SK.tsx
@@ -1,0 +1,24 @@
+import CalendarLocale from '../../Internal/Locale/sk_SK';
+import TimePickerLocale from '../../TimePicker/Locale/sk_SK';
+import type { PickerLocale } from '../Generate/Generate.types';
+
+const locale: PickerLocale = {
+  lang: {
+    placeholder: 'Vyberte dátum',
+    yearPlaceholder: 'Vyberte rok',
+    quarterPlaceholder: 'Vyberte štvrťrok',
+    monthPlaceholder: 'Vyberte mesiac',
+    weekPlaceholder: 'Vyberte týždeň',
+    rangePlaceholder: ['Dátum začiatku', 'Dátum ukončenia'],
+    rangeYearPlaceholder: ['Rok začiatku', 'Rok ukončenia'],
+    rangeQuarterPlaceholder: ['Štvrťrok začiatku', 'Štvrťrok ukončenia'],
+    rangeMonthPlaceholder: ['Mesiac začiatku', 'Mesiac ukončenia'],
+    rangeWeekPlaceholder: ['Týždeň začiatku', 'Týždeň ukončenia'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+export default locale;

--- a/src/components/DateTimePicker/DatePicker/Locale/sr_RS.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/sr_RS.tsx
@@ -1,0 +1,24 @@
+import CalendarLocale from '../../Internal/Locale/sr_RS';
+import TimePickerLocale from '../../TimePicker/Locale/sr_RS';
+import type { PickerLocale } from '../Generate/Generate.types';
+
+const locale: PickerLocale = {
+  lang: {
+    placeholder: 'Izaberite datum',
+    yearPlaceholder: 'Izaberite godinu',
+    quarterPlaceholder: 'Izaberite kvartal',
+    monthPlaceholder: 'Izaberite mesec',
+    weekPlaceholder: 'Izaberite nedelju',
+    rangePlaceholder: ['Početni datum', 'Datum završetka'],
+    rangeYearPlaceholder: ['Početna godina', 'Godina završetka'],
+    rangeQuarterPlaceholder: ['Početni kvartal', 'Kvartal završetka'],
+    rangeMonthPlaceholder: ['Početni mesec', 'Mesec završetka'],
+    rangeWeekPlaceholder: ['Početna nedelja', 'Nedelja završetka'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+export default locale;

--- a/src/components/DateTimePicker/DatePicker/Locale/te_IN.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/te_IN.tsx
@@ -1,0 +1,24 @@
+import CalendarLocale from '../../Internal/Locale/te_IN';
+import TimePickerLocale from '../../TimePicker/Locale/te_IN';
+import type { PickerLocale } from '../Generate/Generate.types';
+
+const locale: PickerLocale = {
+  lang: {
+    placeholder: 'తేదీని ఎంచుకోండి',
+    yearPlaceholder: 'సంవత్సరాన్ని ఎంచుకోండి',
+    quarterPlaceholder: 'త్రైమాసికాన్ని ఎంచుకోండి',
+    monthPlaceholder: 'నెలను ఎంచుకోండి',
+    weekPlaceholder: 'వారాన్ని ఎంచుకోండి',
+    rangePlaceholder: ['ప్రారంభ తేదీ', 'ముగింపు తేదీ'],
+    rangeYearPlaceholder: ['ప్రారంభ సంవత్సరం', 'ముగింపు సంవత్సరం'],
+    rangeQuarterPlaceholder: ['ప్రారంభ త్రైమాసికం', 'ముగింపు త్రైమాసికం'],
+    rangeMonthPlaceholder: ['ప్రారంభ నెల', 'ముగింపు నెల'],
+    rangeWeekPlaceholder: ['ప్రారంభ వారం', 'ముగింపు వారం'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+export default locale;

--- a/src/components/DateTimePicker/DatePicker/Locale/vi_VN.tsx
+++ b/src/components/DateTimePicker/DatePicker/Locale/vi_VN.tsx
@@ -1,0 +1,24 @@
+import CalendarLocale from '../../Internal/Locale/vi_VN';
+import TimePickerLocale from '../../TimePicker/Locale/vi_VN';
+import type { PickerLocale } from '../Generate/Generate.types';
+
+const locale: PickerLocale = {
+  lang: {
+    placeholder: 'Chọn ngày',
+    yearPlaceholder: 'Chọn năm',
+    quarterPlaceholder: 'Chọn quý',
+    monthPlaceholder: 'Chọn tháng',
+    weekPlaceholder: 'Chọn tuần',
+    rangePlaceholder: ['Ngày bắt đầu', 'Ngày kết thúc'],
+    rangeYearPlaceholder: ['Năm bắt đầu', 'Năm kết thúc'],
+    rangeQuarterPlaceholder: ['Quý bắt đầu', 'Quý kết thúc'],
+    rangeMonthPlaceholder: ['Tháng bắt đầu', 'Tháng kết thúc'],
+    rangeWeekPlaceholder: ['Tuần bắt đầu', 'Tuần kết thúc'],
+    ...CalendarLocale,
+  },
+  timePickerLocale: {
+    ...TimePickerLocale,
+  },
+};
+
+export default locale;

--- a/src/components/DateTimePicker/Internal/Generate/dayjs.ts
+++ b/src/components/DateTimePicker/Internal/Generate/dayjs.ts
@@ -29,6 +29,8 @@ dayjs.extend((_o: unknown, c: typeof Dayjs) => {
 // Dayjs currently supported langs: https://github.com/iamkun/dayjs/tree/dev/src/locale
 type IlocaleMapObject = Record<string, string>;
 const localeMap: IlocaleMapObject = {
+  ar_SA: 'ar', // العربية
+  bg_BG: 'bg', // Български
   cs_CZ: 'cs', // čeština
   da_DK: 'da', // Dansk
   de_DE: 'de', // Deutsch
@@ -57,11 +59,16 @@ const localeMap: IlocaleMapObject = {
   pl_PL: 'pl', // Polski
   pt_BR: 'pt-br', // Português (Brazil)
   pt_PT: 'pt', // Português
+  ro_RO: 'ro', // Română
   ru_RU: 'ru', // Pусский
+  sk_SK: 'sk', // Slovenčina
+  sr_RS: 'sr', // Srpski
   sv_SE: 'sv', // Svenska
+  te_IN: 'te', // తెలుగు
   th_TH: 'th', // ภาษาไทย
   tr_TR: 'tr', // Türkçe
   uk_UA: 'uk', // Yкраїнська
+  vi_VN: 'vi', // Tiếng Việt
   zh_CN: 'zh-cn', // 中文 (简体)
   zh_TW: 'zh-tw', // 中文 (繁體)
 };

--- a/src/components/DateTimePicker/Internal/Locale/ar_SA.ts
+++ b/src/components/DateTimePicker/Internal/Locale/ar_SA.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../OcPicker.types';
+
+const locale: Locale = {
+  locale: 'ar_SA',
+  backToToday: 'العودة إلى اليوم',
+  clear: 'مسح',
+  dateFormat: 'D/M/YYYY',
+  dateSelect: 'اختر التاريخ',
+  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
+  dayFormat: 'D',
+  decadeSelect: 'اختر العقد',
+  month: 'الشهر',
+  monthBeforeYear: true,
+  monthSelect: 'اختر الشهر',
+  nextCentury: 'القرن القادم',
+  nextDecade: 'العقد القادم',
+  nextMonth: 'الشهر القادم (PageDown)',
+  nextYear: 'السنة القادمة (Control + right)',
+  now: 'الآن',
+  ok: 'حسنا',
+  previousCentury: 'القرن السابق',
+  previousDecade: 'العقد السابق',
+  previousMonth: 'الشهر السابق (PageUp)',
+  previousYear: 'السنة السابقة (Control + left)',
+  timeSelect: 'اختر الوقت',
+  today: 'اليوم',
+  weekSelect: 'اختر الأسبوع',
+  year: 'السنة',
+  yearFormat: 'YYYY',
+  yearSelect: 'اختر السنة',
+};
+
+export default locale;

--- a/src/components/DateTimePicker/Internal/Locale/bg_BG.ts
+++ b/src/components/DateTimePicker/Internal/Locale/bg_BG.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../OcPicker.types';
+
+const locale: Locale = {
+  locale: 'bg_BG',
+  backToToday: 'Обратно към днес',
+  clear: 'Изчисти',
+  dateFormat: 'D.M.YYYY',
+  dateSelect: 'изберете дата',
+  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
+  dayFormat: 'D',
+  decadeSelect: 'Изберете десетилетие',
+  month: 'Месец',
+  monthBeforeYear: true,
+  monthSelect: 'Изберете месец',
+  nextCentury: 'Следващ век',
+  nextDecade: 'Следващо десетилетие',
+  nextMonth: 'Следващ месец (PageDown)',
+  nextYear: 'Следваща година (Control + дясно)',
+  now: 'Сега',
+  ok: 'Добре',
+  previousCentury: 'Миналия век',
+  previousDecade: 'Миналото десетилетие',
+  previousMonth: 'Предишен месец (PageUp)',
+  previousYear: 'Миналата година (Control + ляво)',
+  timeSelect: 'изберете време',
+  today: 'Днес',
+  weekSelect: 'Изберете седмица',
+  year: 'Година',
+  yearFormat: 'YYYY',
+  yearSelect: 'Изберете година',
+};
+
+export default locale;

--- a/src/components/DateTimePicker/Internal/Locale/ro_RO.ts
+++ b/src/components/DateTimePicker/Internal/Locale/ro_RO.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../OcPicker.types';
+
+const locale: Locale = {
+  locale: 'ro_RO',
+  backToToday: 'Înapoi la azi',
+  clear: 'Șterge',
+  dateFormat: 'D.M.YYYY',
+  dateSelect: 'selectați data',
+  dateTimeFormat: 'D.M.YYYY HH:mm:ss',
+  dayFormat: 'D',
+  decadeSelect: 'Alegeți un deceniu',
+  month: 'Lună',
+  monthBeforeYear: true,
+  monthSelect: 'Alegeți o lună',
+  nextCentury: 'Secolul următor',
+  nextDecade: 'Deceniul următor',
+  nextMonth: 'Luna următoare (PageDown)',
+  nextYear: 'Anul următor (Control + dreapta)',
+  now: 'Acum',
+  ok: 'OK',
+  previousCentury: 'Secolul trecut',
+  previousDecade: 'Deceniul trecut',
+  previousMonth: 'Luna anterioară (PageUp)',
+  previousYear: 'Anul trecut (Control + stânga)',
+  timeSelect: 'selectați ora',
+  today: 'Astăzi',
+  weekSelect: 'Alegeți o săptămână',
+  year: 'An',
+  yearFormat: 'YYYY',
+  yearSelect: 'Alegeți un an',
+};
+
+export default locale;

--- a/src/components/DateTimePicker/Internal/Locale/sk_SK.ts
+++ b/src/components/DateTimePicker/Internal/Locale/sk_SK.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../OcPicker.types';
+
+const locale: Locale = {
+  locale: 'sk_SK',
+  backToToday: 'Späť na dnes',
+  clear: 'Vymazať',
+  dateFormat: 'D/M/YYYY',
+  dateSelect: 'vyberte dátum',
+  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
+  dayFormat: 'D',
+  decadeSelect: 'Vyberte dekádu',
+  month: 'Mesiac',
+  monthBeforeYear: true,
+  monthSelect: 'Vyberte mesiac',
+  nextCentury: 'Ďalšie storočie',
+  nextDecade: 'Ďalšia dekáda',
+  nextMonth: 'Ďalší mesiac (PageDown)',
+  nextYear: 'Ďalší rok (Control + vpravo)',
+  now: 'Teraz',
+  ok: 'OK',
+  previousCentury: 'Predchádzajúce storočie',
+  previousDecade: 'Predchádzajúca dekáda',
+  previousMonth: 'Predchádzajúci mesiac (PageUp)',
+  previousYear: 'Predchádzajúci rok (Control + vľavo)',
+  timeSelect: 'vyberte čas',
+  today: 'Dnes',
+  weekSelect: 'Vyberte týždeň',
+  year: 'Rok',
+  yearFormat: 'YYYY',
+  yearSelect: 'Vyberte rok',
+};
+
+export default locale;

--- a/src/components/DateTimePicker/Internal/Locale/sr_RS.ts
+++ b/src/components/DateTimePicker/Internal/Locale/sr_RS.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../OcPicker.types';
+
+const locale: Locale = {
+  locale: 'sr_RS',
+  backToToday: 'Nazad na danas',
+  clear: 'Očisti',
+  dateFormat: 'D/M/YYYY',
+  dateSelect: 'izaberi datum',
+  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
+  dayFormat: 'D',
+  decadeSelect: 'Izaberi deceniju',
+  month: 'Mesec',
+  monthBeforeYear: true,
+  monthSelect: 'Izaberi mesec',
+  nextCentury: 'Sledeći vek',
+  nextDecade: 'Sledeća decenija',
+  nextMonth: 'Sledeći mesec (PageDown)',
+  nextYear: 'Sledeća godina (Control + desno)',
+  now: 'Sada',
+  ok: 'U redu',
+  previousCentury: 'Prošli vek',
+  previousDecade: 'Prošla decenija',
+  previousMonth: 'Prethodni mesec (PageUp)',
+  previousYear: 'Prošla godina (Control + levo)',
+  timeSelect: 'izaberi vreme',
+  today: 'Danas',
+  weekSelect: 'Izaberi nedelju',
+  year: 'Godina',
+  yearFormat: 'YYYY',
+  yearSelect: 'Izaberi godinu',
+};
+
+export default locale;

--- a/src/components/DateTimePicker/Internal/Locale/te_IN.ts
+++ b/src/components/DateTimePicker/Internal/Locale/te_IN.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../OcPicker.types';
+
+const locale: Locale = {
+  locale: 'te_IN',
+  backToToday: 'ఈ రోజుకు తిరిగి వెళ్ళు',
+  clear: 'క్లియర్',
+  dateFormat: 'D/M/YYYY',
+  dateSelect: 'తేదీని ఎంచుకోండి',
+  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
+  dayFormat: 'D',
+  decadeSelect: 'దశాబ్దాన్ని ఎంచుకోండి',
+  month: 'నెల',
+  monthBeforeYear: true,
+  monthSelect: 'నెలను ఎంచుకోండి',
+  nextCentury: 'తదుపరి శతాబ్దం',
+  nextDecade: 'తదుపరి దశాబ్దం',
+  nextMonth: 'తదుపరి నెల (PageDown)',
+  nextYear: 'తదుపరి సంవత్సరం (Control + right)',
+  now: 'ఇప్పుడు',
+  ok: 'సరే',
+  previousCentury: 'గత శతాబ్దం',
+  previousDecade: 'గత దశాబ్దం',
+  previousMonth: 'మునుపటి నెల (PageUp)',
+  previousYear: 'గత సంవత్సరం (Control + left)',
+  timeSelect: 'సమయాన్ని ఎంచుకోండి',
+  today: 'ఈ రోజు',
+  weekSelect: 'వారాన్ని ఎంచుకోండి',
+  year: 'సంవత్సరం',
+  yearFormat: 'YYYY',
+  yearSelect: 'సంవత్సరాన్ని ఎంచుకోండి',
+};
+
+export default locale;

--- a/src/components/DateTimePicker/Internal/Locale/vi_VN.ts
+++ b/src/components/DateTimePicker/Internal/Locale/vi_VN.ts
@@ -1,0 +1,33 @@
+import type { Locale } from '../OcPicker.types';
+
+const locale: Locale = {
+  locale: 'vi_VN',
+  backToToday: 'Quay lại hôm nay',
+  clear: 'Xóa',
+  dateFormat: 'D/M/YYYY',
+  dateSelect: 'chọn ngày',
+  dateTimeFormat: 'D/M/YYYY HH:mm:ss',
+  dayFormat: 'D',
+  decadeSelect: 'Chọn một thập kỷ',
+  month: 'Tháng',
+  monthBeforeYear: true,
+  monthSelect: 'Chọn một tháng',
+  nextCentury: 'Thế kỷ tiếp theo',
+  nextDecade: 'Thập kỷ tiếp theo',
+  nextMonth: 'Tháng tiếp theo (PageDown)',
+  nextYear: 'Năm tiếp theo (Control + phải)',
+  now: 'Bây giờ',
+  ok: 'Đồng ý',
+  previousCentury: 'Thế kỷ trước',
+  previousDecade: 'Thập kỷ trước',
+  previousMonth: 'Tháng trước (PageUp)',
+  previousYear: 'Năm trước (Control + trái)',
+  timeSelect: 'chọn thời gian',
+  today: 'Hôm nay',
+  weekSelect: 'Chọn một tuần',
+  year: 'Năm',
+  yearFormat: 'YYYY',
+  yearSelect: 'Chọn một năm',
+};
+
+export default locale;

--- a/src/components/DateTimePicker/TimePicker/Locale/ar_SA.tsx
+++ b/src/components/DateTimePicker/TimePicker/Locale/ar_SA.tsx
@@ -1,0 +1,8 @@
+import type { TimePickerLocale } from '../TimePicker.types';
+
+const locale: TimePickerLocale = {
+  placeholder: 'اختر الوقت',
+  rangePlaceholder: ['وقت البداية', 'وقت النهاية'],
+};
+
+export default locale;

--- a/src/components/DateTimePicker/TimePicker/Locale/bg_BG.tsx
+++ b/src/components/DateTimePicker/TimePicker/Locale/bg_BG.tsx
@@ -1,0 +1,8 @@
+import type { TimePickerLocale } from '../TimePicker.types';
+
+const locale: TimePickerLocale = {
+  placeholder: 'Изберете време',
+  rangePlaceholder: ['Начално време', 'Крайно време'],
+};
+
+export default locale;

--- a/src/components/DateTimePicker/TimePicker/Locale/ro_RO.tsx
+++ b/src/components/DateTimePicker/TimePicker/Locale/ro_RO.tsx
@@ -1,0 +1,8 @@
+import type { TimePickerLocale } from '../TimePicker.types';
+
+const locale: TimePickerLocale = {
+  placeholder: 'Selectați ora',
+  rangePlaceholder: ['Ora de început', 'Ora de sfârșit'],
+};
+
+export default locale;

--- a/src/components/DateTimePicker/TimePicker/Locale/sk_SK.tsx
+++ b/src/components/DateTimePicker/TimePicker/Locale/sk_SK.tsx
@@ -1,0 +1,8 @@
+import type { TimePickerLocale } from '../TimePicker.types';
+
+const locale: TimePickerLocale = {
+  placeholder: 'Vyberte čas',
+  rangePlaceholder: ['Čas začiatku', 'Čas ukončenia'],
+};
+
+export default locale;

--- a/src/components/DateTimePicker/TimePicker/Locale/sr_RS.tsx
+++ b/src/components/DateTimePicker/TimePicker/Locale/sr_RS.tsx
@@ -1,0 +1,8 @@
+import type { TimePickerLocale } from '../TimePicker.types';
+
+const locale: TimePickerLocale = {
+  placeholder: 'Izaberite vreme',
+  rangePlaceholder: ['Početno vreme', 'Vreme završetka'],
+};
+
+export default locale;

--- a/src/components/DateTimePicker/TimePicker/Locale/te_IN.tsx
+++ b/src/components/DateTimePicker/TimePicker/Locale/te_IN.tsx
@@ -1,0 +1,8 @@
+import type { TimePickerLocale } from '../TimePicker.types';
+
+const locale: TimePickerLocale = {
+  placeholder: 'సమయాన్ని ఎంచుకోండి',
+  rangePlaceholder: ['ప్రారంభ సమయం', 'ముగింపు సమయం'],
+};
+
+export default locale;

--- a/src/components/DateTimePicker/TimePicker/Locale/vi_VN.tsx
+++ b/src/components/DateTimePicker/TimePicker/Locale/vi_VN.tsx
@@ -1,0 +1,8 @@
+import type { TimePickerLocale } from '../TimePicker.types';
+
+const locale: TimePickerLocale = {
+  placeholder: 'Chọn thời gian',
+  rangePlaceholder: ['Thời gian bắt đầu', 'Thời gian kết thúc'],
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/ar_SA.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ar_SA.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+  lang: {
+    locale: 'ar_SA',
+    cancelText: 'إلغاء',
+    closeButtonAriaLabelText: 'إغلاق',
+    okText: 'حسنا',
+  },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/bg_BG.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/bg_BG.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+  lang: {
+    locale: 'bg_BG',
+    cancelText: 'Отказ',
+    closeButtonAriaLabelText: 'Затвори',
+    okText: 'Добре',
+  },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/ro_RO.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/ro_RO.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+  lang: {
+    locale: 'ro_RO',
+    cancelText: 'Anulează',
+    closeButtonAriaLabelText: 'Închide',
+    okText: 'OK',
+  },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/sk_SK.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/sk_SK.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+  lang: {
+    locale: 'sk_SK',
+    cancelText: 'Zrušiť',
+    closeButtonAriaLabelText: 'Zavrieť',
+    okText: 'OK',
+  },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/sr_RS.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/sr_RS.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+  lang: {
+    locale: 'sr_RS',
+    cancelText: 'Otkaži',
+    closeButtonAriaLabelText: 'Zatvori',
+    okText: 'U redu',
+  },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/te_IN.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/te_IN.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+  lang: {
+    locale: 'te_IN',
+    cancelText: 'రద్దు చేయండి',
+    closeButtonAriaLabelText: 'మూసివేయండి',
+    okText: 'సరే',
+  },
+};
+
+export default locale;

--- a/src/components/Dialog/BaseDialog/Locale/vi_VN.tsx
+++ b/src/components/Dialog/BaseDialog/Locale/vi_VN.tsx
@@ -1,0 +1,12 @@
+import type { DialogLocale } from '../BaseDialog.types';
+
+const locale: DialogLocale = {
+  lang: {
+    locale: 'vi_VN',
+    cancelText: 'Hủy bỏ',
+    closeButtonAriaLabelText: 'Đóng',
+    okText: 'Đồng ý',
+  },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/ar_SA.tsx
+++ b/src/components/InfoBar/Locale/ar_SA.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+  lang: {
+    locale: 'ar_SA',
+    closeButtonAriaLabelText: 'إغلاق',
+  },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/bg_BG.tsx
+++ b/src/components/InfoBar/Locale/bg_BG.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+  lang: {
+    locale: 'bg_BG',
+    closeButtonAriaLabelText: 'Затвори',
+  },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/ro_RO.tsx
+++ b/src/components/InfoBar/Locale/ro_RO.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+  lang: {
+    locale: 'ro_RO',
+    closeButtonAriaLabelText: 'Închide',
+  },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/sk_SK.tsx
+++ b/src/components/InfoBar/Locale/sk_SK.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+  lang: {
+    locale: 'sk_SK',
+    closeButtonAriaLabelText: 'Zavrieť',
+  },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/sr_RS.tsx
+++ b/src/components/InfoBar/Locale/sr_RS.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+  lang: {
+    locale: 'sr_RS',
+    closeButtonAriaLabelText: 'Zatvori',
+  },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/te_IN.tsx
+++ b/src/components/InfoBar/Locale/te_IN.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+  lang: {
+    locale: 'te_IN',
+    closeButtonAriaLabelText: 'మూసివేయండి',
+  },
+};
+
+export default locale;

--- a/src/components/InfoBar/Locale/vi_VN.tsx
+++ b/src/components/InfoBar/Locale/vi_VN.tsx
@@ -1,0 +1,10 @@
+import type { InfoBarLocale } from '../InfoBar.types';
+
+const locale: InfoBarLocale = {
+  lang: {
+    locale: 'vi_VN',
+    closeButtonAriaLabelText: 'Đóng',
+  },
+};
+
+export default locale;

--- a/src/components/Locale/ar_SA.tsx
+++ b/src/components/Locale/ar_SA.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Locale } from '../LocaleProvider';
+import Breadcrumb from '../Breadcrumb/Locale/ar_SA';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/ar_SA';
+import Dialog from '../Dialog/BaseDialog/Locale/ar_SA';
+import InfoBar from '../InfoBar/Locale/ar_SA';
+import Pagination from '../Pagination/Locale/ar_SA';
+import Panel from '../Panel/Locale/ar_SA';
+import PersistentBar from '../PersistentBar/Locale/ar_SA';
+import Stepper from '../Stepper/Locale/ar_SA';
+import Table from '../Table/Locale/ar_SA';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/ar_SA';
+import Upload from '../Upload/Locale/ar_SA';
+
+const typeTemplate = '${label} ليس ${type} صالحًا';
+
+const localeValues: Locale = {
+  locale: 'ar',
+  global: {
+    placeholder: 'اختر',
+  },
+  Breadcrumb,
+  DatePicker,
+  Dialog,
+  Form: {
+    optional: '(اختياري)',
+    defaultValidateMessages: {
+      default: 'خطأ في التحقق من صحة الحقل ${label}',
+      required: '${label} مطلوب',
+      enum: '${label} يجب أن يكون واحدًا من [${enum}]',
+      whitespace: '${label} لا يمكن أن يكون حرفًا فارغًا',
+      date: {
+        format: 'تنسيق التاريخ ${label} غير صالح',
+        parse: 'لا يمكن تحويل ${label} إلى تاريخ',
+        invalid: '${label} هو تاريخ غير صالح',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: 'يجب أن يكون ${label} ${len} حروف',
+        min: 'يجب أن يكون ${label} على الأقل ${min} حروف',
+        max: 'يجب أن يكون ${label} حتى ${max} حروف',
+        range: 'يجب أن يكون ${label} بين ${min}-${max} حروف',
+      },
+      number: {
+        len: 'يجب أن يكون ${label} مساويا لـ ${len}',
+        min: 'يجب أن يكون ${label} الحد الأدنى ${min}',
+        max: 'يجب أن يكون ${label} الحد الأقصى ${max}',
+        range: 'يجب أن يكون ${label} بين ${min}-${max}',
+      },
+      array: {
+        len: 'يجب أن يكون ${len} ${label}',
+        min: 'على الأقل ${min} ${label}',
+        max: 'على الأكثر ${max} ${label}',
+        range: 'يجب أن يكون مقدار ${label} بين ${min}-${max}',
+      },
+      pattern: {
+        mismatch: '${label} لا يتطابق مع النمط ${pattern}',
+      },
+    },
+  },
+  InfoBar,
+  Pagination,
+  Panel,
+  PersistentBar,
+  Stepper,
+  Table,
+  TimePicker,
+  Upload,
+};
+
+export default localeValues;

--- a/src/components/Locale/bg_BG.tsx
+++ b/src/components/Locale/bg_BG.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Locale } from '../LocaleProvider';
+import Breadcrumb from '../Breadcrumb/Locale/bg_BG';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/bg_BG';
+import Dialog from '../Dialog/BaseDialog/Locale/bg_BG';
+import InfoBar from '../InfoBar/Locale/bg_BG';
+import Pagination from '../Pagination/Locale/bg_BG';
+import Panel from '../Panel/Locale/bg_BG';
+import PersistentBar from '../PersistentBar/Locale/bg_BG';
+import Stepper from '../Stepper/Locale/bg_BG';
+import Table from '../Table/Locale/bg_BG';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/bg_BG';
+import Upload from '../Upload/Locale/bg_BG';
+
+const typeTemplate = '${label} не е валиден ${type}';
+
+const localeValues: Locale = {
+  locale: 'bg',
+  global: {
+    placeholder: 'Изберете',
+  },
+  Breadcrumb,
+  DatePicker,
+  Dialog,
+  Form: {
+    optional: '(по избор)',
+    defaultValidateMessages: {
+      default: 'Грешка при валидация на полето за ${label}',
+      required: '${label} е задължително',
+      enum: '${label} трябва да бъде едно от [${enum}]',
+      whitespace: '${label} не може да бъде празен символ',
+      date: {
+        format: 'Форматът на датата ${label} е невалиден',
+        parse: '${label} не може да бъде преобразувано в дата',
+        invalid: '${label} е невалидна дата',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} трябва да бъде ${len} символа',
+        min: '${label} трябва да бъде поне ${min} символа',
+        max: '${label} трябва да бъде до ${max} символа',
+        range: '${label} трябва да бъде между ${min}-${max} символа',
+      },
+      number: {
+        len: '${label} трябва да бъде равно на ${len}',
+        min: '${label} трябва да бъде минимум ${min}',
+        max: '${label} трябва да бъде максимум ${max}',
+        range: '${label} трябва да бъде между ${min}-${max}',
+      },
+      array: {
+        len: 'Трябва да бъде ${len} ${label}',
+        min: 'Поне ${min} ${label}',
+        max: 'Най-много ${max} ${label}',
+        range: 'Броят на ${label} трябва да бъде между ${min}-${max}',
+      },
+      pattern: {
+        mismatch: '${label} не съответства на модела ${pattern}',
+      },
+    },
+  },
+  InfoBar,
+  Pagination,
+  Panel,
+  PersistentBar,
+  Stepper,
+  Table,
+  TimePicker,
+  Upload,
+};
+
+export default localeValues;

--- a/src/components/Locale/ro_RO.tsx
+++ b/src/components/Locale/ro_RO.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Locale } from '../LocaleProvider';
+import Breadcrumb from '../Breadcrumb/Locale/ro_RO';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/ro_RO';
+import Dialog from '../Dialog/BaseDialog/Locale/ro_RO';
+import InfoBar from '../InfoBar/Locale/ro_RO';
+import Pagination from '../Pagination/Locale/ro_RO';
+import Panel from '../Panel/Locale/ro_RO';
+import PersistentBar from '../PersistentBar/Locale/ro_RO';
+import Stepper from '../Stepper/Locale/ro_RO';
+import Table from '../Table/Locale/ro_RO';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/ro_RO';
+import Upload from '../Upload/Locale/ro_RO';
+
+const typeTemplate = '${label} nu este un ${type} valid';
+
+const localeValues: Locale = {
+  locale: 'ro',
+  global: {
+    placeholder: 'Selectați',
+  },
+  Breadcrumb,
+  DatePicker,
+  Dialog,
+  Form: {
+    optional: '(opțional)',
+    defaultValidateMessages: {
+      default: 'Eroare de validare a câmpului pentru ${label}',
+      required: '${label} este necesar',
+      enum: '${label} trebuie să fie unul dintre [${enum}]',
+      whitespace: '${label} nu poate fi un caracter gol',
+      date: {
+        format: 'Formatul datei ${label} este invalid',
+        parse: '${label} nu poate fi convertit într-o dată',
+        invalid: '${label} este o dată invalidă',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} trebuie să aibă ${len} caractere',
+        min: '${label} trebuie să aibă cel puțin ${min} caractere',
+        max: '${label} trebuie să aibă până la ${max} caractere',
+        range: '${label} trebuie să aibă între ${min}-${max} caractere',
+      },
+      number: {
+        len: '${label} trebuie să fie egal cu ${len}',
+        min: '${label} trebuie să fie minim ${min}',
+        max: '${label} trebuie să fie maxim ${max}',
+        range: '${label} trebuie să fie între ${min}-${max}',
+      },
+      array: {
+        len: 'Trebuie să fie ${len} ${label}',
+        min: 'Cel puțin ${min} ${label}',
+        max: 'Cel mult ${max} ${label}',
+        range: 'Cantitatea de ${label} trebuie să fie între ${min}-${max}',
+      },
+      pattern: {
+        mismatch: '${label} nu se potrivește cu modelul ${pattern}',
+      },
+    },
+  },
+  InfoBar,
+  Pagination,
+  Panel,
+  PersistentBar,
+  Stepper,
+  Table,
+  TimePicker,
+  Upload,
+};
+
+export default localeValues;

--- a/src/components/Locale/sk_SK.tsx
+++ b/src/components/Locale/sk_SK.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Locale } from '../LocaleProvider';
+import Breadcrumb from '../Breadcrumb/Locale/sk_SK';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/sk_SK';
+import Dialog from '../Dialog/BaseDialog/Locale/sk_SK';
+import InfoBar from '../InfoBar/Locale/sk_SK';
+import Pagination from '../Pagination/Locale/sk_SK';
+import Panel from '../Panel/Locale/sk_SK';
+import PersistentBar from '../PersistentBar/Locale/sk_SK';
+import Stepper from '../Stepper/Locale/sk_SK';
+import Table from '../Table/Locale/sk_SK';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/sk_SK';
+import Upload from '../Upload/Locale/sk_SK';
+
+const typeTemplate = '${label} nie je platný ${type}';
+
+const localeValues: Locale = {
+  locale: 'sk',
+  global: {
+    placeholder: 'Vyberte',
+  },
+  Breadcrumb,
+  DatePicker,
+  Dialog,
+  Form: {
+    optional: '(voliteľné)',
+    defaultValidateMessages: {
+      default: 'Chyba overenia polia pre ${label}',
+      required: '${label} je povinné',
+      enum: '${label} musí byť jedno z [${enum}]',
+      whitespace: '${label} nemôže byť prázdny znak',
+      date: {
+        format: 'Formát dátumu ${label} je neplatný',
+        parse: '${label} nie je možné previesť na dátum',
+        invalid: '${label} je neplatný dátum',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} musí mať ${len} znakov',
+        min: '${label} musí mať aspoň ${min} znakov',
+        max: '${label} musí mať najviac ${max} znakov',
+        range: '${label} musí byť medzi ${min}-${max} znakmi',
+      },
+      number: {
+        len: '${label} musí byť rovné ${len}',
+        min: '${label} musí byť minimálne ${min}',
+        max: '${label} musí byť maximálne ${max}',
+        range: '${label} musí byť medzi ${min}-${max}',
+      },
+      array: {
+        len: 'Musí byť ${len} ${label}',
+        min: 'Aspoň ${min} ${label}',
+        max: 'Najviac ${max} ${label}',
+        range: 'Počet ${label} musí byť medzi ${min}-${max}',
+      },
+      pattern: {
+        mismatch: '${label} sa nezhoduje s vzorom ${pattern}',
+      },
+    },
+  },
+  InfoBar,
+  Pagination,
+  Panel,
+  PersistentBar,
+  Stepper,
+  Table,
+  TimePicker,
+  Upload,
+};
+
+export default localeValues;

--- a/src/components/Locale/sr_RS.tsx
+++ b/src/components/Locale/sr_RS.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Locale } from '../LocaleProvider';
+import Breadcrumb from '../Breadcrumb/Locale/sr_RS';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/sr_RS';
+import Dialog from '../Dialog/BaseDialog/Locale/sr_RS';
+import InfoBar from '../InfoBar/Locale/sr_RS';
+import Pagination from '../Pagination/Locale/sr_RS';
+import Panel from '../Panel/Locale/sr_RS';
+import PersistentBar from '../PersistentBar/Locale/sr_RS';
+import Stepper from '../Stepper/Locale/sr_RS';
+import Table from '../Table/Locale/sr_RS';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/sr_RS';
+import Upload from '../Upload/Locale/sr_RS';
+
+const typeTemplate = '${label} nije validan ${type}';
+
+const localeValues: Locale = {
+  locale: 'sr',
+  global: {
+    placeholder: 'Izaberi',
+  },
+  Breadcrumb,
+  DatePicker,
+  Dialog,
+  Form: {
+    optional: '(opciono)',
+    defaultValidateMessages: {
+      default: 'Greška pri validaciji polja za ${label}',
+      required: '${label} je obavezno',
+      enum: '${label} mora biti jedan od [${enum}]',
+      whitespace: '${label} ne može biti prazan karakter',
+      date: {
+        format: 'Format datuma ${label} je nevažeći',
+        parse: '${label} ne može biti konvertovan u datum',
+        invalid: '${label} je nevažeći datum',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} mora biti ${len} karaktera',
+        min: '${label} mora biti najmanje ${min} karaktera',
+        max: '${label} mora biti do ${max} karaktera',
+        range: '${label} mora biti između ${min}-${max} karaktera',
+      },
+      number: {
+        len: '${label} mora biti jednako ${len}',
+        min: '${label} mora biti minimalno ${min}',
+        max: '${label} mora biti maksimalno ${max}',
+        range: '${label} mora biti između ${min}-${max}',
+      },
+      array: {
+        len: 'Mora biti ${len} ${label}',
+        min: 'Najmanje ${min} ${label}',
+        max: 'Najviše ${max} ${label}',
+        range: 'Količina ${label} mora biti između ${min}-${max}',
+      },
+      pattern: {
+        mismatch: '${label} se ne podudara sa šablonom ${pattern}',
+      },
+    },
+  },
+  InfoBar,
+  Pagination,
+  Panel,
+  PersistentBar,
+  Stepper,
+  Table,
+  TimePicker,
+  Upload,
+};
+
+export default localeValues;

--- a/src/components/Locale/te_IN.tsx
+++ b/src/components/Locale/te_IN.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Locale } from '../LocaleProvider';
+import Breadcrumb from '../Breadcrumb/Locale/te_IN';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/te_IN';
+import Dialog from '../Dialog/BaseDialog/Locale/te_IN';
+import InfoBar from '../InfoBar/Locale/te_IN';
+import Pagination from '../Pagination/Locale/te_IN';
+import Panel from '../Panel/Locale/te_IN';
+import PersistentBar from '../PersistentBar/Locale/te_IN';
+import Stepper from '../Stepper/Locale/te_IN';
+import Table from '../Table/Locale/te_IN';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/te_IN';
+import Upload from '../Upload/Locale/te_IN';
+
+const typeTemplate = '${label} సరైన ${type} కాదు';
+
+const localeValues: Locale = {
+  locale: 'te',
+  global: {
+    placeholder: 'ఎంచుకోండి',
+  },
+  Breadcrumb,
+  DatePicker,
+  Dialog,
+  Form: {
+    optional: '(ఐచ్ఛికం)',
+    defaultValidateMessages: {
+      default: '${label} కోసం ఫీల్డ్ ధృవీకరణ లోపం',
+      required: '${label} అవసరం',
+      enum: '${label} [${enum}] లో ఒకటి ఉండాలి',
+      whitespace: '${label} ఖాళీ అక్షరం ఉండకూడదు',
+      date: {
+        format: '${label} తేదీ ఫార్మాట్ చెల్లదు',
+        parse: '${label} తేదీగా మార్చలేము',
+        invalid: '${label} చెల్లని తేదీ',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} క్యారెక్టర్లు ${len} ఉండాలి',
+        min: '${label} కనీసం ${min} క్యారెక్టర్లు ఉండాలి',
+        max: '${label} గరిష్ఠం ${max} క్యారెక్టర్లు ఉండాలి',
+        range: '${label} ${min}-${max} క్యారెక్టర్ల మధ్య ఉండాలి',
+      },
+      number: {
+        len: '${label} ${len} కి సమానం ఉండాలి',
+        min: '${label} కనీసం ${min} ఉండాలి',
+        max: '${label} గరిష్ఠం ${max} ఉండాలి',
+        range: '${label} ${min}-${max} మధ్య ఉండాలి',
+      },
+      array: {
+        len: '${len} ${label} ఉండాలి',
+        min: '${min} ${label} కనీసం ఉండాలి',
+        max: '${max} ${label} గరిష్ఠం ఉండాలి',
+        range: '${label} యొక్క సంఖ్య ${min}-${max} మధ్య ఉండాలి',
+      },
+      pattern: {
+        mismatch: '${label} మోడల్ ${pattern} తో సరిపోలడం లేదు',
+      },
+    },
+  },
+  InfoBar,
+  Pagination,
+  Panel,
+  PersistentBar,
+  Stepper,
+  Table,
+  TimePicker,
+  Upload,
+};
+
+export default localeValues;

--- a/src/components/Locale/vi_VN.tsx
+++ b/src/components/Locale/vi_VN.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-template-curly-in-string */
+import type { Locale } from '../LocaleProvider';
+import Breadcrumb from '../Breadcrumb/Locale/vi_VN';
+import DatePicker from '../DateTimePicker/DatePicker/Locale/vi_VN';
+import Dialog from '../Dialog/BaseDialog/Locale/vi_VN';
+import InfoBar from '../InfoBar/Locale/vi_VN';
+import Pagination from '../Pagination/Locale/vi_VN';
+import Panel from '../Panel/Locale/vi_VN';
+import PersistentBar from '../PersistentBar/Locale/vi_VN';
+import Stepper from '../Stepper/Locale/vi_VN';
+import Table from '../Table/Locale/vi_VN';
+import TimePicker from '../DateTimePicker/TimePicker/Locale/vi_VN';
+import Upload from '../Upload/Locale/vi_VN';
+
+const typeTemplate = '${label} không phải là một ${type} hợp lệ';
+
+const localeValues: Locale = {
+  locale: 'vi',
+  global: {
+    placeholder: 'Chọn',
+  },
+  Breadcrumb,
+  DatePicker,
+  Dialog,
+  Form: {
+    optional: '(tùy chọn)',
+    defaultValidateMessages: {
+      default: 'Lỗi xác thực trường cho ${label}',
+      required: '${label} là bắt buộc',
+      enum: '${label} phải là một trong số [${enum}]',
+      whitespace: '${label} không thể là một ký tự trắng',
+      date: {
+        format: 'Định dạng ngày ${label} không hợp lệ',
+        parse: '${label} không thể chuyển đổi thành ngày',
+        invalid: '${label} là một ngày không hợp lệ',
+      },
+      types: {
+        string: typeTemplate,
+        method: typeTemplate,
+        array: typeTemplate,
+        object: typeTemplate,
+        number: typeTemplate,
+        date: typeTemplate,
+        boolean: typeTemplate,
+        integer: typeTemplate,
+        float: typeTemplate,
+        regexp: typeTemplate,
+        email: typeTemplate,
+        url: typeTemplate,
+        hex: typeTemplate,
+      },
+      string: {
+        len: '${label} phải có ${len} ký tự',
+        min: '${label} phải có ít nhất ${min} ký tự',
+        max: '${label} phải có tối đa ${max} ký tự',
+        range: '${label} phải nằm trong khoảng từ ${min} đến ${max} ký tự',
+      },
+      number: {
+        len: '${label} phải bằng ${len}',
+        min: '${label} phải tối thiểu là ${min}',
+        max: '${label} phải tối đa là ${max}',
+        range: '${label} phải nằm trong khoảng từ ${min} đến ${max}',
+      },
+      array: {
+        len: 'Phải có ${len} ${label}',
+        min: 'Ít nhất ${min} ${label}',
+        max: 'Tối đa ${max} ${label}',
+        range: 'Số lượng ${label} phải nằm trong khoảng từ ${min} đến ${max}',
+      },
+      pattern: {
+        mismatch: '${label} không khớp với mẫu ${pattern}',
+      },
+    },
+  },
+  InfoBar,
+  Pagination,
+  Panel,
+  PersistentBar,
+  Stepper,
+  Table,
+  TimePicker,
+  Upload,
+};
+
+export default localeValues;

--- a/src/components/LocaleProvider/Tests/__snapshots__/index.test.js.snap
+++ b/src/components/LocaleProvider/Tests/__snapshots__/index.test.js.snap
@@ -30,6 +30,26 @@ LoadedCheerio {
 }
 `;
 
+exports[`Locale Provider should display the text as ar 1`] = `
+LoadedCheerio {
+  "length": 0,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;
+
+exports[`Locale Provider should display the text as bg 1`] = `
+LoadedCheerio {
+  "length": 0,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;
+
 exports[`Locale Provider should display the text as cs 1`] = `
 LoadedCheerio {
   "length": 0,
@@ -310,6 +330,16 @@ LoadedCheerio {
 }
 `;
 
+exports[`Locale Provider should display the text as ro 1`] = `
+LoadedCheerio {
+  "length": 0,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;
+
 exports[`Locale Provider should display the text as ru 1`] = `
 LoadedCheerio {
   "length": 0,
@@ -320,7 +350,37 @@ LoadedCheerio {
 }
 `;
 
+exports[`Locale Provider should display the text as sk 1`] = `
+LoadedCheerio {
+  "length": 0,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;
+
+exports[`Locale Provider should display the text as sr 1`] = `
+LoadedCheerio {
+  "length": 0,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;
+
 exports[`Locale Provider should display the text as sv 1`] = `
+LoadedCheerio {
+  "length": 0,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;
+
+exports[`Locale Provider should display the text as te 1`] = `
 LoadedCheerio {
   "length": 0,
   "options": Object {
@@ -351,6 +411,16 @@ LoadedCheerio {
 `;
 
 exports[`Locale Provider should display the text as uk 1`] = `
+LoadedCheerio {
+  "length": 0,
+  "options": Object {
+    "decodeEntities": true,
+    "xml": false,
+  },
+}
+`;
+
+exports[`Locale Provider should display the text as vi 1`] = `
 LoadedCheerio {
   "length": 0,
   "options": Object {

--- a/src/components/LocaleProvider/Tests/index.test.js
+++ b/src/components/LocaleProvider/Tests/index.test.js
@@ -12,6 +12,8 @@ import { Modal } from '../../Modal';
 import { Pagination } from '../../Pagination';
 import { Select } from '../../Select';
 import { Table } from '../../Table';
+import arSA from '../ar_SA';
+import bgBG from '../bg_BG';
 import csCZ from '../cs_CZ';
 import daDK from '../da_DK';
 import deDE from '../de_DE';
@@ -40,11 +42,16 @@ import nlNL from '../nl_NL';
 import plPL from '../pl_PL';
 import ptBR from '../pt_BR';
 import ptPT from '../pt_PT';
+import roRO from '../ro_RO';
 import ruRU from '../ru_RU';
+import skSK from '../sk_SK';
+import srRS from '../sr_RS';
 import svSE from '../sv_SE';
+import teIN from '../te_IN';
 import thTH from '../th_TH';
 import trTR from '../tr_TR';
 import ukUA from '../uk_UA';
+import viVN from '../vi_VN';
 import zhCN from '../zh_CN';
 import zhTW from '../zh_TW';
 
@@ -53,6 +60,8 @@ Enzyme.configure({ adapter: new Adapter() });
 let matchMedia;
 
 const locales = [
+  arSA,
+  bgBG,
   csCZ,
   daDK,
   deDE,
@@ -81,11 +90,16 @@ const locales = [
   plPL,
   ptBR,
   ptPT,
+  roRO,
   ruRU,
+  skSK,
+  srRS,
   svSE,
+  teIN,
   thTH,
   trTR,
   ukUA,
+  viVN,
   zhCN,
   zhTW,
 ];

--- a/src/components/LocaleProvider/ar_SA.tsx
+++ b/src/components/LocaleProvider/ar_SA.tsx
@@ -1,0 +1,3 @@
+import locale from '../Locale/ar_SA';
+
+export default locale;

--- a/src/components/LocaleProvider/bg_BG.tsx
+++ b/src/components/LocaleProvider/bg_BG.tsx
@@ -1,0 +1,3 @@
+import locale from '../Locale/bg_BG';
+
+export default locale;

--- a/src/components/LocaleProvider/ro_RO.tsx
+++ b/src/components/LocaleProvider/ro_RO.tsx
@@ -1,0 +1,3 @@
+import locale from '../Locale/ro_RO';
+
+export default locale;

--- a/src/components/LocaleProvider/sk_SK.tsx
+++ b/src/components/LocaleProvider/sk_SK.tsx
@@ -1,0 +1,3 @@
+import locale from '../Locale/sk_SK';
+
+export default locale;

--- a/src/components/LocaleProvider/sr_RS.tsx
+++ b/src/components/LocaleProvider/sr_RS.tsx
@@ -1,0 +1,3 @@
+import locale from '../Locale/sr_RS';
+
+export default locale;

--- a/src/components/LocaleProvider/te_IN.tsx
+++ b/src/components/LocaleProvider/te_IN.tsx
@@ -1,0 +1,3 @@
+import locale from '../Locale/te_IN';
+
+export default locale;

--- a/src/components/LocaleProvider/vi_VN.tsx
+++ b/src/components/LocaleProvider/vi_VN.tsx
@@ -1,0 +1,3 @@
+import locale from '../Locale/vi_VN';
+
+export default locale;

--- a/src/components/Pagination/Locale/ar_SA.tsx
+++ b/src/components/Pagination/Locale/ar_SA.tsx
@@ -1,0 +1,18 @@
+import type { PaginationLocale } from '../Pagination.types';
+
+const locale: PaginationLocale = {
+  lang: {
+    locale: 'ar_SA',
+    goToText: 'اذهب إلى',
+    nextIconButtonAriaLabel: 'التالي',
+    pagerText: 'من',
+    pageSizeButtonAriaLabel: 'حجم الصفحة المحدد',
+    pageSizeText: 'صفحة',
+    previousIconButtonAriaLabel: 'السابق',
+    quickNextIconButtonAriaLabel: 'التالي 5',
+    quickPreviousIconButtonAriaLabel: 'السابق 5',
+    totalText: 'الإجمالي',
+  },
+};
+
+export default locale;

--- a/src/components/Pagination/Locale/bg_BG.tsx
+++ b/src/components/Pagination/Locale/bg_BG.tsx
@@ -1,0 +1,18 @@
+import type { PaginationLocale } from '../Pagination.types';
+
+const locale: PaginationLocale = {
+  lang: {
+    locale: 'bg_BG',
+    goToText: 'Отиди на',
+    nextIconButtonAriaLabel: 'Следващ',
+    pagerText: 'от',
+    pageSizeButtonAriaLabel: 'Избран размер на страницата',
+    pageSizeText: 'страница',
+    previousIconButtonAriaLabel: 'Предишен',
+    quickNextIconButtonAriaLabel: 'Следващи 5',
+    quickPreviousIconButtonAriaLabel: 'Предишни 5',
+    totalText: 'Общо',
+  },
+};
+
+export default locale;

--- a/src/components/Pagination/Locale/ro_RO.tsx
+++ b/src/components/Pagination/Locale/ro_RO.tsx
@@ -1,0 +1,18 @@
+import type { PaginationLocale } from '../Pagination.types';
+
+const locale: PaginationLocale = {
+  lang: {
+    locale: 'ro_RO',
+    goToText: 'Mergi la',
+    nextIconButtonAriaLabel: 'Următorul',
+    pagerText: 'din',
+    pageSizeButtonAriaLabel: 'Dimensiunea paginii selectate',
+    pageSizeText: 'pagina',
+    previousIconButtonAriaLabel: 'Anterior',
+    quickNextIconButtonAriaLabel: 'Următoarele 5',
+    quickPreviousIconButtonAriaLabel: 'Precedentele 5',
+    totalText: 'Total',
+  },
+};
+
+export default locale;

--- a/src/components/Pagination/Locale/sk_SK.tsx
+++ b/src/components/Pagination/Locale/sk_SK.tsx
@@ -1,0 +1,18 @@
+import type { PaginationLocale } from '../Pagination.types';
+
+const locale: PaginationLocale = {
+  lang: {
+    locale: 'sk_SK',
+    goToText: 'Ísť na',
+    nextIconButtonAriaLabel: 'Ďalšie',
+    pagerText: 'z',
+    pageSizeButtonAriaLabel: 'Vybraná veľkosť stránky',
+    pageSizeText: 'stránka',
+    previousIconButtonAriaLabel: 'Predchádzajúce',
+    quickNextIconButtonAriaLabel: 'Ďalších 5',
+    quickPreviousIconButtonAriaLabel: 'Predchádzajúcich 5',
+    totalText: 'Celkom',
+  },
+};
+
+export default locale;

--- a/src/components/Pagination/Locale/sr_RS.tsx
+++ b/src/components/Pagination/Locale/sr_RS.tsx
@@ -1,0 +1,18 @@
+import type { PaginationLocale } from '../Pagination.types';
+
+const locale: PaginationLocale = {
+  lang: {
+    locale: 'sr_RS',
+    goToText: 'Idi na',
+    nextIconButtonAriaLabel: 'Sledeće',
+    pagerText: 'od',
+    pageSizeButtonAriaLabel: 'Izabrana veličina stranice',
+    pageSizeText: 'stranica',
+    previousIconButtonAriaLabel: 'Prethodno',
+    quickNextIconButtonAriaLabel: 'Sledećih 5',
+    quickPreviousIconButtonAriaLabel: 'Prethodnih 5',
+    totalText: 'Ukupno',
+  },
+};
+
+export default locale;

--- a/src/components/Pagination/Locale/te_IN.tsx
+++ b/src/components/Pagination/Locale/te_IN.tsx
@@ -1,0 +1,18 @@
+import type { PaginationLocale } from '../Pagination.types';
+
+const locale: PaginationLocale = {
+  lang: {
+    locale: 'te_IN',
+    goToText: 'వెళ్ళు',
+    nextIconButtonAriaLabel: 'తదుపరి',
+    pagerText: 'యొక్క',
+    pageSizeButtonAriaLabel: 'ఎంచుకున్న పేజీ పరిమాణం',
+    pageSizeText: 'పేజీ',
+    previousIconButtonAriaLabel: 'మునుపటి',
+    quickNextIconButtonAriaLabel: 'తదుపరి 5',
+    quickPreviousIconButtonAriaLabel: 'మునుపటి 5',
+    totalText: 'మొత్తం',
+  },
+};
+
+export default locale;

--- a/src/components/Pagination/Locale/vi_VN.tsx
+++ b/src/components/Pagination/Locale/vi_VN.tsx
@@ -1,0 +1,18 @@
+import type { PaginationLocale } from '../Pagination.types';
+
+const locale: PaginationLocale = {
+  lang: {
+    locale: 'vi_VN',
+    goToText: 'Đi đến',
+    nextIconButtonAriaLabel: 'Tiếp theo',
+    pagerText: 'của',
+    pageSizeButtonAriaLabel: 'Kích thước trang đã chọn',
+    pageSizeText: 'trang',
+    previousIconButtonAriaLabel: 'Trước',
+    quickNextIconButtonAriaLabel: '5 tiếp theo',
+    quickPreviousIconButtonAriaLabel: '5 trước',
+    totalText: 'Tổng cộng',
+  },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/ar_SA.tsx
+++ b/src/components/Panel/Locale/ar_SA.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+  lang: {
+    locale: 'ar_SA',
+    closeButtonAriaLabelText: 'إغلاق',
+  },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/bg_BG.tsx
+++ b/src/components/Panel/Locale/bg_BG.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+  lang: {
+    locale: 'bg_BG',
+    closeButtonAriaLabelText: 'Затвори',
+  },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/ro_RO.tsx
+++ b/src/components/Panel/Locale/ro_RO.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+  lang: {
+    locale: 'ro_RO',
+    closeButtonAriaLabelText: 'Închide',
+  },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/sk_SK.tsx
+++ b/src/components/Panel/Locale/sk_SK.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+  lang: {
+    locale: 'sk_SK',
+    closeButtonAriaLabelText: 'Zavrieť',
+  },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/sr_RS.tsx
+++ b/src/components/Panel/Locale/sr_RS.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+  lang: {
+    locale: 'sr_RS',
+    closeButtonAriaLabelText: 'Zatvori',
+  },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/te_IN.tsx
+++ b/src/components/Panel/Locale/te_IN.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+  lang: {
+    locale: 'te_IN',
+    closeButtonAriaLabelText: 'మూసివేయండి',
+  },
+};
+
+export default locale;

--- a/src/components/Panel/Locale/vi_VN.tsx
+++ b/src/components/Panel/Locale/vi_VN.tsx
@@ -1,0 +1,10 @@
+import type { PanelLocale } from '../Panel.types';
+
+const locale: PanelLocale = {
+  lang: {
+    locale: 'vi_VN',
+    closeButtonAriaLabelText: 'Đóng',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/ar_SA.tsx
+++ b/src/components/PersistentBar/Locale/ar_SA.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'ar_SA',
+    overflowAriaLabelText: 'المزيد من الأزرار',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/bg_BG.tsx
+++ b/src/components/PersistentBar/Locale/bg_BG.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'bg_BG',
+    overflowAriaLabelText: 'Още бутони',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/ro_RO.tsx
+++ b/src/components/PersistentBar/Locale/ro_RO.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'ro_RO',
+    overflowAriaLabelText: 'Mai multe butoane',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/sk_SK.tsx
+++ b/src/components/PersistentBar/Locale/sk_SK.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'sk_SK',
+    overflowAriaLabelText: 'Viac tlačidiel',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/sr_RS.tsx
+++ b/src/components/PersistentBar/Locale/sr_RS.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'sr_RS',
+    overflowAriaLabelText: 'Više dugmadi',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/te_IN.tsx
+++ b/src/components/PersistentBar/Locale/te_IN.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'te_IN',
+    overflowAriaLabelText: 'మరిన్ని బటన్లు',
+  },
+};
+
+export default locale;

--- a/src/components/PersistentBar/Locale/vi_VN.tsx
+++ b/src/components/PersistentBar/Locale/vi_VN.tsx
@@ -1,0 +1,10 @@
+import type { PersistentBarLocale } from '../PersistentBar.types';
+
+const locale: PersistentBarLocale = {
+  lang: {
+    locale: 'vi_VN',
+    overflowAriaLabelText: 'Thêm nút',
+  },
+};
+
+export default locale;

--- a/src/components/Stepper/Locale/ar_SA.tsx
+++ b/src/components/Stepper/Locale/ar_SA.tsx
@@ -1,0 +1,15 @@
+import type { StepperLocale } from '../Stepper.types';
+
+const locale: StepperLocale = {
+  lang: {
+    locale: 'ar_SA',
+    completeAriaLabelText: 'اكتمال',
+    nodeAriaLabelText: 'العقدة',
+    scrollDownAriaLabelText: 'التمرير للأسفل',
+    scrollLeftAriaLabelText: 'التمرير لليسار',
+    scrollRightAriaLabelText: 'التمرير لليمين',
+    scrollUpAriaLabelText: 'التمرير للأعلى',
+  },
+};
+
+export default locale;

--- a/src/components/Stepper/Locale/bg_BG.tsx
+++ b/src/components/Stepper/Locale/bg_BG.tsx
@@ -1,0 +1,15 @@
+import type { StepperLocale } from '../Stepper.types';
+
+const locale: StepperLocale = {
+  lang: {
+    locale: 'bg_BG',
+    completeAriaLabelText: 'завършен',
+    nodeAriaLabelText: 'Възел',
+    scrollDownAriaLabelText: 'Превъртете надолу',
+    scrollLeftAriaLabelText: 'Превъртете наляво',
+    scrollRightAriaLabelText: 'Превъртете надясно',
+    scrollUpAriaLabelText: 'Превъртете нагоре',
+  },
+};
+
+export default locale;

--- a/src/components/Stepper/Locale/ro_RO.tsx
+++ b/src/components/Stepper/Locale/ro_RO.tsx
@@ -1,0 +1,15 @@
+import type { StepperLocale } from '../Stepper.types';
+
+const locale: StepperLocale = {
+  lang: {
+    locale: 'ro_RO',
+    completeAriaLabelText: 'complet',
+    nodeAriaLabelText: 'Nod',
+    scrollDownAriaLabelText: 'Derulați în jos',
+    scrollLeftAriaLabelText: 'Derulați la stânga',
+    scrollRightAriaLabelText: 'Derulați la dreapta',
+    scrollUpAriaLabelText: 'Derulați în sus',
+  },
+};
+
+export default locale;

--- a/src/components/Stepper/Locale/sk_SK.tsx
+++ b/src/components/Stepper/Locale/sk_SK.tsx
@@ -1,0 +1,15 @@
+import type { StepperLocale } from '../Stepper.types';
+
+const locale: StepperLocale = {
+  lang: {
+    locale: 'sk_SK',
+    completeAriaLabelText: 'dokončené',
+    nodeAriaLabelText: 'Uzol',
+    scrollDownAriaLabelText: 'Posunúť nadol',
+    scrollLeftAriaLabelText: 'Posunúť doľava',
+    scrollRightAriaLabelText: 'Posunúť doprava',
+    scrollUpAriaLabelText: 'Posunúť nahor',
+  },
+};
+
+export default locale;

--- a/src/components/Stepper/Locale/sr_RS.tsx
+++ b/src/components/Stepper/Locale/sr_RS.tsx
@@ -1,0 +1,15 @@
+import type { StepperLocale } from '../Stepper.types';
+
+const locale: StepperLocale = {
+  lang: {
+    locale: 'sr_RS',
+    completeAriaLabelText: 'kompletan',
+    nodeAriaLabelText: 'Čvor',
+    scrollDownAriaLabelText: 'Pomeri dole',
+    scrollLeftAriaLabelText: 'Pomeri levo',
+    scrollRightAriaLabelText: 'Pomeri desno',
+    scrollUpAriaLabelText: 'Pomeri gore',
+  },
+};
+
+export default locale;

--- a/src/components/Stepper/Locale/te_IN.tsx
+++ b/src/components/Stepper/Locale/te_IN.tsx
@@ -1,0 +1,15 @@
+import type { StepperLocale } from '../Stepper.types';
+
+const locale: StepperLocale = {
+  lang: {
+    locale: 'te_IN',
+    completeAriaLabelText: 'పూర్తయింది',
+    nodeAriaLabelText: 'నోడ్',
+    scrollDownAriaLabelText: 'కిందకి స్క్రోల్ చేయండి',
+    scrollLeftAriaLabelText: 'ఎడమవైపు స్క్రోల్ చేయండి',
+    scrollRightAriaLabelText: 'కుడివైపు స్క్రోల్ చేయండి',
+    scrollUpAriaLabelText: 'పైకి స్క్రోల్ చేయండి',
+  },
+};
+
+export default locale;

--- a/src/components/Stepper/Locale/vi_VN.tsx
+++ b/src/components/Stepper/Locale/vi_VN.tsx
@@ -1,0 +1,15 @@
+import type { StepperLocale } from '../Stepper.types';
+
+const locale: StepperLocale = {
+  lang: {
+    locale: 'vi_VN',
+    completeAriaLabelText: 'hoàn thành',
+    nodeAriaLabelText: 'Nút',
+    scrollDownAriaLabelText: 'Cuộn xuống',
+    scrollLeftAriaLabelText: 'Cuộn sang trái',
+    scrollRightAriaLabelText: 'Cuộn sang phải',
+    scrollUpAriaLabelText: 'Cuộn lên',
+  },
+};
+
+export default locale;

--- a/src/components/Table/Locale/ar_SA.tsx
+++ b/src/components/Table/Locale/ar_SA.tsx
@@ -1,0 +1,28 @@
+import type { TableLocale } from '../Table.types';
+
+const locale: TableLocale = {
+  lang: {
+    locale: 'ar_SA',
+    filterConfirmText: 'حسنا',
+    filterResetText: 'إعادة تعيين',
+    filterEmptyText: 'لا يوجد فلاتر',
+    filterCheckallText: 'اختر جميع العناصر',
+    filterSearchPlaceholderText: 'البحث في الفلاتر',
+    emptyText: 'لم يتم العثور على بيانات',
+    emptyTextDetails: '',
+    selectInvertText: 'عكس الصفحة الحالية',
+    selectNoneText: 'مسح جميع البيانات',
+    selectionAllText: 'اختر جميع البيانات',
+    expandText: 'توسيع الصف',
+    collapseText: 'طي الصف',
+    triggerDescText: 'انقر للترتيب تنازليا',
+    triggerAscText: 'انقر للترتيب تصاعديا',
+    cancelSortText: 'انقر لإلغاء الترتيب',
+    scrollLeftAriaLabelText: 'التمرير لليسار',
+    scrollRightAriaLabelText: 'التمرير لليمين',
+    selectAllRowsText: 'اختر جميع الصفوف',
+    selectRowText: 'اختر الصف',
+  },
+};
+
+export default locale;

--- a/src/components/Table/Locale/bg_BG.tsx
+++ b/src/components/Table/Locale/bg_BG.tsx
@@ -1,0 +1,28 @@
+import type { TableLocale } from '../Table.types';
+
+const locale: TableLocale = {
+  lang: {
+    locale: 'bg_BG',
+    filterConfirmText: 'ОК',
+    filterResetText: 'Нулиране',
+    filterEmptyText: 'Няма филтри',
+    filterCheckallText: 'Изберете всички елементи',
+    filterSearchPlaceholderText: 'Търсене във филтрите',
+    emptyText: 'Няма намерени данни',
+    emptyTextDetails: '',
+    selectInvertText: 'Инвертирайте текущата страница',
+    selectNoneText: 'Изчистете всички данни',
+    selectionAllText: 'Изберете всички данни',
+    expandText: 'Разширете реда',
+    collapseText: 'Свийте реда',
+    triggerDescText: 'Кликнете за сортиране в низходящ ред',
+    triggerAscText: 'Кликнете за сортиране във възходящ ред',
+    cancelSortText: 'Кликнете, за да отмените сортирането',
+    scrollLeftAriaLabelText: 'Превъртете наляво',
+    scrollRightAriaLabelText: 'Превъртете надясно',
+    selectAllRowsText: 'Изберете всички редове',
+    selectRowText: 'Изберете ред',
+  },
+};
+
+export default locale;

--- a/src/components/Table/Locale/ro_RO.tsx
+++ b/src/components/Table/Locale/ro_RO.tsx
@@ -1,0 +1,28 @@
+import type { TableLocale } from '../Table.types';
+
+const locale: TableLocale = {
+  lang: {
+    locale: 'ro_RO',
+    filterConfirmText: 'OK',
+    filterResetText: 'Resetare',
+    filterEmptyText: 'Fără filtre',
+    filterCheckallText: 'Selectați toate elementele',
+    filterSearchPlaceholderText: 'Căutați în filtre',
+    emptyText: 'Nu s-au găsit date',
+    emptyTextDetails: '',
+    selectInvertText: 'Inversați pagina curentă',
+    selectNoneText: 'Ștergeți toate datele',
+    selectionAllText: 'Selectați toate datele',
+    expandText: 'Extindeți rândul',
+    collapseText: 'Restrângeți rândul',
+    triggerDescText: 'Faceți clic pentru a sorta descrescător',
+    triggerAscText: 'Faceți clic pentru a sorta crescător',
+    cancelSortText: 'Faceți clic pentru a anula sortarea',
+    scrollLeftAriaLabelText: 'Derulați la stânga',
+    scrollRightAriaLabelText: 'Derulați la dreapta',
+    selectAllRowsText: 'Selectați toate rândurile',
+    selectRowText: 'Selectați rândul',
+  },
+};
+
+export default locale;

--- a/src/components/Table/Locale/sk_SK.tsx
+++ b/src/components/Table/Locale/sk_SK.tsx
@@ -1,0 +1,28 @@
+import type { TableLocale } from '../Table.types';
+
+const locale: TableLocale = {
+  lang: {
+    locale: 'sk_SK',
+    filterConfirmText: 'OK',
+    filterResetText: 'Resetovať',
+    filterEmptyText: 'Žiadne filtre',
+    filterCheckallText: 'Vybrať všetky položky',
+    filterSearchPlaceholderText: 'Hľadať vo filtroch',
+    emptyText: 'Nenašli sa žiadne dáta',
+    emptyTextDetails: '',
+    selectInvertText: 'Invertovať aktuálnu stránku',
+    selectNoneText: 'Vymazať všetky dáta',
+    selectionAllText: 'Vybrať všetky dáta',
+    expandText: 'Rozbaliť riadok',
+    collapseText: 'Zbaliť riadok',
+    triggerDescText: 'Kliknite pre zostupné zoradenie',
+    triggerAscText: 'Kliknite pre vzostupné zoradenie',
+    cancelSortText: 'Kliknite pre zrušenie zoradenia',
+    scrollLeftAriaLabelText: 'Posunúť doľava',
+    scrollRightAriaLabelText: 'Posunúť doprava',
+    selectAllRowsText: 'Vybrať všetky riadky',
+    selectRowText: 'Vybrať riadok',
+  },
+};
+
+export default locale;

--- a/src/components/Table/Locale/sr_RS.tsx
+++ b/src/components/Table/Locale/sr_RS.tsx
@@ -1,0 +1,28 @@
+import type { TableLocale } from '../Table.types';
+
+const locale: TableLocale = {
+  lang: {
+    locale: 'sr_RS',
+    filterConfirmText: 'U redu',
+    filterResetText: 'Resetuj',
+    filterEmptyText: 'Nema filtera',
+    filterCheckallText: 'Izaberi sve stavke',
+    filterSearchPlaceholderText: 'Pretraga u filterima',
+    emptyText: 'Podaci nisu pronađeni',
+    emptyTextDetails: '',
+    selectInvertText: 'Invertuj trenutnu stranicu',
+    selectNoneText: 'Očisti sve podatke',
+    selectionAllText: 'Izaberi sve podatke',
+    expandText: 'Proširi red',
+    collapseText: 'Skupi red',
+    triggerDescText: 'Klikni za sortiranje silazno',
+    triggerAscText: 'Klikni za sortiranje uzlazno',
+    cancelSortText: 'Klikni da otkažeš sortiranje',
+    scrollLeftAriaLabelText: 'Pomeri levo',
+    scrollRightAriaLabelText: 'Pomeri desno',
+    selectAllRowsText: 'Izaberi sve redove',
+    selectRowText: 'Izaberi red',
+  },
+};
+
+export default locale;

--- a/src/components/Table/Locale/te_IN.tsx
+++ b/src/components/Table/Locale/te_IN.tsx
@@ -1,0 +1,28 @@
+import type { TableLocale } from '../Table.types';
+
+const locale: TableLocale = {
+  lang: {
+    locale: 'te_IN',
+    filterConfirmText: 'సరే',
+    filterResetText: 'రీసెట్',
+    filterEmptyText: 'ఫిల్టర్లు లేవు',
+    filterCheckallText: 'అన్ని అంశాలను ఎంచుకోండి',
+    filterSearchPlaceholderText: 'ఫిల్టర్లలో శోధించండి',
+    emptyText: 'డేటా కనబడలేదు',
+    emptyTextDetails: '',
+    selectInvertText: 'ప్రస్తుత పేజీని తిరగబెట్టండి',
+    selectNoneText: 'అన్ని డేటాను క్లియర్ చేయండి',
+    selectionAllText: 'అన్ని డేటాను ఎంచుకోండి',
+    expandText: 'వరుసను విస్తరించండి',
+    collapseText: 'వరుసను మూసివేయండి',
+    triggerDescText: 'అవరోహణ క్రమంలో సర్ట్ చేయడానికి క్లిక్ చేయండి',
+    triggerAscText: 'ఆరోహణ క్రమంలో సర్ట్ చేయడానికి క్లిక్ చేయండి',
+    cancelSortText: 'సర్టింగ్ రద్దు చేయడానికి క్లిక్ చేయండి',
+    scrollLeftAriaLabelText: 'ఎడమవైపు స్క్రోల్ చేయండి',
+    scrollRightAriaLabelText: 'కుడివైపు స్క్రోల్ చేయండి',
+    selectAllRowsText: 'అన్ని వరుసలను ఎంచుకోండి',
+    selectRowText: 'వరుసను ఎంచుకోండి',
+  },
+};
+
+export default locale;

--- a/src/components/Table/Locale/vi_VN.tsx
+++ b/src/components/Table/Locale/vi_VN.tsx
@@ -1,0 +1,28 @@
+import type { TableLocale } from '../Table.types';
+
+const locale: TableLocale = {
+  lang: {
+    locale: 'vi_VN',
+    filterConfirmText: 'Đồng ý',
+    filterResetText: 'Đặt lại',
+    filterEmptyText: 'Không có bộ lọc',
+    filterCheckallText: 'Chọn tất cả các mục',
+    filterSearchPlaceholderText: 'Tìm kiếm trong bộ lọc',
+    emptyText: 'Không tìm thấy dữ liệu',
+    emptyTextDetails: '',
+    selectInvertText: 'Đảo ngược trang hiện tại',
+    selectNoneText: 'Xóa tất cả dữ liệu',
+    selectionAllText: 'Chọn tất cả dữ liệu',
+    expandText: 'Mở rộng hàng',
+    collapseText: 'Thu gọn hàng',
+    triggerDescText: 'Nhấp để sắp xếp giảm dần',
+    triggerAscText: 'Nhấp để sắp xếp tăng dần',
+    cancelSortText: 'Nhấp để hủy sắp xếp',
+    scrollLeftAriaLabelText: 'Cuộn sang trái',
+    scrollRightAriaLabelText: 'Cuộn sang phải',
+    selectAllRowsText: 'Chọn tất cả các hàng',
+    selectRowText: 'Chọn hàng',
+  },
+};
+
+export default locale;

--- a/src/components/Upload/Locale/ar_SA.tsx
+++ b/src/components/Upload/Locale/ar_SA.tsx
@@ -1,0 +1,28 @@
+import type { UploadLocale } from '../Upload.types';
+
+const locale: UploadLocale = {
+  lang: {
+    locale: 'ar_SA',
+    acceptedFileTypesText: '(doc، docx، pdf أو txt)',
+    downloadFileText: 'تحميل الملف',
+    dragAndDropFileText: 'اسحب وأسقط الملف',
+    dragAndDropMultipleFilesText: 'اسحب وأسقط الملفات',
+    modalCancelText: 'إلغاء',
+    modalCloseButtonAriaLabelText: 'إغلاق',
+    modalOkText: 'حسنا',
+    modalTitleText: 'تعديل الصورة',
+    previewFileText: 'معاينة الملف',
+    removeFileText: 'إزالة الملف',
+    replaceFileText: 'استبدال',
+    rotateLeftButtonAriaLabelText: 'تدوير لليسار',
+    rotateRightButtonAriaLabelText: 'تدوير لليمين',
+    selectFileText: 'اختر ملف',
+    selectMultipleFilesText: 'اختر ملفات',
+    uploadErrorText: 'فشل تحميل الملف',
+    uploadingText: 'جار التحميل',
+    zoomInButtonAriaLabelText: 'تكبير',
+    zoomOutButtonAriaLabelText: 'تصغير',
+  },
+};
+
+export default locale;

--- a/src/components/Upload/Locale/bg_BG.tsx
+++ b/src/components/Upload/Locale/bg_BG.tsx
@@ -1,0 +1,28 @@
+import type { UploadLocale } from '../Upload.types';
+
+const locale: UploadLocale = {
+  lang: {
+    locale: 'bg_BG',
+    acceptedFileTypesText: '(doc, docx, pdf или txt)',
+    downloadFileText: 'Изтегли файл',
+    dragAndDropFileText: 'Плъзнете и пуснете файл',
+    dragAndDropMultipleFilesText: 'Плъзнете и пуснете файлове',
+    modalCancelText: 'Отказ',
+    modalCloseButtonAriaLabelText: 'Затвори',
+    modalOkText: 'Добре',
+    modalTitleText: 'Редактирай изображение',
+    previewFileText: 'Преглед на файл',
+    removeFileText: 'Премахни файла',
+    replaceFileText: 'Замени',
+    rotateLeftButtonAriaLabelText: 'Завъртете наляво',
+    rotateRightButtonAriaLabelText: 'Завъртете надясно',
+    selectFileText: 'Изберете файл',
+    selectMultipleFilesText: 'Изберете файлове',
+    uploadErrorText: 'Качването на файла не бе успешно',
+    uploadingText: 'Качване',
+    zoomInButtonAriaLabelText: 'Увеличи',
+    zoomOutButtonAriaLabelText: 'Намали',
+  },
+};
+
+export default locale;

--- a/src/components/Upload/Locale/ro_RO.tsx
+++ b/src/components/Upload/Locale/ro_RO.tsx
@@ -1,0 +1,28 @@
+import type { UploadLocale } from '../Upload.types';
+
+const locale: UploadLocale = {
+  lang: {
+    locale: 'ro_RO',
+    acceptedFileTypesText: '(doc, docx, pdf sau txt)',
+    downloadFileText: 'Descărcați fișierul',
+    dragAndDropFileText: 'Trageți și fixați fișierul',
+    dragAndDropMultipleFilesText: 'Trageți și fixați fișierele',
+    modalCancelText: 'Anulează',
+    modalCloseButtonAriaLabelText: 'Închide',
+    modalOkText: 'OK',
+    modalTitleText: 'Editați imaginea',
+    previewFileText: 'Previzualizați fișierul',
+    removeFileText: 'Eliminați fișierul',
+    replaceFileText: 'Înlocuiți',
+    rotateLeftButtonAriaLabelText: 'Rotiți la stânga',
+    rotateRightButtonAriaLabelText: 'Rotiți la dreapta',
+    selectFileText: 'Selectați fișierul',
+    selectMultipleFilesText: 'Selectați fișierele',
+    uploadErrorText: 'Încărcarea fișierului a eșuat',
+    uploadingText: 'Se încarcă',
+    zoomInButtonAriaLabelText: 'Măriți',
+    zoomOutButtonAriaLabelText: 'Micșorați',
+  },
+};
+
+export default locale;

--- a/src/components/Upload/Locale/sk_SK.tsx
+++ b/src/components/Upload/Locale/sk_SK.tsx
@@ -1,0 +1,28 @@
+import type { UploadLocale } from '../Upload.types';
+
+const locale: UploadLocale = {
+  lang: {
+    locale: 'sk_SK',
+    acceptedFileTypesText: '(doc, docx, pdf alebo txt)',
+    downloadFileText: 'Stiahnuť súbor',
+    dragAndDropFileText: 'Presuňte súbor',
+    dragAndDropMultipleFilesText: 'Presuňte súbory',
+    modalCancelText: 'Zrušiť',
+    modalCloseButtonAriaLabelText: 'Zavrieť',
+    modalOkText: 'OK',
+    modalTitleText: 'Upraviť obrázok',
+    previewFileText: 'Náhľad súboru',
+    removeFileText: 'Odstrániť súbor',
+    replaceFileText: 'Nahradiť',
+    rotateLeftButtonAriaLabelText: 'Otočiť doľava',
+    rotateRightButtonAriaLabelText: 'Otočiť doprava',
+    selectFileText: 'Vyberte súbor',
+    selectMultipleFilesText: 'Vyberte súbory',
+    uploadErrorText: 'Nahrávanie súboru zlyhalo',
+    uploadingText: 'Nahrávanie',
+    zoomInButtonAriaLabelText: 'Priblížiť',
+    zoomOutButtonAriaLabelText: 'Oddialiť',
+  },
+};
+
+export default locale;

--- a/src/components/Upload/Locale/sr_RS.tsx
+++ b/src/components/Upload/Locale/sr_RS.tsx
@@ -1,0 +1,28 @@
+import type { UploadLocale } from '../Upload.types';
+
+const locale: UploadLocale = {
+  lang: {
+    locale: 'sr_RS',
+    acceptedFileTypesText: '(doc, docx, pdf ili txt)',
+    downloadFileText: 'Preuzmi datoteku',
+    dragAndDropFileText: 'Prevuci i otpusti datoteku',
+    dragAndDropMultipleFilesText: 'Prevuci i otpusti datoteke',
+    modalCancelText: 'Otkaži',
+    modalCloseButtonAriaLabelText: 'Zatvori',
+    modalOkText: 'U redu',
+    modalTitleText: 'Izmeni sliku',
+    previewFileText: 'Pregledaj datoteku',
+    removeFileText: 'Ukloni datoteku',
+    replaceFileText: 'Zameni',
+    rotateLeftButtonAriaLabelText: 'Rotiraj levo',
+    rotateRightButtonAriaLabelText: 'Rotiraj desno',
+    selectFileText: 'Izaberi datoteku',
+    selectMultipleFilesText: 'Izaberi datoteke',
+    uploadErrorText: 'Otpremanje datoteke nije uspelo',
+    uploadingText: 'Otpremanje',
+    zoomInButtonAriaLabelText: 'Uvećaj',
+    zoomOutButtonAriaLabelText: 'Smanji',
+  },
+};
+
+export default locale;

--- a/src/components/Upload/Locale/te_IN.tsx
+++ b/src/components/Upload/Locale/te_IN.tsx
@@ -1,0 +1,28 @@
+import type { UploadLocale } from '../Upload.types';
+
+const locale: UploadLocale = {
+  lang: {
+    locale: 'te_IN',
+    acceptedFileTypesText: '(doc, docx, pdf లేదా txt)',
+    downloadFileText: 'ఫైల్ డౌన్లోడ్ చేయండి',
+    dragAndDropFileText: 'ఫైల్ డ్రాగ్ చేసి డ్రాప్ చేయండి',
+    dragAndDropMultipleFilesText: 'ఫైళ్ళను డ్రాగ్ చేసి డ్రాప్ చేయండి',
+    modalCancelText: 'రద్దు చేయండి',
+    modalCloseButtonAriaLabelText: 'మూసివేయండి',
+    modalOkText: 'సరే',
+    modalTitleText: 'చిత్రాన్ని సవరించండి',
+    previewFileText: 'ఫైల్ మునుజూపు',
+    removeFileText: 'ఫైల్ తీసివేయండి',
+    replaceFileText: 'మార్పు',
+    rotateLeftButtonAriaLabelText: 'ఎడమవైపు తిరుగు',
+    rotateRightButtonAriaLabelText: 'కుడివైపు తిరుగు',
+    selectFileText: 'ఫైల్ ఎంచుకోండి',
+    selectMultipleFilesText: 'ఫైళ్ళను ఎంచుకోండి',
+    uploadErrorText: 'ఫైల్ అప్లోడ్ విఫలమైంది',
+    uploadingText: 'అప్లోడ్ అవుతోంది',
+    zoomInButtonAriaLabelText: 'జూమిన్',
+    zoomOutButtonAriaLabelText: 'జూమౌట్',
+  },
+};
+
+export default locale;

--- a/src/components/Upload/Locale/vi_VN.tsx
+++ b/src/components/Upload/Locale/vi_VN.tsx
@@ -1,0 +1,28 @@
+import type { UploadLocale } from '../Upload.types';
+
+const locale: UploadLocale = {
+  lang: {
+    locale: 'vi_VN',
+    acceptedFileTypesText: '(doc, docx, pdf hoặc txt)',
+    downloadFileText: 'Tải tệp xuống',
+    dragAndDropFileText: 'Kéo và thả tệp',
+    dragAndDropMultipleFilesText: 'Kéo và thả các tệp',
+    modalCancelText: 'Hủy bỏ',
+    modalCloseButtonAriaLabelText: 'Đóng',
+    modalOkText: 'Đồng ý',
+    modalTitleText: 'Chỉnh sửa hình ảnh',
+    previewFileText: 'Xem trước tệp',
+    removeFileText: 'Xóa tệp',
+    replaceFileText: 'Thay thế',
+    rotateLeftButtonAriaLabelText: 'Xoay trái',
+    rotateRightButtonAriaLabelText: 'Xoay phải',
+    selectFileText: 'Chọn tệp',
+    selectMultipleFilesText: 'Chọn nhiều tệp',
+    uploadErrorText: 'Tải lên tệp thất bại',
+    uploadingText: 'Đang tải lên',
+    zoomInButtonAriaLabelText: 'Phóng to',
+    zoomOutButtonAriaLabelText: 'Thu nhỏ',
+  },
+};
+
+export default locale;

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,6 +1,8 @@
 import type { Locale } from './components/LocaleProvider';
 
 // Supported locales
+import arSA from './components/Locale/ar_SA'; // العربية
+import bgBG from './components/Locale/bg_BG'; // Български
 import csCZ from './components/Locale/cs_CZ'; // čeština
 import daDK from './components/Locale/da_DK'; // Dansk
 import deDE from './components/Locale/de_DE'; // Deutsch
@@ -29,16 +31,23 @@ import nlNL from './components/Locale/nl_NL'; // Nederlands
 import plPL from './components/Locale/pl_PL'; // Polski
 import ptBR from './components/Locale/pt_BR'; // Português (Brazil)
 import ptPT from './components/Locale/pt_PT'; // Português
+import roRO from './components/Locale/ro_RO'; // Română
 import ruRU from './components/Locale/ru_RU'; // Pусский
+import skSK from './components/Locale/sk_SK'; // Slovenčina
+import srRS from './components/Locale/sr_RS'; // Srpski
 import svSE from './components/Locale/sv_SE'; // Svenska
+import teIN from './components/Locale/te_IN'; // తెలుగు
 import thTH from './components/Locale/th_TH'; // ภาษาไทย
 import trTR from './components/Locale/tr_TR'; // Türkçe
 import ukUA from './components/Locale/uk_UA'; // Yкраїнська
+import viVN from './components/Locale/vi_VN'; // Tiếng Việt
 import zhCN from './components/Locale/zh_CN'; // 中文 (简体)
 import zhTW from './components/Locale/zh_TW'; // 中文 (繁體)
 
 export {
   Locale,
+  arSA,
+  bgBG,
   csCZ,
   daDK,
   deDE,
@@ -67,11 +76,16 @@ export {
   plPL,
   ptBR,
   ptPT,
+  roRO,
   ruRU,
+  skSK,
+  srRS,
   svSE,
+  teIN,
   thTH,
   trTR,
   ukUA,
+  viVN,
   zhCN,
   zhTW,
 };


### PR DESCRIPTION
## SUMMARY:
- Adds the following locales: `ar`, `bg`, `ro`, `sk`, `sr`, `te`, `vi`

## JIRA TASK (Eightfold Employees Only):
ENG-74800
ENG-68362
ENG-64238
ENG-64236
ENG-64235
ENG-64234
ENG-64233

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request
- [x] Chore

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the 7 new langs may be chosen in the `ConfigProvider` `Locale` story.