### PR TITLE
feat: table: expandable config improvements

### DIFF
--- a/src/components/Table/ExpandIcon.tsx
+++ b/src/components/Table/ExpandIcon.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Button, ButtonShape, ButtonVariant } from '../Button';
+import { IconName } from '../Icon';
 import { mergeClasses } from '../../shared/utilities';
 
 import styles from './Styles/table.module.scss';
@@ -20,18 +22,18 @@ function renderExpandIcon(collapseText: string, expandText: string) {
     disabled,
   }: DefaultExpandIconProps<RecordType>) {
     return (
-      <button
-        aria-label={expanded ? collapseText : expandText}
-        className={mergeClasses([
+      <Button
+        ariaLabel={expanded ? collapseText : expandText}
+        classNames={mergeClasses([
           styles.tableRowExpandIcon,
-          { [styles.tableRowExpandIconSpaced]: !expandable },
+          { [styles.tableRowExpandIconVisuallyHidden]: !expandable },
           { [styles.tableExpandedRow]: expandable && expanded },
-          {
-            [styles.tableRowExpandIconCollapsed]: expandable && !expanded,
-          },
-          { [styles.tableRowExpandIconDisabled]: !!disabled },
         ])}
         disabled={disabled}
+        htmlType="button"
+        iconProps={{
+          path: expanded ? IconName.mdiChevronUp : IconName.mdiChevronDown,
+        }}
         onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
           if (disabled) {
             return;
@@ -39,7 +41,8 @@ function renderExpandIcon(collapseText: string, expandText: string) {
           onExpand(record, e!);
           e?.stopPropagation();
         }}
-        type="button"
+        shape={ButtonShape.Round}
+        variant={ButtonVariant.Neutral}
       />
     );
   };

--- a/src/components/Table/Internal/Body/BodyRow.tsx
+++ b/src/components/Table/Internal/Body/BodyRow.tsx
@@ -48,13 +48,13 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
     expandIcon,
     expandedRowRender,
   } = useContext(BodyContext);
-  const [expandRended, setExpandRended] = useState<boolean>(false);
+  const [expandRendered, setExpandRendered] = useState<boolean>(false);
 
   const expanded: boolean = expandedKeys?.has(props.recordKey);
 
   useEffect(() => {
     if (expanded) {
-      setExpandRended(true);
+      setExpandRendered(true);
     }
   }, [expanded]);
 
@@ -111,7 +111,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
       data-row-key={rowKey}
       className={mergeClasses?.([
         classNames,
-        'table-row',
+        styles.tableRow,
         `table-row-level-${indent}`,
         computeRowClassName,
         additionalProps?.className,
@@ -191,7 +191,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
 
   // ======================== Expand Row =========================
   let expandRowNode: React.ReactElement;
-  if (rowSupportExpand && (expandRended || expanded)) {
+  if (rowSupportExpand && (expandRendered || expanded)) {
     const expandContent = expandedRowRender(
       record,
       index,
@@ -224,7 +224,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
   return (
     <>
       {baseRowNode}
-      {expandRowNode}
+      {rowSupportExpand && expanded && expandRowNode}
     </>
   );
 }

--- a/src/components/Table/Internal/Cell/index.tsx
+++ b/src/components/Table/Internal/Cell/index.tsx
@@ -245,7 +245,7 @@ function Cell<RecordType extends DefaultRecordType>(
       { [styles.tableCellFixRightFirst]: firstFixRight && supportSticky },
       { [styles.tableCellFixRightLast]: lastFixRight && supportSticky },
       { [styles.tableCellEllipsis]: ellipsis },
-      { ['table-cell-with-append']: appendNode },
+      { [styles.tableCellWithAppend]: appendNode },
       {
         [styles.tableCellFixSticky]:
           (isFixLeft || isFixRight) && isSticky && supportSticky,

--- a/src/components/Table/Internal/OcTable.tsx
+++ b/src/components/Table/Internal/OcTable.tsx
@@ -93,6 +93,7 @@ function OcTable<RecordType extends DefaultRecordType>(
   props: OcTableProps<RecordType>
 ) {
   const {
+    alternateRowColor,
     bordered,
     classNames,
     rowClassName,
@@ -741,6 +742,7 @@ function OcTable<RecordType extends DefaultRecordType>(
     <div
       className={mergeClasses([
         styles.table,
+        { [styles.tableAlternate]: alternateRowColor },
         { [styles.tableBordered]: bordered },
         {
           [styles.tableRowHover]: rowHoverBackgroundEnabled,

--- a/src/components/Table/Internal/OcTable.types.ts
+++ b/src/components/Table/Internal/OcTable.types.ts
@@ -486,6 +486,11 @@ export type ScrollerRef = {
 
 export interface OcTableProps<RecordType = unknown> {
   /**
+   * The Table Row background colors alternate.
+   * @default true
+   */
+  alternateRowColor?: boolean;
+  /**
    * Show all Table borders.
    */
   bordered?: boolean;

--- a/src/components/Table/Internal/Tests/ExpandRow.test.js
+++ b/src/components/Table/Internal/Tests/ExpandRow.test.js
@@ -573,15 +573,11 @@ describe('Table.Expand', () => {
     wrapper.find('.custom-expand-icon').first().simulate('click');
     expect(onExpand).toHaveBeenCalledWith(true, data[0]);
     expect(onExpand).toHaveBeenCalledTimes(1);
-    expect(
-      wrapper.find('.table-expanded-row').first().getDOMNode().style.display
-    ).toBe('');
+    expect(wrapper.find('.table-expanded-row').length).toBe(1);
     wrapper.find('.custom-expand-icon').first().simulate('click');
     expect(onExpand).toHaveBeenCalledWith(false, data[0]);
     expect(onExpand).toHaveBeenCalledTimes(2);
-    expect(
-      wrapper.find('.table-expanded-row').first().getDOMNode().style.display
-    ).toBe('none');
+    expect(wrapper.find('.table-expanded-row').length).toBe(0);
   });
 
   it('should be collapsible when `expandRowByClick` without custom `expandIcon`', () => {

--- a/src/components/Table/Internal/octable.module.scss
+++ b/src/components/Table/Internal/octable.module.scss
@@ -67,6 +67,12 @@
       }
     }
 
+    &.table-cell-with-append {
+      align-items: center;
+      display: flex;
+      justify-content: flex-start;
+    }
+
     &.table-cell-ellipsis {
       overflow: hidden;
       white-space: nowrap;
@@ -226,10 +232,16 @@
 
   &-alternate {
     tbody {
-      tr {
+      tr.table-row {
         &:nth-child(odd) {
           td {
             background-color: var(--table-background-alternate-color);
+          }
+
+          &:hover {
+            td {
+              background-color: var(--table-row-hover-background-color);
+            }
           }
         }
       }

--- a/src/components/Table/Styles/mixins.scss
+++ b/src/components/Table/Styles/mixins.scss
@@ -1,24 +1,3 @@
-$border-width: 1px;
-$border-color: var(--grey-background2-color);
-$border: $border-width solid $border-color;
-
-@mixin operation-unit() {
-  color: var(--primary-color);
-  text-decoration: none;
-  outline: none;
-  cursor: pointer;
-  transition: color $motion-duration-extra-fast;
-
-  &:focus:not(:disabled),
-  &:hover:not(:disabled) {
-    color: var(--primary-color);
-  }
-
-  &:active:not(:disabled) {
-    color: var(--primary-color);
-  }
-}
-
 @mixin table-border() {
   border: var(--table-border);
   border-radius: $table-border-radius;

--- a/src/components/Table/Styles/rtl.scss
+++ b/src/components/Table/Styles/rtl.scss
@@ -81,18 +81,6 @@
             margin-right: 0;
             margin-left: $space-xs;
           }
-
-          &:after {
-            transform: rotate(-90deg);
-          }
-
-          &-collapsed:before {
-            transform: rotate(180deg);
-          }
-
-          &-collapsed:after {
-            transform: rotate(0deg);
-          }
         }
 
         tr {

--- a/src/components/Table/Styles/size.scss
+++ b/src/components/Table/Styles/size.scss
@@ -73,10 +73,6 @@
           }
         }
       }
-
-      .table-selection-column {
-        padding-inline-start: calc($table-padding-horizontal-lg / 4);
-      }
     }
 
     &-medium {
@@ -117,10 +113,6 @@
               calc($table-padding-horizontal-md + ceil((14 * 1.4)));
           }
         }
-      }
-
-      .table-selection-column {
-        padding-inline-start: calc($table-padding-horizontal-md / 4);
       }
     }
 
@@ -166,10 +158,6 @@
               calc($table-padding-horizontal-sm + ceil((14 * 1.4)));
           }
         }
-      }
-
-      .table-selection-column {
-        padding-inline-start: calc($table-padding-horizontal-sm / 4);
       }
     }
   }

--- a/src/components/Table/Styles/table.module.scss
+++ b/src/components/Table/Styles/table.module.scss
@@ -161,7 +161,7 @@
     &-pagination {
       display: flex;
       flex-wrap: wrap;
-      margin: 16px 0;
+      margin: $space-m 0;
       row-gap: $space-xs;
 
       * {
@@ -267,6 +267,7 @@
     }
 
     &-filter-column {
+      align-items: center;
       display: flex;
       justify-content: space-between;
     }
@@ -352,7 +353,7 @@
 
     .selection-checkbox,
     .selection-radiobutton {
-      margin: 0 16px;
+      margin: 0 auto;
       label {
         span {
           margin-left: 0;
@@ -361,18 +362,6 @@
           &:last-child {
             visibility: hidden;
             width: 0;
-          }
-        }
-      }
-    }
-
-    &-alternate {
-      tbody {
-        tr {
-          &:nth-child(odd) {
-            td {
-              background-color: var(--table-background-alternate-color);
-            }
           }
         }
       }
@@ -439,89 +428,18 @@
     }
 
     &-row-expand-icon {
-      @include operation-unit();
-
       position: relative;
       display: inline-flex;
       float: left;
-      box-sizing: border-box;
-      width: 18px;
-      height: 18px;
-      padding: 0;
-      margin: 2px $space-m 0 $space-m;
-      color: inherit;
-      line-height: 18px;
-      background: var(--table-expand-icon-background-color);
-      border: 2px var(--table-border-style) var(--grey-secondary-color);
-      border-radius: $border-radius-s;
-      outline: none;
-      transform: scale(unit(22) / unit(18));
-      transition: all $motion-duration-extra-fast;
-      user-select: none;
+      margin: 0 $space-m;
 
-      &:focus:not(:disabled),
-      &:hover:not(:disabled),
-      &:active:not(:disabled) {
-        border-color: var(--table-header-icon-color);
-      }
-
-      &:before,
-      &:after {
-        position: absolute;
-        background: currentcolor;
-        transition: transform $motion-duration-extra-fast ease-out;
-        content: '';
-      }
-
-      &:before {
-        top: 6px;
-        right: 3px;
-        left: 3px;
-        height: 2px;
-      }
-
-      &:after {
-        top: 3px;
-        bottom: 3px;
-        left: 6px;
-        width: 2px;
-        transform: rotate(90deg);
-      }
-
-      &-collapsed:before {
-        transform: rotate(-180deg);
-      }
-
-      &-collapsed:after {
-        transform: rotate(0deg);
-      }
-
-      &-spaced {
-        &:before,
-        &:after {
-          display: none;
-          content: none;
-        }
-        background: transparent;
-        border: 0;
+      &-visually-hidden {
+        opacity: 0;
         visibility: hidden;
       }
 
       .table-row-indent + & {
-        margin-top: calc((14 * 20 - 2 * 3) / 2) -
-          ceil(calc((14 * 1.4 - 2 * 3) / 2));
         margin-right: $space-s;
-      }
-
-      // Hides the browser default keyboard focus-visible styles.
-      // Use the ConfigProvider instead.
-      &:focus-visible {
-        outline: none;
-      }
-
-      &-disabled {
-        cursor: not-allowed;
-        opacity: $disabled-alpha-value;
       }
     }
 
@@ -712,20 +630,6 @@
           }
         }
       }
-
-      &.table-alternate {
-        tbody {
-          tr {
-            &:nth-child(odd) {
-              &:hover {
-                td {
-                  background-color: var(--table-row-hover-background-color);
-                }
-              }
-            }
-          }
-        }
-      }
     }
   }
 }
@@ -793,19 +697,6 @@
     overflow: hidden;
     background-color: var(--table-header-filter-buttons-background-color);
     border-top: var(--table-border);
-  }
-}
-
-:global(.focus-visible) {
-  .table-wrapper {
-    .table {
-      &-row-expand-icon {
-        &.focus-visible,
-        &:focus-visible {
-          box-shadow: var(--focus-visible-box-shadow);
-        }
-      }
-    }
   }
 }
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1414,7 +1414,8 @@ export const Fixed_Columns_with_Scroller = Table_Wrapped_Story.bind({});
 export const Fixed_Columns_and_Header_with_Scroller = Table_Wrapped_Story.bind(
   {}
 );
-export const Selection = Table_Base_Story.bind({});
+export const Selection_CheckBox = Table_Base_Story.bind({});
+export const Selection_Radio = Table_Base_Story.bind({});
 export const Expandable_Row = Table_Base_Story.bind({});
 export const Expandable_Row_Custom_Button = Table_Base_Story.bind({});
 export const Order_Select_And_Expand_Column = Table_Base_Story.bind({});
@@ -1464,7 +1465,8 @@ export const __namedExportsOrder = [
   'Fixed_Columns_and_Header',
   'Fixed_Columns_with_Scroller',
   'Fixed_Columns_and_Header_with_Scroller',
-  'Selection',
+  'Selection_CheckBox',
+  'Selection_Radio',
   'Expandable_Row',
   'Expandable_Row_Custom_Button',
   'Order_Select_And_Expand_Column',
@@ -1636,10 +1638,18 @@ Fixed_Columns_and_Header_with_Scroller.args = {
   sticky: true,
 };
 
-Selection.args = {
+Selection_CheckBox.args = {
   ...tableArgs,
   rowSelection: {
     type: 'checkbox',
+    ...rowSelection,
+  },
+};
+
+Selection_Radio.args = {
+  ...tableArgs,
+  rowSelection: {
+    type: 'radio',
     ...rowSelection,
   },
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,17 +1,19 @@
 import React, { Component, FC, useEffect, useRef, useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Link } from '../Link';
-import { Stack } from '../Stack';
-import { Avatar } from '../Avatar';
 import Table from './index';
 import { TableSize } from './Table.types';
 import type { ColumnsType } from './Table.types';
-import { ResizeObserver } from '../../shared/ResizeObserver/ResizeObserver';
+import { Avatar } from '../Avatar';
+import { Button, ButtonShape, ButtonVariant } from '../Button';
+import { IconName } from '../Icon';
+import { Link } from '../Link';
 import { VariableSizeGrid as Grid } from 'react-window';
-import { mergeClasses } from '../../shared/utilities';
 import { PaginationLayoutOptions } from '../Pagination';
+import { Stack } from '../Stack';
 import { Tooltip, TooltipTheme } from '../Tooltip';
+import { ResizeObserver } from '../../shared/ResizeObserver/ResizeObserver';
+import { mergeClasses } from '../../shared/utilities';
 
 export default {
   title: 'Table',
@@ -516,11 +518,11 @@ const basicCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -594,11 +596,11 @@ const ellipsisCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -662,11 +664,11 @@ const ellipsisTooltipCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -772,11 +774,11 @@ const filterCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -827,11 +829,11 @@ const fixedCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -902,11 +904,11 @@ const groupingCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -985,6 +987,33 @@ const groupingCols: ColumnsType<DataType> = [
   },
 ];
 
+const expandColEnd: ColumnsType<DataType> = [
+  {
+    title: 'Role',
+    dataIndex: 'title',
+  },
+  {
+    title: 'Profile',
+    dataIndex: 'profile',
+    render: (text: string[]) => (
+      <Stack direction="horizontal" flexGap="s">
+        <Avatar alt={text[0]} theme="green" type="round">
+          {text[1]}
+        </Avatar>
+        <Stack direction="vertical" flexGap="xxs">
+          <Link variant="primary">{text[0]}</Link>
+          {text[2]}
+        </Stack>
+      </Stack>
+    ),
+  },
+  {
+    title: 'Level',
+    dataIndex: 'level',
+  },
+  Table.EXPAND_COLUMN,
+];
+
 const orderSelectAndExpandCols: ColumnsType<DataType> = [
   {
     title: 'Role',
@@ -995,11 +1024,11 @@ const orderSelectAndExpandCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -1022,11 +1051,11 @@ const sortCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -1070,11 +1099,11 @@ const responsiveCols: ColumnsType<DataType> = [
     title: 'Profile (show at medium)',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -1103,11 +1132,11 @@ const sortMultipleCols: ColumnsType<DataType> = [
     title: 'Profile',
     dataIndex: 'profile',
     render: (text: string[]) => (
-      <Stack direction="horizontal" gap="s">
+      <Stack direction="horizontal" flexGap="s">
         <Avatar alt={text[0]} theme="green" type="round">
           {text[1]}
         </Avatar>
-        <Stack direction="vertical" gap="xxs">
+        <Stack direction="vertical" flexGap="xxs">
           <Link variant="primary">{text[0]}</Link>
           {text[2]}
         </Stack>
@@ -1387,6 +1416,7 @@ export const Fixed_Columns_and_Header_with_Scroller = Table_Wrapped_Story.bind(
 );
 export const Selection = Table_Base_Story.bind({});
 export const Expandable_Row = Table_Base_Story.bind({});
+export const Expandable_Row_Custom_Button = Table_Base_Story.bind({});
 export const Order_Select_And_Expand_Column = Table_Base_Story.bind({});
 export const Colspan_Rows = Table_Base_Story.bind({});
 export const Sort = Table_Base_Story.bind({});
@@ -1436,6 +1466,7 @@ export const __namedExportsOrder = [
   'Fixed_Columns_and_Header_with_Scroller',
   'Selection',
   'Expandable_Row',
+  'Expandable_Row_Custom_Button',
   'Order_Select_And_Expand_Column',
   'Colspan_Rows',
   'Sort',
@@ -1617,7 +1648,68 @@ Expandable_Row.args = {
   ...tableArgs,
   expandableConfig: {
     expandedRowRender: (record: DataType) => (
-      <p style={{ margin: 0 }}>{record.description}</p>
+      <p style={{ margin: 12, maxWidth: 800 }}>{record.description}</p>
+    ),
+    rowExpandable: (record: DataType) => record.name !== 'Farida Ashfaq',
+    rowExpandDisabled: (record: DataType) => record.name === 'Cobbey Deevey',
+  },
+};
+
+Expandable_Row_Custom_Button.args = {
+  ...tableArgs,
+  columns: expandColEnd,
+  expandableConfig: {
+    expandIcon: ({
+      disabled,
+      expandable,
+      expanded,
+      onExpand,
+      record,
+    }: {
+      disabled: boolean;
+      expandable: boolean;
+      expanded: boolean;
+      onExpand: (record: DataType, e: React.MouseEvent<HTMLElement>) => void;
+      record: DataType;
+    }) => {
+      return (
+        <Stack direction="horizontal" flexGap="xs">
+          <Button
+            htmlType="button"
+            iconProps={{
+              path: IconName.mdiAccount,
+            }}
+            onClick={(_e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+              console.log('Custom button clicked');
+            }}
+            text="Custom Button"
+            variant={ButtonVariant.Primary}
+          />
+          <Button
+            ariaLabel={expanded ? 'Collapse row' : 'Expand row'}
+            disabled={disabled}
+            htmlType="button"
+            iconProps={{
+              path: expanded ? IconName.mdiChevronUp : IconName.mdiChevronDown,
+            }}
+            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+              if (disabled) {
+                return;
+              }
+              onExpand(record, e!);
+              e?.stopPropagation();
+            }}
+            shape={ButtonShape.Round}
+            style={{
+              display: expandable ? 'flex' : 'none',
+            }}
+            variant={ButtonVariant.Neutral}
+          />
+        </Stack>
+      );
+    },
+    expandedRowRender: (record: DataType) => (
+      <p style={{ margin: 12, maxWidth: 800 }}>{record.description}</p>
     ),
     rowExpandable: (record: DataType) => record.name !== 'Farida Ashfaq',
     rowExpandDisabled: (record: DataType) => record.name === 'Cobbey Deevey',
@@ -1633,7 +1725,7 @@ Order_Select_And_Expand_Column.args = {
   },
   expandableConfig: {
     expandedRowRender: (record: DataType) => (
-      <p style={{ margin: 0 }}>{record.description}</p>
+      <p style={{ margin: 12, maxWidth: 800 }}>{record.description}</p>
     ),
     rowExpandable: (record: DataType) => record.name !== 'Farida Ashfaq',
     rowExpandDisabled: (record: DataType) => record.name === 'Cobbey Deevey',
@@ -1695,6 +1787,7 @@ Tree.args = {
   ...tableArgs,
   columns: treeCols,
   dataSource: treeData,
+  indentSize: 36,
   pagination: false,
 };
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -625,10 +625,9 @@ function InternalTable<RecordType extends object = any>(
 
   // ========================== Expandable ==========================
 
-  mergedExpandableConfig.expandIcon = renderExpandIcon(
-    collapseText,
-    expandText
-  );
+  mergedExpandableConfig.expandIcon =
+    mergedExpandableConfig?.expandIcon ||
+    renderExpandIcon(collapseText, expandText);
 
   // Indent size
   if (typeof mergedExpandableConfig.indentSize !== 'number') {
@@ -759,6 +758,7 @@ function InternalTable<RecordType extends object = any>(
           <div ref={ref} className={wrapperClassNames} style={style}>
             {topPaginationNode}
             <OcTable<RecordType>
+              alternateRowColor={alternateRowColor}
               {...tableProps}
               columns={mergedColumns as OcTableProps<RecordType>['columns']}
               direction={htmlDir}
@@ -775,7 +775,6 @@ function InternalTable<RecordType extends object = any>(
                 {
                   [styles.tableSmall]: mergedSize === TableSize.Small,
                 },
-                { [styles.tableAlternate]: alternateRowColor },
                 { [styles.tableBordered]: bordered },
                 {
                   [styles.tableCellBordered]:

--- a/src/components/Table/Tests/Table.expand.test.tsx
+++ b/src/components/Table/Tests/Table.expand.test.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import Table from '../index';
+import { Button, ButtonShape, ButtonVariant } from '../../Button';
+import { IconName } from '../../Icon';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -70,11 +72,51 @@ describe('Table.expand', () => {
         columns={columns}
         dataSource={data}
         expandableConfig={{
-          expandIcon: () => <div className="expand-icon" />,
+          expandIcon: ({
+            disabled,
+            expandable,
+            expanded,
+            onExpand,
+            record,
+          }: {
+            disabled: boolean;
+            expandable: boolean;
+            expanded: boolean;
+            onExpand: (record: any, e: React.MouseEvent<HTMLElement>) => void;
+            record: any;
+          }) => {
+            return (
+              <Button
+                ariaLabel={expanded ? 'Collapse row' : 'Expand row'}
+                classNames="expand-icon"
+                disabled={disabled}
+                htmlType="button"
+                iconProps={{
+                  path: expanded
+                    ? IconName.mdiChevronUp
+                    : IconName.mdiChevronDown,
+                }}
+                onClick={(
+                  e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+                ) => {
+                  if (disabled) {
+                    return;
+                  }
+                  onExpand(record, e!);
+                  e?.stopPropagation();
+                }}
+                shape={ButtonShape.Round}
+                style={{
+                  display: expandable ? 'flex' : 'none',
+                }}
+                variant={ButtonVariant.Neutral}
+              />
+            );
+          },
         }}
       />
     );
-    const button = wrapper.find('.table-row-expand-icon').at(0);
+    const button = wrapper.find('.expand-icon').at(0);
     button.simulate('click');
     expect(wrapper.find('.indent-level-1').at(0).prop('style')).toHaveProperty(
       'paddingLeft',

--- a/src/components/Table/Tests/__snapshots__/Table.expand.test.tsx.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.expand.test.tsx.snap
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -105,11 +105,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Collapse row",
-                                            "class": "table-row-expand-icon table-expanded-row",
+                                            "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -117,11 +190,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -141,11 +216,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Collapse row",
-                                          "class": "table-row-expand-icon table-expanded-row",
+                                          "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -173,11 +321,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -221,11 +371,84 @@ LoadedCheerio {
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Expand row",
-                                              "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                              "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -233,11 +456,13 @@ LoadedCheerio {
                                             "prev": [Circular],
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -257,11 +482,84 @@ LoadedCheerio {
                                         },
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Expand row",
-                                            "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                            "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -289,11 +587,13 @@ LoadedCheerio {
                                           },
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -362,11 +662,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Expand row",
-                                            "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                            "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -374,11 +747,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -398,11 +773,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Expand row",
-                                          "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                          "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -430,11 +878,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -480,11 +930,84 @@ LoadedCheerio {
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Collapse row",
-                                              "class": "table-row-expand-icon table-expanded-row",
+                                              "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -492,11 +1015,13 @@ LoadedCheerio {
                                             "prev": [Circular],
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -516,11 +1041,84 @@ LoadedCheerio {
                                         },
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Collapse row",
-                                            "class": "table-row-expand-icon table-expanded-row",
+                                            "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -548,11 +1146,13 @@ LoadedCheerio {
                                           },
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -701,11 +1301,84 @@ LoadedCheerio {
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Collapse row",
-                                          "class": "table-row-expand-icon table-expanded-row",
+                                          "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -713,11 +1386,13 @@ LoadedCheerio {
                                         "prev": [Circular],
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -737,11 +1412,84 @@ LoadedCheerio {
                                     },
                                     Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Collapse row",
-                                        "class": "table-row-expand-icon table-expanded-row",
+                                        "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -769,11 +1517,13 @@ LoadedCheerio {
                                       },
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -817,11 +1567,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Expand row",
-                                            "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                            "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -829,11 +1652,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -853,11 +1678,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Expand row",
-                                          "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                          "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -885,11 +1783,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -958,11 +1858,84 @@ LoadedCheerio {
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Expand row",
-                                          "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                          "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -970,11 +1943,13 @@ LoadedCheerio {
                                         "prev": [Circular],
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -994,11 +1969,84 @@ LoadedCheerio {
                                     },
                                     Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Expand row",
-                                        "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                        "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -1026,11 +2074,13 @@ LoadedCheerio {
                                       },
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -1076,11 +2126,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Collapse row",
-                                            "class": "table-row-expand-icon table-expanded-row",
+                                            "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -1088,11 +2211,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -1112,11 +2237,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Collapse row",
-                                          "class": "table-row-expand-icon table-expanded-row",
+                                          "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -1144,11 +2342,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -1255,11 +2455,84 @@ LoadedCheerio {
                                     "namespace": "http://www.w3.org/1999/xhtml",
                                     "next": Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Collapse row",
-                                        "class": "table-row-expand-icon table-expanded-row",
+                                        "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -1267,11 +2540,13 @@ LoadedCheerio {
                                       "prev": [Circular],
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -1291,11 +2566,84 @@ LoadedCheerio {
                                   },
                                   Node {
                                     "attribs": Object {
+                                      "aria-disabled": "false",
                                       "aria-label": "Collapse row",
-                                      "class": "table-row-expand-icon table-expanded-row",
+                                      "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                       "type": "button",
                                     },
-                                    "children": Array [],
+                                    "children": Array [
+                                      Node {
+                                        "attribs": Object {
+                                          "aria-hidden": "false",
+                                          "class": "icon icon-wrapper",
+                                          "role": "presentation",
+                                        },
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "role": "presentation",
+                                              "style": "width: 20px; height: 20px;",
+                                              "viewBox": "0 0 24 24",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                  "style": "fill: currentColor;",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "d": undefined,
+                                                  "style": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "d": undefined,
+                                                  "style": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "namespace": "http://www.w3.org/2000/svg",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "role": undefined,
+                                              "style": undefined,
+                                              "viewBox": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "role": undefined,
+                                              "style": undefined,
+                                              "viewBox": undefined,
+                                            },
+                                          },
+                                        ],
+                                        "name": "span",
+                                        "namespace": "http://www.w3.org/1999/xhtml",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                        "x-attribsNamespace": Object {
+                                          "aria-hidden": undefined,
+                                          "class": undefined,
+                                          "role": undefined,
+                                        },
+                                        "x-attribsPrefix": Object {
+                                          "aria-hidden": undefined,
+                                          "class": undefined,
+                                          "role": undefined,
+                                        },
+                                      },
+                                    ],
                                     "name": "button",
                                     "namespace": "http://www.w3.org/1999/xhtml",
                                     "next": null,
@@ -1323,11 +2671,13 @@ LoadedCheerio {
                                     },
                                     "type": "tag",
                                     "x-attribsNamespace": Object {
+                                      "aria-disabled": undefined,
                                       "aria-label": undefined,
                                       "class": undefined,
                                       "type": undefined,
                                     },
                                     "x-attribsPrefix": Object {
+                                      "aria-disabled": undefined,
                                       "aria-label": undefined,
                                       "class": undefined,
                                       "type": undefined,
@@ -1371,11 +2721,84 @@ LoadedCheerio {
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Expand row",
-                                          "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                          "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -1383,11 +2806,13 @@ LoadedCheerio {
                                         "prev": [Circular],
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -1407,11 +2832,84 @@ LoadedCheerio {
                                     },
                                     Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Expand row",
-                                        "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                        "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -1439,11 +2937,13 @@ LoadedCheerio {
                                       },
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -1512,11 +3012,84 @@ LoadedCheerio {
                                     "namespace": "http://www.w3.org/1999/xhtml",
                                     "next": Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Expand row",
-                                        "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                        "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -1524,11 +3097,13 @@ LoadedCheerio {
                                       "prev": [Circular],
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -1548,11 +3123,84 @@ LoadedCheerio {
                                   },
                                   Node {
                                     "attribs": Object {
+                                      "aria-disabled": "false",
                                       "aria-label": "Expand row",
-                                      "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                      "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                       "type": "button",
                                     },
-                                    "children": Array [],
+                                    "children": Array [
+                                      Node {
+                                        "attribs": Object {
+                                          "aria-hidden": "false",
+                                          "class": "icon icon-wrapper",
+                                          "role": "presentation",
+                                        },
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "role": "presentation",
+                                              "style": "width: 20px; height: 20px;",
+                                              "viewBox": "0 0 24 24",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                  "style": "fill: currentColor;",
+                                                },
+                                                "children": Array [],
+                                                "name": "path",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "d": undefined,
+                                                  "style": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "d": undefined,
+                                                  "style": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "svg",
+                                            "namespace": "http://www.w3.org/2000/svg",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "role": undefined,
+                                              "style": undefined,
+                                              "viewBox": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "role": undefined,
+                                              "style": undefined,
+                                              "viewBox": undefined,
+                                            },
+                                          },
+                                        ],
+                                        "name": "span",
+                                        "namespace": "http://www.w3.org/1999/xhtml",
+                                        "next": null,
+                                        "parent": [Circular],
+                                        "prev": null,
+                                        "type": "tag",
+                                        "x-attribsNamespace": Object {
+                                          "aria-hidden": undefined,
+                                          "class": undefined,
+                                          "role": undefined,
+                                        },
+                                        "x-attribsPrefix": Object {
+                                          "aria-hidden": undefined,
+                                          "class": undefined,
+                                          "role": undefined,
+                                        },
+                                      },
+                                    ],
                                     "name": "button",
                                     "namespace": "http://www.w3.org/1999/xhtml",
                                     "next": null,
@@ -1580,11 +3228,13 @@ LoadedCheerio {
                                     },
                                     "type": "tag",
                                     "x-attribsNamespace": Object {
+                                      "aria-disabled": undefined,
                                       "aria-label": undefined,
                                       "class": undefined,
                                       "type": undefined,
                                     },
                                     "x-attribsPrefix": Object {
+                                      "aria-disabled": undefined,
                                       "aria-label": undefined,
                                       "class": undefined,
                                       "type": undefined,
@@ -1630,11 +3280,84 @@ LoadedCheerio {
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Collapse row",
-                                          "class": "table-row-expand-icon table-expanded-row",
+                                          "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -1642,11 +3365,13 @@ LoadedCheerio {
                                         "prev": [Circular],
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -1666,11 +3391,84 @@ LoadedCheerio {
                                     },
                                     Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Collapse row",
-                                        "class": "table-row-expand-icon table-expanded-row",
+                                        "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -1698,11 +3496,13 @@ LoadedCheerio {
                                       },
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -2296,7 +4096,7 @@ LoadedCheerio {
         "parent": [Circular],
         "prev": Node {
           "attribs": Object {
-            "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+            "class": "table table-alternate table-row-hover table table-medium table-row-hover",
           },
           "children": Array [
             Node {
@@ -2392,11 +4192,84 @@ LoadedCheerio {
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Collapse row",
-                                              "class": "table-row-expand-icon table-expanded-row",
+                                              "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -2404,11 +4277,13 @@ LoadedCheerio {
                                             "prev": [Circular],
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -2428,11 +4303,84 @@ LoadedCheerio {
                                         },
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Collapse row",
-                                            "class": "table-row-expand-icon table-expanded-row",
+                                            "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -2460,11 +4408,13 @@ LoadedCheerio {
                                           },
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -2508,11 +4458,84 @@ LoadedCheerio {
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "aria-label": "Expand row",
-                                                "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                                "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                                 "type": "button",
                                               },
-                                              "children": Array [],
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "aria-hidden": "false",
+                                                    "class": "icon icon-wrapper",
+                                                    "role": "presentation",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "role": "presentation",
+                                                        "style": "width: 20px; height: 20px;",
+                                                        "viewBox": "0 0 24 24",
+                                                      },
+                                                      "children": Array [
+                                                        Node {
+                                                          "attribs": Object {
+                                                            "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                            "style": "fill: currentColor;",
+                                                          },
+                                                          "children": Array [],
+                                                          "name": "path",
+                                                          "namespace": "http://www.w3.org/2000/svg",
+                                                          "next": null,
+                                                          "parent": [Circular],
+                                                          "prev": null,
+                                                          "type": "tag",
+                                                          "x-attribsNamespace": Object {
+                                                            "d": undefined,
+                                                            "style": undefined,
+                                                          },
+                                                          "x-attribsPrefix": Object {
+                                                            "d": undefined,
+                                                            "style": undefined,
+                                                          },
+                                                        },
+                                                      ],
+                                                      "name": "svg",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "role": undefined,
+                                                        "style": undefined,
+                                                        "viewBox": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "role": undefined,
+                                                        "style": undefined,
+                                                        "viewBox": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "span",
+                                                  "namespace": "http://www.w3.org/1999/xhtml",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "aria-hidden": undefined,
+                                                    "class": undefined,
+                                                    "role": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "aria-hidden": undefined,
+                                                    "class": undefined,
+                                                    "role": undefined,
+                                                  },
+                                                },
+                                              ],
                                               "name": "button",
                                               "namespace": "http://www.w3.org/1999/xhtml",
                                               "next": null,
@@ -2520,11 +4543,13 @@ LoadedCheerio {
                                               "prev": [Circular],
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "aria-label": undefined,
                                                 "class": undefined,
                                                 "type": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "aria-label": undefined,
                                                 "class": undefined,
                                                 "type": undefined,
@@ -2544,11 +4569,84 @@ LoadedCheerio {
                                           },
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Expand row",
-                                              "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                              "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -2576,11 +4674,13 @@ LoadedCheerio {
                                             },
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -2649,11 +4749,84 @@ LoadedCheerio {
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Expand row",
-                                              "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                              "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -2661,11 +4834,13 @@ LoadedCheerio {
                                             "prev": [Circular],
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -2685,11 +4860,84 @@ LoadedCheerio {
                                         },
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Expand row",
-                                            "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                            "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -2717,11 +4965,13 @@ LoadedCheerio {
                                           },
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -2767,11 +5017,84 @@ LoadedCheerio {
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": Node {
                                               "attribs": Object {
+                                                "aria-disabled": "false",
                                                 "aria-label": "Collapse row",
-                                                "class": "table-row-expand-icon table-expanded-row",
+                                                "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                                 "type": "button",
                                               },
-                                              "children": Array [],
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "aria-hidden": "false",
+                                                    "class": "icon icon-wrapper",
+                                                    "role": "presentation",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "role": "presentation",
+                                                        "style": "width: 20px; height: 20px;",
+                                                        "viewBox": "0 0 24 24",
+                                                      },
+                                                      "children": Array [
+                                                        Node {
+                                                          "attribs": Object {
+                                                            "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                            "style": "fill: currentColor;",
+                                                          },
+                                                          "children": Array [],
+                                                          "name": "path",
+                                                          "namespace": "http://www.w3.org/2000/svg",
+                                                          "next": null,
+                                                          "parent": [Circular],
+                                                          "prev": null,
+                                                          "type": "tag",
+                                                          "x-attribsNamespace": Object {
+                                                            "d": undefined,
+                                                            "style": undefined,
+                                                          },
+                                                          "x-attribsPrefix": Object {
+                                                            "d": undefined,
+                                                            "style": undefined,
+                                                          },
+                                                        },
+                                                      ],
+                                                      "name": "svg",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "role": undefined,
+                                                        "style": undefined,
+                                                        "viewBox": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "role": undefined,
+                                                        "style": undefined,
+                                                        "viewBox": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "span",
+                                                  "namespace": "http://www.w3.org/1999/xhtml",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "aria-hidden": undefined,
+                                                    "class": undefined,
+                                                    "role": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "aria-hidden": undefined,
+                                                    "class": undefined,
+                                                    "role": undefined,
+                                                  },
+                                                },
+                                              ],
                                               "name": "button",
                                               "namespace": "http://www.w3.org/1999/xhtml",
                                               "next": null,
@@ -2779,11 +5102,13 @@ LoadedCheerio {
                                               "prev": [Circular],
                                               "type": "tag",
                                               "x-attribsNamespace": Object {
+                                                "aria-disabled": undefined,
                                                 "aria-label": undefined,
                                                 "class": undefined,
                                                 "type": undefined,
                                               },
                                               "x-attribsPrefix": Object {
+                                                "aria-disabled": undefined,
                                                 "aria-label": undefined,
                                                 "class": undefined,
                                                 "type": undefined,
@@ -2803,11 +5128,84 @@ LoadedCheerio {
                                           },
                                           Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Collapse row",
-                                              "class": "table-row-expand-icon table-expanded-row",
+                                              "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -2835,11 +5233,13 @@ LoadedCheerio {
                                             },
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -2988,11 +5388,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Collapse row",
-                                            "class": "table-row-expand-icon table-expanded-row",
+                                            "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -3000,11 +5473,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -3024,11 +5499,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Collapse row",
-                                          "class": "table-row-expand-icon table-expanded-row",
+                                          "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -3056,11 +5604,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -3104,11 +5654,84 @@ LoadedCheerio {
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Expand row",
-                                              "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                              "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -3116,11 +5739,13 @@ LoadedCheerio {
                                             "prev": [Circular],
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -3140,11 +5765,84 @@ LoadedCheerio {
                                         },
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Expand row",
-                                            "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                            "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -3172,11 +5870,13 @@ LoadedCheerio {
                                           },
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -3245,11 +5945,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Expand row",
-                                            "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                            "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -3257,11 +6030,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -3281,11 +6056,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Expand row",
-                                          "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                          "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -3313,11 +6161,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -3363,11 +6213,84 @@ LoadedCheerio {
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": Node {
                                             "attribs": Object {
+                                              "aria-disabled": "false",
                                               "aria-label": "Collapse row",
-                                              "class": "table-row-expand-icon table-expanded-row",
+                                              "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                               "type": "button",
                                             },
-                                            "children": Array [],
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "aria-hidden": "false",
+                                                  "class": "icon icon-wrapper",
+                                                  "role": "presentation",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "role": "presentation",
+                                                      "style": "width: 20px; height: 20px;",
+                                                      "viewBox": "0 0 24 24",
+                                                    },
+                                                    "children": Array [
+                                                      Node {
+                                                        "attribs": Object {
+                                                          "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                          "style": "fill: currentColor;",
+                                                        },
+                                                        "children": Array [],
+                                                        "name": "path",
+                                                        "namespace": "http://www.w3.org/2000/svg",
+                                                        "next": null,
+                                                        "parent": [Circular],
+                                                        "prev": null,
+                                                        "type": "tag",
+                                                        "x-attribsNamespace": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                        "x-attribsPrefix": Object {
+                                                          "d": undefined,
+                                                          "style": undefined,
+                                                        },
+                                                      },
+                                                    ],
+                                                    "name": "svg",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "role": undefined,
+                                                      "style": undefined,
+                                                      "viewBox": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "span",
+                                                "namespace": "http://www.w3.org/1999/xhtml",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "aria-hidden": undefined,
+                                                  "class": undefined,
+                                                  "role": undefined,
+                                                },
+                                              },
+                                            ],
                                             "name": "button",
                                             "namespace": "http://www.w3.org/1999/xhtml",
                                             "next": null,
@@ -3375,11 +6298,13 @@ LoadedCheerio {
                                             "prev": [Circular],
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
                                             },
                                             "x-attribsPrefix": Object {
+                                              "aria-disabled": undefined,
                                               "aria-label": undefined,
                                               "class": undefined,
                                               "type": undefined,
@@ -3399,11 +6324,84 @@ LoadedCheerio {
                                         },
                                         Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Collapse row",
-                                            "class": "table-row-expand-icon table-expanded-row",
+                                            "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -3431,11 +6429,13 @@ LoadedCheerio {
                                           },
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -3542,11 +6542,84 @@ LoadedCheerio {
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Collapse row",
-                                          "class": "table-row-expand-icon table-expanded-row",
+                                          "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -3554,11 +6627,13 @@ LoadedCheerio {
                                         "prev": [Circular],
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -3578,11 +6653,84 @@ LoadedCheerio {
                                     },
                                     Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Collapse row",
-                                        "class": "table-row-expand-icon table-expanded-row",
+                                        "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -3610,11 +6758,13 @@ LoadedCheerio {
                                       },
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -3658,11 +6808,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Expand row",
-                                            "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                            "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -3670,11 +6893,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -3694,11 +6919,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Expand row",
-                                          "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                          "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -3726,11 +7024,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -3799,11 +7099,84 @@ LoadedCheerio {
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Expand row",
-                                          "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                          "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -3811,11 +7184,13 @@ LoadedCheerio {
                                         "prev": [Circular],
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
@@ -3835,11 +7210,84 @@ LoadedCheerio {
                                     },
                                     Node {
                                       "attribs": Object {
+                                        "aria-disabled": "false",
                                         "aria-label": "Expand row",
-                                        "class": "table-row-expand-icon table-row-expand-icon-spaced",
+                                        "class": "table-row-expand-icon table-row-expand-icon-visually-hidden button button-neutral button-medium round-shape icon-left",
                                         "type": "button",
                                       },
-                                      "children": Array [],
+                                      "children": Array [
+                                        Node {
+                                          "attribs": Object {
+                                            "aria-hidden": "false",
+                                            "class": "icon icon-wrapper",
+                                            "role": "presentation",
+                                          },
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "role": "presentation",
+                                                "style": "width: 20px; height: 20px;",
+                                                "viewBox": "0 0 24 24",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "d": "M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z",
+                                                    "style": "fill: currentColor;",
+                                                  },
+                                                  "children": Array [],
+                                                  "name": "path",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "d": undefined,
+                                                    "style": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "svg",
+                                              "namespace": "http://www.w3.org/2000/svg",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "role": undefined,
+                                                "style": undefined,
+                                                "viewBox": undefined,
+                                              },
+                                            },
+                                          ],
+                                          "name": "span",
+                                          "namespace": "http://www.w3.org/1999/xhtml",
+                                          "next": null,
+                                          "parent": [Circular],
+                                          "prev": null,
+                                          "type": "tag",
+                                          "x-attribsNamespace": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                          "x-attribsPrefix": Object {
+                                            "aria-hidden": undefined,
+                                            "class": undefined,
+                                            "role": undefined,
+                                          },
+                                        },
+                                      ],
                                       "name": "button",
                                       "namespace": "http://www.w3.org/1999/xhtml",
                                       "next": null,
@@ -3867,11 +7315,13 @@ LoadedCheerio {
                                       },
                                       "type": "tag",
                                       "x-attribsNamespace": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
                                       },
                                       "x-attribsPrefix": Object {
+                                        "aria-disabled": undefined,
                                         "aria-label": undefined,
                                         "class": undefined,
                                         "type": undefined,
@@ -3917,11 +7367,84 @@ LoadedCheerio {
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": Node {
                                           "attribs": Object {
+                                            "aria-disabled": "false",
                                             "aria-label": "Collapse row",
-                                            "class": "table-row-expand-icon table-expanded-row",
+                                            "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                             "type": "button",
                                           },
-                                          "children": Array [],
+                                          "children": Array [
+                                            Node {
+                                              "attribs": Object {
+                                                "aria-hidden": "false",
+                                                "class": "icon icon-wrapper",
+                                                "role": "presentation",
+                                              },
+                                              "children": Array [
+                                                Node {
+                                                  "attribs": Object {
+                                                    "role": "presentation",
+                                                    "style": "width: 20px; height: 20px;",
+                                                    "viewBox": "0 0 24 24",
+                                                  },
+                                                  "children": Array [
+                                                    Node {
+                                                      "attribs": Object {
+                                                        "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                        "style": "fill: currentColor;",
+                                                      },
+                                                      "children": Array [],
+                                                      "name": "path",
+                                                      "namespace": "http://www.w3.org/2000/svg",
+                                                      "next": null,
+                                                      "parent": [Circular],
+                                                      "prev": null,
+                                                      "type": "tag",
+                                                      "x-attribsNamespace": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                      "x-attribsPrefix": Object {
+                                                        "d": undefined,
+                                                        "style": undefined,
+                                                      },
+                                                    },
+                                                  ],
+                                                  "name": "svg",
+                                                  "namespace": "http://www.w3.org/2000/svg",
+                                                  "next": null,
+                                                  "parent": [Circular],
+                                                  "prev": null,
+                                                  "type": "tag",
+                                                  "x-attribsNamespace": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                  "x-attribsPrefix": Object {
+                                                    "role": undefined,
+                                                    "style": undefined,
+                                                    "viewBox": undefined,
+                                                  },
+                                                },
+                                              ],
+                                              "name": "span",
+                                              "namespace": "http://www.w3.org/1999/xhtml",
+                                              "next": null,
+                                              "parent": [Circular],
+                                              "prev": null,
+                                              "type": "tag",
+                                              "x-attribsNamespace": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                              "x-attribsPrefix": Object {
+                                                "aria-hidden": undefined,
+                                                "class": undefined,
+                                                "role": undefined,
+                                              },
+                                            },
+                                          ],
                                           "name": "button",
                                           "namespace": "http://www.w3.org/1999/xhtml",
                                           "next": null,
@@ -3929,11 +7452,13 @@ LoadedCheerio {
                                           "prev": [Circular],
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
                                           },
                                           "x-attribsPrefix": Object {
+                                            "aria-disabled": undefined,
                                             "aria-label": undefined,
                                             "class": undefined,
                                             "type": undefined,
@@ -3953,11 +7478,84 @@ LoadedCheerio {
                                       },
                                       Node {
                                         "attribs": Object {
+                                          "aria-disabled": "false",
                                           "aria-label": "Collapse row",
-                                          "class": "table-row-expand-icon table-expanded-row",
+                                          "class": "table-row-expand-icon table-expanded-row button button-neutral button-medium round-shape icon-left",
                                           "type": "button",
                                         },
-                                        "children": Array [],
+                                        "children": Array [
+                                          Node {
+                                            "attribs": Object {
+                                              "aria-hidden": "false",
+                                              "class": "icon icon-wrapper",
+                                              "role": "presentation",
+                                            },
+                                            "children": Array [
+                                              Node {
+                                                "attribs": Object {
+                                                  "role": "presentation",
+                                                  "style": "width: 20px; height: 20px;",
+                                                  "viewBox": "0 0 24 24",
+                                                },
+                                                "children": Array [
+                                                  Node {
+                                                    "attribs": Object {
+                                                      "d": "M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z",
+                                                      "style": "fill: currentColor;",
+                                                    },
+                                                    "children": Array [],
+                                                    "name": "path",
+                                                    "namespace": "http://www.w3.org/2000/svg",
+                                                    "next": null,
+                                                    "parent": [Circular],
+                                                    "prev": null,
+                                                    "type": "tag",
+                                                    "x-attribsNamespace": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                    "x-attribsPrefix": Object {
+                                                      "d": undefined,
+                                                      "style": undefined,
+                                                    },
+                                                  },
+                                                ],
+                                                "name": "svg",
+                                                "namespace": "http://www.w3.org/2000/svg",
+                                                "next": null,
+                                                "parent": [Circular],
+                                                "prev": null,
+                                                "type": "tag",
+                                                "x-attribsNamespace": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                                "x-attribsPrefix": Object {
+                                                  "role": undefined,
+                                                  "style": undefined,
+                                                  "viewBox": undefined,
+                                                },
+                                              },
+                                            ],
+                                            "name": "span",
+                                            "namespace": "http://www.w3.org/1999/xhtml",
+                                            "next": null,
+                                            "parent": [Circular],
+                                            "prev": null,
+                                            "type": "tag",
+                                            "x-attribsNamespace": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                            "x-attribsPrefix": Object {
+                                              "aria-hidden": undefined,
+                                              "class": undefined,
+                                              "role": undefined,
+                                            },
+                                          },
+                                        ],
                                         "name": "button",
                                         "namespace": "http://www.w3.org/1999/xhtml",
                                         "next": null,
@@ -3985,11 +7583,13 @@ LoadedCheerio {
                                         },
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,
                                         },
                                         "x-attribsPrefix": Object {
+                                          "aria-disabled": undefined,
                                           "aria-label": undefined,
                                           "class": undefined,
                                           "type": undefined,

--- a/src/components/Table/Tests/__snapshots__/Table.filter.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.filter.test.js.snap
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -3695,7 +3695,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -7381,7 +7381,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionexpandonleft.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionexpandonleft.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-row-hover",
         },
         "children": Array [
           Node {

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionleft.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionleft.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-row-hover",
         },
         "children": Array [
           Node {

--- a/src/components/Table/Tests/__snapshots__/Table.fixselectionwithcols.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.fixselectionwithcols.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-row-hover",
         },
         "children": Array [
           Node {

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.accepttrue.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.accepttrue.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -1324,7 +1324,7 @@ LoadedCheerio {
         "parent": [Circular],
         "prev": Node {
           "attribs": Object {
-            "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+            "class": "table table-alternate table-row-hover table table-medium table-row-hover",
           },
           "children": Array [
             Node {

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.nocrashonchange.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.nocrashonchange.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -1324,7 +1324,7 @@ LoadedCheerio {
         "parent": [Circular],
         "prev": Node {
           "attribs": Object {
-            "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+            "class": "table table-alternate table-row-hover table table-medium table-row-hover",
           },
           "children": Array [
             Node {

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.position.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.position.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -1324,7 +1324,7 @@ LoadedCheerio {
         "parent": [Circular],
         "prev": Node {
           "attribs": Object {
-            "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+            "class": "table table-alternate table-row-hover table table-medium table-row-hover",
           },
           "children": Array [
             Node {

--- a/src/components/Table/Tests/__snapshots__/Table.pagination.renders.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.pagination.renders.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -1324,7 +1324,7 @@ LoadedCheerio {
         "parent": [Circular],
         "prev": Node {
           "attribs": Object {
-            "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+            "class": "table table-alternate table-row-hover table table-medium table-row-hover",
           },
           "children": Array [
             Node {

--- a/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
@@ -1173,7 +1173,7 @@ LoadedCheerio {
             "next": null,
             "parent": Node {
               "attribs": Object {
-                "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+                "class": "table table-alternate table-row-hover table table-medium table-row-hover",
               },
               "children": Array [
                 [Circular],
@@ -2074,7 +2074,7 @@ LoadedCheerio {
           "next": null,
           "parent": Node {
             "attribs": Object {
-              "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+              "class": "table table-alternate table-row-hover table table-medium table-row-hover",
             },
             "children": Array [
               [Circular],
@@ -2961,7 +2961,7 @@ LoadedCheerio {
             "next": null,
             "parent": Node {
               "attribs": Object {
-                "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+                "class": "table table-alternate table-row-hover table table-medium table-row-hover",
               },
               "children": Array [
                 [Circular],
@@ -3137,7 +3137,7 @@ LoadedCheerio {
       "children": Array [
         Node {
           "attribs": Object {
-            "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+            "class": "table table-alternate table-row-hover table table-medium table-row-hover",
           },
           "children": Array [
             Node {
@@ -6800,7 +6800,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {
@@ -8640,7 +8640,7 @@ LoadedCheerio {
         "parent": [Circular],
         "prev": Node {
           "attribs": Object {
-            "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+            "class": "table table-alternate table-row-hover table table-medium table-row-hover",
           },
           "children": Array [
             Node {

--- a/src/components/Table/Tests/__snapshots__/Table.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.test.js.snap
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {

--- a/src/components/Table/Tests/__snapshots__/Table.usecolselectionwithkey.shot
+++ b/src/components/Table/Tests/__snapshots__/Table.usecolselectionwithkey.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover",
         },
         "children": Array [
           Node {

--- a/src/components/Table/Tests/__snapshots__/empty.render.shot
+++ b/src/components/Table/Tests/__snapshots__/empty.render.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table table-medium table-alternate table-row-hover table-empty",
+          "class": "table table-alternate table-row-hover table table-medium table-row-hover table-empty",
         },
         "children": Array [
           Node {

--- a/src/components/Table/Tests/__snapshots__/empty.renderfixedcols.shot
+++ b/src/components/Table/Tests/__snapshots__/empty.renderfixedcols.shot
@@ -9,7 +9,7 @@ LoadedCheerio {
     "children": Array [
       Node {
         "attribs": Object {
-          "class": "table table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-alternate table-row-hover table-empty",
+          "class": "table table-alternate table-row-hover table-fixed-column table-scroll-horizontal table-has-fix-left table table-medium table-row-hover table-empty",
         },
         "children": Array [
           Node {


### PR DESCRIPTION
## SUMMARY:
- Updates default Expand Icon `Button` to match latest UX specifications
- Updates Tree indentation to include the button in the indent
- Fixes `expandIcon` prop so that custom expand cell content may be used along with a custom expand icon button
- Adds new story demonstrating custom `expandIcon`
- Separates CheckBox and Radio Selection stories to better communicate the options
- Ensures the Selection component is horizontally centered in its cell
- Updates UTs

Before:
https://github.com/EightfoldAI/octuple/assets/99700808/ba7594e2-8ce4-49e7-80ea-582782a051c6

After:
https://github.com/EightfoldAI/octuple/assets/99700808/df14636c-a21c-4328-85e9-c7b5e5d4c0a1


## JIRA TASK (Eightfold Employees Only):
ENG-76971

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Table` stories behave as expected.