### PR TITLE
fix: slider: ensure touchmove is not prevented to enable default touch on mobile

### DIFF
--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -915,6 +915,7 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                   placement={'top'}
                   portal
                   portalRoot={sliderRef.current}
+                  preventTouchMoveDefault={false}
                   theme={TooltipTheme.dark}
                   {...tooltipProps}
                   tooltipStyle={getTooltipStyles(

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -73,6 +73,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         portalId,
         portalRoot,
         positionStrategy = 'absolute',
+        preventTouchMoveDefault = true,
         referenceOnClick,
         referenceOnKeydown,
         showTooltip,
@@ -134,7 +135,8 @@ export const Tooltip: FC<TooltipProps> = React.memo(
       });
 
       const gestureType: Gestures = useGestures(
-        refs.reference?.current as HTMLElement
+        refs.reference?.current as HTMLElement,
+        preventTouchMoveDefault
       );
 
       const toggle: Function =

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -128,6 +128,11 @@ export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
    */
   placement?: Placement;
   /**
+   * Whether to prevent the default behavior of touchmove.
+   * @default true
+   */
+  preventTouchMoveDefault?: boolean;
+  /**
    * Whether the Tooltip is portaled.
    * @default false
    */

--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -8,7 +8,8 @@ export enum Gestures {
   TapAndHold = 'TapAndHold',
 }
 const useGestures = (
-  swipeTarget: HTMLElement | Window | null
+  swipeTarget: HTMLElement | Window | null,
+  preventTouchMoveDefault: boolean = true
 ): Gestures | null => {
   const startTimeRef = useRef<number>(0);
   const touchStartXRef = useRef<number>(0);
@@ -71,7 +72,9 @@ const useGestures = (
       if (!swipeTarget) {
         return;
       }
-      e.preventDefault();
+      if (preventTouchMoveDefault) {
+        e.preventDefault();
+      }
     },
     [swipeTarget]
   );


### PR DESCRIPTION
## SUMMARY:
- Provides a argument (`preventTouchMoveDefault`) to determine if `touchmove` should be handled in `useGesture`
- Applies fix to Slider so the thumb may be dragged on mobile again

## JIRA TASK (Eightfold Employees Only):
ENG-75094

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Slider` stories behave as expected on touch screen by dragging the thumb.
## TEST PLAN:
