### PR TITLE
fix: input: updates validation status font color to latest specification

### DIFF
--- a/src/components/DateTimePicker/DatePicker/Styles/status.scss
+++ b/src/components/DateTimePicker/DatePicker/Styles/status.scss
@@ -3,20 +3,20 @@
 .picker {
   &-status-error {
     input {
-      @include placeholder(var(--disruptive-color));
+      @include placeholder(var(--input-error-placeholder-color));
     }
 
-    border-color: var(--disruptive-color);
-    color: var(--disruptive-color);
+    border-color: var(--input-error-border-color);
+    color: var(--input-error-text-color);
   }
 
   &-status-warning {
     input {
-      @include placeholder(var(--warning-color));
+      @include placeholder(var(--input-warning-placeholder-color));
     }
 
-    border-color: var(--warning-color);
-    color: var(--warning-color);
+    border-color: var(--input-warning-border-color);
+    color: var(--input-warning-text-color);
   }
 
   &-status-success {
@@ -24,7 +24,7 @@
       @include placeholder(var(--picker-input-foreground-color));
     }
 
-    border-color: var(--border-color);
-    color: var(--text-primary-color);
+    border-color: var(--input-success-border-color);
+    color: var(--input-success-text-color);
   }
 }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -406,17 +406,15 @@
   --input-placeholder-text-color: var(--text-secondary-color);
   --input-readonly-background-color: var(--grey-background1-color);
   --input-readonly-border-color: var(--grey-tertiary-color);
-  --input-readonly-text-color: var(--text-primary-color);
-  --input-success-text-color: var(--text-primary-color);
+  --input-readonly-text-color: var(--input-text-color);
+  --input-success-text-color: var(--input-text-color);
   --input-success-border-color: var(--input-border-color);
-  --input-success-text-color: var(--text-primary-color);
-  --input-success-border-color: var(--input-border-color);
-  --input-warning-text-color: var(--warning-color);
+  --input-warning-text-color: var(--input-text-color);
   --input-warning-border-color: var(--warning-color);
-  --input-warning-placeholder-color: var(--warning-color);
-  --input-error-text-color: var(--error-color);
+  --input-warning-placeholder-color: var(--input-placeholder-text-color);
+  --input-error-text-color: var(--input-text-color);
   --input-error-border-color: var(--error-color);
-  --input-error-placeholder-color: var(--error-color);
+  --input-error-placeholder-color: var(--input-placeholder-text-color);
   --input-disabled-placeholder-text-color: var(--text-tertiary-color);
 
   // ------ Tabs theme ------


### PR DESCRIPTION
## SUMMARY:
- Updates the default text validation status input font colors to `--text-primary-color` so they are consistent with invalidated state, deferring visual cue to its border and inline validation text

![validationFontColorCorrected](https://github.com/EightfoldAI/octuple/assets/99700808/df6fe238-8e76-4905-9fd6-3f1bb751e0d3)

## JIRA TASK (Eightfold Employees Only):
ENG-65381

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Form` stories behave as expected.