### PR TITLE
fix: tooltip: dedupes tooltip id and updates story for screen readers

### DIFF
--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Breadcrumb Crumb should support string \`0\` 1`] = `
       >
         <div
           class="reference-wrapper"
-          id="tooltip-"
+          id="tooltip--wrapper"
         >
           <a
             aria-disabled="false"
@@ -55,7 +55,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -93,7 +93,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -131,7 +131,7 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <span
               aria-current="location"
@@ -167,7 +167,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -206,7 +206,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -245,7 +245,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -284,7 +284,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -323,7 +323,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -362,7 +362,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -401,7 +401,7 @@ exports[`Breadcrumb Renders without crashing 1`] = `
         >
           <div
             class="reference-wrapper"
-            id="tooltip-"
+            id="tooltip--wrapper"
           >
             <a
               aria-disabled="false"
@@ -455,7 +455,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
       >
         <div
           class="reference-wrapper"
-          id="tooltip-"
+          id="tooltip--wrapper"
         >
           <a
             aria-disabled="false"
@@ -494,7 +494,7 @@ exports[`Breadcrumb should support custom attribute 1`] = `
       >
         <div
           class="reference-wrapper"
-          id="tooltip-"
+          id="tooltip--wrapper"
         >
           <a
             aria-disabled="false"

--- a/src/components/Skill/Tests/__snapshots__/SkillBlock.test.tsx.snap
+++ b/src/components/Skill/Tests/__snapshots__/SkillBlock.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`SkillBlock Skill block has no border 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -188,7 +188,7 @@ exports[`SkillBlock Skill block is bordered 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -301,7 +301,7 @@ exports[`SkillBlock Skill block is disabled 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -415,7 +415,7 @@ exports[`SkillBlock Skill block is readonly 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -529,7 +529,7 @@ exports[`SkillBlock Skill block renders 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -669,7 +669,7 @@ exports[`SkillBlock Skill block uses custom props 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -905,7 +905,7 @@ exports[`SkillBlock Skill is a below and upskilling assessment block and the ico
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1019,7 +1019,7 @@ exports[`SkillBlock Skill is a below and upskilling assessment block and the ico
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1158,7 +1158,7 @@ exports[`SkillBlock Skill is a below assessment block and the icon is enabled 1`
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1272,7 +1272,7 @@ exports[`SkillBlock Skill is a below assessment block and the icon is not enable
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1388,7 +1388,7 @@ exports[`SkillBlock Skill is a clickable block 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1502,7 +1502,7 @@ exports[`SkillBlock Skill is a default block 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1632,7 +1632,7 @@ exports[`SkillBlock Skill is a default block with custom iconProps 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1757,7 +1757,7 @@ exports[`SkillBlock Skill is a default block with custom inlineSvgProps 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -1871,7 +1871,7 @@ exports[`SkillBlock Skill is a default block with customButtonProps 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2018,7 +2018,7 @@ exports[`SkillBlock Skill is a default block with endorseButtonProps 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2174,7 +2174,7 @@ exports[`SkillBlock Skill is a default block with highlightButtonProps 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2361,7 +2361,7 @@ exports[`SkillBlock Skill is a exceed and upskilling assessment block and the ic
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2475,7 +2475,7 @@ exports[`SkillBlock Skill is a exceed and upskilling assessment block and the ic
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2614,7 +2614,7 @@ exports[`SkillBlock Skill is a exceed assessment block and the icon is enabled 1
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2728,7 +2728,7 @@ exports[`SkillBlock Skill is a exceed assessment block and the icon is not enabl
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2858,7 +2858,7 @@ exports[`SkillBlock Skill is a highlight block 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -2988,7 +2988,7 @@ exports[`SkillBlock Skill is a match block 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -3140,7 +3140,7 @@ exports[`SkillBlock Skill is a meet and upskilling assessment block and the icon
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -3254,7 +3254,7 @@ exports[`SkillBlock Skill is a meet and upskilling assessment block and the icon
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -3393,7 +3393,7 @@ exports[`SkillBlock Skill is a meet assessment block and the icon is enabled 1`]
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -3507,7 +3507,7 @@ exports[`SkillBlock Skill is a meet assessment block and the icon is not enabled
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -3621,7 +3621,7 @@ exports[`SkillBlock Skill is a required block 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -3742,7 +3742,7 @@ exports[`SkillBlock Skill is a required block with lineClamp and long text 1`] =
                 />
                 <div
                   class="reference-wrapper"
-                  id="tooltip-"
+                  id="tooltip--wrapper"
                 >
                   <input
                     aria-disabled="false"
@@ -3857,7 +3857,7 @@ exports[`SkillBlock Skill is a required block with the required mark hidden 1`] 
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -3996,7 +3996,7 @@ exports[`SkillBlock Skill is a upskilling assessment block and the icon is enabl
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -4110,7 +4110,7 @@ exports[`SkillBlock Skill is a upskilling assessment block and the icon is not e
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"
@@ -4226,7 +4226,7 @@ exports[`SkillBlock Skill overflow item menu 1`] = `
               />
               <div
                 class="reference-wrapper"
-                id="tooltip-"
+                id="tooltip--wrapper"
               >
                 <input
                   aria-disabled="false"

--- a/src/components/Skill/Tests/__snapshots__/SkillTag.test.tsx.snap
+++ b/src/components/Skill/Tests/__snapshots__/SkillTag.test.tsx.snap
@@ -1352,7 +1352,7 @@ exports[`SkillTag Skill tag has a popup 1`] = `
 <div>
   <div
     class="reference-wrapper"
-    id="popup-"
+    id="popup--wrapper"
   >
     <div
       aria-controls="popup-"
@@ -1409,7 +1409,7 @@ exports[`SkillTag Skill tag has a tooltip 1`] = `
 <div>
   <div
     class="reference-wrapper"
-    id="tooltip-"
+    id="tooltip--wrapper"
   >
     <div
       aria-disabled="false"

--- a/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
@@ -20,7 +20,7 @@ LoadedCheerio {
               Node {
                 "attribs": Object {
                   "class": "reference-wrapper",
-                  "id": "sortTip",
+                  "id": "sortTip-wrapper",
                 },
                 "children": Array [
                   Node {
@@ -3178,7 +3178,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "reference-wrapper",
-                                          "id": "sortTip",
+                                          "id": "sortTip-wrapper",
                                         },
                                         "children": Array [
                                           Node {
@@ -4330,7 +4330,7 @@ LoadedCheerio {
                                     Node {
                                       "attribs": Object {
                                         "class": "reference-wrapper",
-                                        "id": "sortTip",
+                                        "id": "sortTip-wrapper",
                                       },
                                       "children": Array [
                                         Node {
@@ -6253,7 +6253,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "reference-wrapper",
-                                          "id": "sortTip",
+                                          "id": "sortTip-wrapper",
                                         },
                                         "children": Array [
                                           Node {
@@ -6842,7 +6842,7 @@ LoadedCheerio {
                                     Node {
                                       "attribs": Object {
                                         "class": "reference-wrapper",
-                                        "id": "sortTip",
+                                        "id": "sortTip-wrapper",
                                       },
                                       "children": Array [
                                         Node {
@@ -7289,7 +7289,7 @@ LoadedCheerio {
                                   Node {
                                     "attribs": Object {
                                       "class": "reference-wrapper",
-                                      "id": "sortTip",
+                                      "id": "sortTip-wrapper",
                                     },
                                     "children": Array [
                                       Node {
@@ -7799,7 +7799,7 @@ LoadedCheerio {
                                     Node {
                                       "attribs": Object {
                                         "class": "reference-wrapper",
-                                        "id": "sortTip",
+                                        "id": "sortTip-wrapper",
                                       },
                                       "children": Array [
                                         Node {
@@ -8682,7 +8682,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "reference-wrapper",
-                                          "id": "sortTip",
+                                          "id": "sortTip-wrapper",
                                         },
                                         "children": Array [
                                           Node {
@@ -9129,7 +9129,7 @@ LoadedCheerio {
                                     Node {
                                       "attribs": Object {
                                         "class": "reference-wrapper",
-                                        "id": "sortTip",
+                                        "id": "sortTip-wrapper",
                                       },
                                       "children": Array [
                                         Node {
@@ -9639,7 +9639,7 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "class": "reference-wrapper",
-                                          "id": "sortTip",
+                                          "id": "sortTip-wrapper",
                                         },
                                         "children": Array [
                                           Node {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -141,10 +141,11 @@ Tooltips.args = {
   animate: true,
   bordered: false,
   dropShadow: true,
+  id: 'myTooltipId',
   classNames: 'my-tooltip-class',
   openDelay: 0,
   hideAfter: 200,
-  tabIndex: 0,
+  tabIndex: -1,
   trigger: 'hover',
   triggerAbove: false,
   touchInteraction: TooltipTouchInteraction.TapAndHold,
@@ -154,7 +155,7 @@ Tooltips.args = {
   portalRoot: null,
   children: (
     <Button
-      ariaLabel="Show Tooltip"
+      aria-describedby="myTooltipId"
       onClick={() => {
         console.log('clicked');
       }}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -108,6 +108,9 @@ export const Tooltip: FC<TooltipProps> = React.memo(
       const tooltipReferenceId: React.MutableRefObject<string> = useRef<string>(
         `${tooltipId?.current}-reference`
       );
+      const tooltipWrapperId: React.MutableRefObject<string> = useRef<string>(
+        `${tooltipId?.current}-wrapper`
+      );
 
       let timeout: ReturnType<typeof setTimeout>;
       const {
@@ -577,7 +580,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
           <div
             className={referenceWrapperClassNames}
             style={wrapperStyle}
-            id={tooltipId?.current}
+            id={tooltipWrapperId?.current}
             onClick={(
               event: React.MouseEvent<HTMLDivElement, MouseEvent>
             ): void => {
@@ -630,7 +633,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
       const getPopup = (): JSX.Element => (
         <div
           className={referenceWrapperClassNames}
-          id={tooltipId?.current}
+          id={tooltipWrapperId?.current}
           style={wrapperStyle}
           ref={reference}
           {...(TRIGGER_TO_HANDLER_MAP_ON_LEAVE[trigger] && !gestureType


### PR DESCRIPTION
## SUMMARY:
- Dedupes `tooltipId`
- Adds `tooltipWrapperID`
- Updates story to work with screen readers via `tabIndex` and `aria-describedby` changes


https://github.com/EightfoldAI/octuple/assets/99700808/84ab67d6-98f3-44b5-9ccc-a4e9744a11cf


## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/763

## JIRA TASK (Eightfold Employees Only):
ENG-74737

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Tooltip` story works as expected using VoiceOver.