### PR TITLE
fix: upstream: ensures upstream snaps do not minify function component names

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -69,3 +69,5 @@ export const Icon: FC<IconProps> = ({
     </span>
   );
 };
+
+Icon.displayName = 'Icon';

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -857,6 +857,7 @@ type InternalTableType = typeof ForwardTable;
 
 interface TableInterface extends InternalTableType {
   defaultProps?: Partial<TableProps<any>>;
+  displayName?: string;
   SELECTION_COLUMN: typeof SELECTION_COLUMN;
   EXPAND_COLUMN: typeof OcTable.EXPAND_COLUMN;
   SELECTION_ALL: 'SELECT_ALL';
@@ -881,5 +882,7 @@ Table.SELECTION_NONE = SELECTION_NONE;
 Table.Column = Column;
 Table.ColumnGroup = ColumnGroup;
 Table.Summary = Summary;
+
+Table.displayName = 'Table';
 
 export default Table;

--- a/src/shared/ResizeObserver/ResizeObserver.tsx
+++ b/src/shared/ResizeObserver/ResizeObserver.tsx
@@ -40,4 +40,6 @@ export const ResizeObserver = (props: ResizeObserverProps) => {
   }) as any as React.ReactElement;
 };
 
+ResizeObserver.displayName = 'ResizeObserver';
+
 ResizeObserver.Collection = Collection;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = (_, { mode }) => ({
   entry: {
@@ -44,7 +45,14 @@ module.exports = (_, { mode }) => ({
     ],
   },
   optimization: {
-    minimizer: [`...`, new CssMinimizerPlugin()],
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          keep_fnames: true,
+        },
+      }),
+      new CssMinimizerPlugin(),
+    ],
   },
   plugins: [
     new MiniCssExtractPlugin({


### PR DESCRIPTION
## SUMMARY:
Currently with every semver merged into vscode apps, the snapshot tests reflect a partial guid representing the function names in Octuple (e.g. `<Xw />`), this change ensures function names are not minified so the snaps should not need to be updated with each version bump.

## JIRA TASK (Eightfold Employees Only):
ENG-77343

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify components behave as expected. Then follow the steps in the internal wiki to create your own tarball, install is in vscode react project and run the project, then execute `npm run test:update` Note that the function names are no longer minified and should persist from version to version. There may be one failing vscode unit test (DropdownWrapper), but that one is fixed, pending merge in v2.48.0 and is to be expected.