### PR TITLE
feat: stat: adds direction lineclamp fullwidth and maxwidth props

### DIFF
--- a/src/components/Tabs/Stat/Stat.tsx
+++ b/src/components/Tabs/Stat/Stat.tsx
@@ -21,6 +21,8 @@ export const Stat: FC<StatProps> = React.forwardRef(
       buttonProps,
       classNames,
       disabled,
+      direction = 'horizontal',
+      fullWidth = false,
       icon,
       label,
       loading,
@@ -36,8 +38,14 @@ export const Stat: FC<StatProps> = React.forwardRef(
   ) => {
     const htmlDir: string = useCanvasDirection();
 
-    const { currentActiveTab, statgrouptheme, readOnly, onTabClick } =
-      useTabs();
+    const {
+      currentActiveTab,
+      lineClamp,
+      maxWidth,
+      statgrouptheme,
+      readOnly,
+      onTabClick,
+    } = useTabs();
 
     const mergedTheme: StatThemeName = theme ?? statgrouptheme;
 
@@ -56,6 +64,8 @@ export const Stat: FC<StatProps> = React.forwardRef(
         [styles.statusSuccess]: status === 'success',
         [styles.statusWarning]: status === 'warning',
         [styles.statusError]: status === 'error',
+        [styles.vertical]: direction === 'vertical',
+        [styles.fullWidth]: fullWidth && direction === 'vertical',
         [styles.tabRtl]: htmlDir === 'rtl',
       },
       classNames,
@@ -77,7 +87,17 @@ export const Stat: FC<StatProps> = React.forwardRef(
       );
 
     const getLabel = (): JSX.Element =>
-      labelExists && <span className={styles.label}>{label}</span>;
+      labelExists && (
+        <span
+          className={mergeClasses([
+            styles.label,
+            { [styles.lineClamp]: lineClamp },
+          ])}
+          style={lineClamp ? { WebkitLineClamp: lineClamp } : null}
+        >
+          {label}
+        </span>
+      );
 
     const getRatioA = (): JSX.Element =>
       ratioAExists && <span className={styles.ratioA}>{ratioA}</span>;
@@ -110,6 +130,7 @@ export const Stat: FC<StatProps> = React.forwardRef(
         role="tab"
         disabled={disabled}
         onClick={!readOnly ? (e) => onTabClick(value, e) : null}
+        style={{ ...rest.style, maxWidth }}
       >
         <Stack
           direction="horizontal"

--- a/src/components/Tabs/StatTabs.stories.tsx
+++ b/src/components/Tabs/StatTabs.stories.tsx
@@ -176,6 +176,7 @@ export const Stat_Medium = Stat_Story.bind({});
 export const Stat_Small = Stat_Story.bind({});
 export const Stat_XSmall = Stat_Story.bind({});
 export const Stat_With_Button = Stat_With_Button_Story.bind({});
+export const Stat_Vertical = Stat_Story.bind({});
 export const Stat_Group_Read_Only = Stat_Story.bind({});
 export const Stat_Group_Theme = Stat_Story.bind({});
 export const Stat_Item_Theme_Override = Stat_Themed_Story.bind({});
@@ -188,6 +189,7 @@ export const __namedExportsOrder = [
   'Stat_Small',
   'Stat_XSmall',
   'Stat_With_Button',
+  'Stat_Vertical',
   'Stat_Group_Read_Only',
   'Stat_Group_Theme',
   'Stat_Item_Theme_Override',
@@ -205,20 +207,34 @@ const tabsArgs: Object = {
 
 Stat_Medium.args = {
   ...tabsArgs,
+  lineClamp: 2,
+  maxWidth: 240,
 };
 
 Stat_Small.args = {
   ...tabsArgs,
+  lineClamp: 2,
+  maxWidth: 240,
   size: TabSize.Small,
 };
 
 Stat_XSmall.args = {
   ...tabsArgs,
+  lineClamp: 1,
+  maxWidth: 240,
   size: TabSize.XSmall,
 };
 
 Stat_With_Button.args = {
   ...tabsArgs,
+  lineClamp: 1,
+};
+
+Stat_Vertical.args = {
+  ...tabsArgs,
+  direction: 'vertical',
+  fullWidth: false,
+  lineClamp: 2,
 };
 
 Stat_Group_Read_Only.args = {

--- a/src/components/Tabs/Tabs.context.tsx
+++ b/src/components/Tabs/Tabs.context.tsx
@@ -14,6 +14,10 @@ const TabsContext = createContext<Partial<ITabsContext>>({});
 const TabsProvider = ({
   alignIcon = TabIconAlign.Start,
   children,
+  direction = 'horizontal',
+  fullWidth = false,
+  lineClamp,
+  maxWidth,
   onChange,
   readOnly,
   size = TabSize.Medium,
@@ -36,6 +40,10 @@ const TabsProvider = ({
       value={{
         alignIcon,
         currentActiveTab,
+        direction,
+        fullWidth,
+        lineClamp,
+        maxWidth,
         onTabClick,
         readOnly,
         size,

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -248,6 +248,82 @@ describe('Tabs', () => {
     ).toMatchSnapshot();
   });
 
+  test('stat tabs medium vertical fullWidth snapshot', () => {
+    expect(
+      create(
+        <Tabs onChange={tabClick} value={'tab1'} direction="vertical" fullWidth>
+          {tabs.map((tab) => (
+            <Stat key={tab.value} {...tab} />
+          ))}
+        </Tabs>
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  test('stat tabs medium horizontal maxWidth lineClamp snapshot', () => {
+    expect(
+      create(
+        <Tabs
+          onChange={tabClick}
+          value={'tab1'}
+          direction="vertical"
+          maxWidth={240}
+          lineClamp={2}
+        >
+          {tabs.map((tab) => (
+            <Stat key={tab.value} {...tab} />
+          ))}
+        </Tabs>
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  test('stat tabs medium vertical snapshot', () => {
+    expect(
+      create(
+        <Tabs onChange={tabClick} value={'tab1'} direction="vertical">
+          {tabs.map((tab) => (
+            <Stat key={tab.value} {...tab} />
+          ))}
+        </Tabs>
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  test('stat tabs small vertical snapshot', () => {
+    expect(
+      create(
+        <Tabs
+          onChange={tabClick}
+          size={TabSize.Small}
+          value={'tab1'}
+          direction="vertical"
+        >
+          {tabs.map((tab) => (
+            <Stat key={tab.value} {...tab} />
+          ))}
+        </Tabs>
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
+  test('stat tabs xsmall vertical snapshot', () => {
+    expect(
+      create(
+        <Tabs
+          onChange={tabClick}
+          size={TabSize.XSmall}
+          value={'tab1'}
+          direction="vertical"
+        >
+          {tabs.map((tab) => (
+            <Stat key={tab.value} {...tab} />
+          ))}
+        </Tabs>
+      ).toJSON()
+    ).toMatchSnapshot();
+  });
+
   test('stat tabs with buttons snapshot', () => {
     expect(
       create(

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -13,6 +13,8 @@ export type SelectTabEvent<E = HTMLElement> =
 
 export type OnChangeHandler = (value: TabValue, event: SelectTabEvent) => void;
 
+export type TabsDirection = 'vertical' | 'horizontal';
+
 export enum TabIconAlign {
   Start = 'start',
   End = 'end',
@@ -55,6 +57,29 @@ export interface TabsContextProps {
    */
   children: React.ReactNode;
   /**
+   * Direction type - horizontal or vertical
+   * Use when variant is `stat`
+   * @default TabsDirection.horizontal
+   */
+  direction?: TabsDirection;
+  /**
+   * Assigns Tabs 100% width.
+   * Use when direction is `vertical` and variant is `stat`.
+   * @default false
+   */
+  fullWidth?: boolean;
+  /**
+   * Maximum number of lines the tabs' label can have.
+   * Use when variant is `stat`.
+   * `0` or `null` means no limit.
+   */
+  lineClamp?: number;
+  /**
+   * Assigns Tabs a max width.
+   * Use when the variant is `stat`.
+   */
+  maxWidth?: number;
+  /**
    * The onChange event handler.
    */
   onChange: OnChangeHandler;
@@ -94,6 +119,29 @@ export interface ITabsContext {
    * The currently active tab value.
    */
   currentActiveTab: TabValue;
+  /**
+   * Direction type - horizontal or vertical
+   * Use when variant is `stat`
+   * @default TabsDirection.horizontal
+   */
+  direction?: TabsDirection;
+  /**
+   * Assigns Tabs 100% width.
+   * Use when direction is `vertical` and variant is `stat`.
+   * @default false
+   */
+  fullWidth?: boolean;
+  /**
+   * Maximum number of lines the tab label can have.
+   * Use when variant is `stat`.
+   * `0` or `null` means no limit.
+   */
+  lineClamp?: number;
+  /**
+   * Assigns Tabs a max width.
+   * Use when the variant is `stat`.
+   */
+  maxWidth?: number;
   /**
    * The onClick handler of the tab.
    */
@@ -170,6 +218,26 @@ export interface StatProps extends Omit<TabProps, 'badgeContent'> {
    */
   buttonProps?: ButtonProps;
   /**
+   * Direction type - horizontal or vertical
+   * @default TabsDirection.horizontal
+   */
+  direction?: TabsDirection;
+  /**
+   * Assigns Tabs 100% width.
+   * Use when direction is `vertical`.
+   * @default false
+   */
+  fullWidth?: boolean;
+  /**
+   * Maximum number of lines the tab label can have.
+   * `0` or `null` means no limit.
+   */
+  lineClamp?: number;
+  /**
+   * Assigns Tab a max width.
+   */
+  maxWidth?: number;
+  /**
    * The stat tab 'a' ratio value, e.g. [1]/2.
    */
   ratioA?: string | number;
@@ -205,11 +273,34 @@ export interface TabsProps extends Omit<OcBaseProps<HTMLElement>, 'onChange'> {
    */
   children: React.ReactElement<TabProps> | React.ReactElement<TabProps>[];
   /**
+   * Direction type - horizontal or vertical
+   * Use when variant is `stat`
+   * @default TabsDirection.horizontal
+   */
+  direction?: TabsDirection;
+  /**
    * Use when variant is `stat`.
    * If the stat tabs are separated by a dashed line or not.
    * @default true
    */
   divider?: boolean;
+  /**
+   * Assigns Tabs 100% width.
+   * Use when direction is `vertical` and variant is `stat`.
+   * @default false
+   */
+  fullWidth?: boolean;
+  /**
+   * Maximum number of lines the tab label can have.
+   * Use when variant is `stat`.
+   * `0` or `null` means no limit.
+   */
+  lineClamp?: number;
+  /**
+   * Assigns Tabs a max width.
+   * Use when the variant is `stat`.
+   */
+  maxWidth?: number;
   /**
    * Callback called on click of a tab.
    * @param value {TabValue}

--- a/src/components/Tabs/Tabs/AnimatedTabs.tsx
+++ b/src/components/Tabs/Tabs/AnimatedTabs.tsx
@@ -9,10 +9,11 @@ import styles from '../tabs.module.scss';
 export const AnimatedTabs: FC<TabsProps> = React.forwardRef(
   (
     {
-      alignIcon = TabIconAlign.Start,
       bordered = true,
       children,
       classNames,
+      direction = 'horizontal',
+      fullWidth = false,
       onChange,
       scrollable,
       divider = true,
@@ -39,6 +40,10 @@ export const AnimatedTabs: FC<TabsProps> = React.forwardRef(
         [styles.stat]: variant === TabVariant.stat,
         [styles.bordered]: variant === TabVariant.stat && bordered,
         [styles.divider]: variant === TabVariant.stat && divider,
+        [styles.vertical]:
+          direction === 'vertical' && variant === TabVariant.stat,
+        [styles.fullWidth]:
+          fullWidth && direction === 'vertical' && variant === TabVariant.stat,
         [styles.scrollable]: scrollable,
       },
       classNames,

--- a/src/components/Tabs/Tabs/index.tsx
+++ b/src/components/Tabs/Tabs/index.tsx
@@ -8,6 +8,10 @@ export const Tabs: FC<TabsProps> = React.forwardRef(
     const {
       alignIcon,
       children,
+      direction,
+      fullWidth,
+      lineClamp,
+      maxWidth,
       onChange,
       readOnly,
       size,
@@ -18,6 +22,10 @@ export const Tabs: FC<TabsProps> = React.forwardRef(
     return (
       <TabsProvider
         alignIcon={alignIcon}
+        direction={direction}
+        fullWidth={fullWidth}
+        lineClamp={lineClamp}
+        maxWidth={maxWidth}
         onChange={onChange}
         readOnly={readOnly}
         size={size}

--- a/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -696,10 +696,12 @@ exports[`Tabs pill tabs small snapshot 1`] = `
 </div>
 `;
 
-exports[`Tabs stat tabs medium snapshot 1`] = `
+exports[`Tabs stat tabs medium horizontal maxWidth lineClamp snapshot 1`] = `
 <div>
   <div
     className="tab-wrap"
+    lineClamp={2}
+    maxWidth={240}
     role="tablist"
     value="tab1"
   >
@@ -709,6 +711,11 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
       className="tab undefined active"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": 240,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -757,7 +764,12 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
           }
         >
           <span
-            className="label"
+            className="label line-clamp"
+            style={
+              Object {
+                "WebkitLineClamp": 2,
+              }
+            }
           >
             Tab 1
           </span>
@@ -775,6 +787,11 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": 240,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -823,7 +840,12 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
           }
         >
           <span
-            className="label"
+            className="label line-clamp"
+            style={
+              Object {
+                "WebkitLineClamp": 2,
+              }
+            }
           >
             Tab 2
           </span>
@@ -841,6 +863,11 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": 240,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -889,7 +916,12 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
           }
         >
           <span
-            className="label"
+            className="label line-clamp"
+            style={
+              Object {
+                "WebkitLineClamp": 2,
+              }
+            }
           >
             Tab 3
           </span>
@@ -908,6 +940,98 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
       disabled={true}
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": 240,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label line-clamp"
+            style={
+              Object {
+                "WebkitLineClamp": 2,
+              }
+            }
+          >
+            Tab 4
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Tabs stat tabs medium snapshot 1`] = `
+<div>
+  <div
+    className="tab-wrap"
+    role="tablist"
+    value="tab1"
+  >
+    <button
+      aria-label="Tab 1"
+      aria-selected={true}
+      className="tab undefined active"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -957,6 +1081,824 @@ exports[`Tabs stat tabs medium snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
+          >
+            Tab 1
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 2"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 2
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 3"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 3
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 4"
+      aria-selected={false}
+      className="tab undefined"
+      disabled={true}
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 4
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Tabs stat tabs medium vertical fullWidth snapshot 1`] = `
+<div>
+  <div
+    className="tab-wrap"
+    role="tablist"
+    value="tab1"
+  >
+    <button
+      aria-label="Tab 1"
+      aria-selected={true}
+      className="tab undefined active"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 1
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 2"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 2
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 3"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 3
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 4"
+      aria-selected={false}
+      className="tab undefined"
+      disabled={true}
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 4
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Tabs stat tabs medium vertical snapshot 1`] = `
+<div>
+  <div
+    className="tab-wrap"
+    role="tablist"
+    value="tab1"
+  >
+    <button
+      aria-label="Tab 1"
+      aria-selected={true}
+      className="tab undefined active"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 1
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 2"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 2
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 3"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 3
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 4"
+      aria-selected={false}
+      className="tab undefined"
+      disabled={true}
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
           >
             Tab 4
           </span>
@@ -985,6 +1927,11 @@ exports[`Tabs stat tabs small snapshot 1`] = `
       className="tab undefined active"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1034,6 +1981,7 @@ exports[`Tabs stat tabs small snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 1
           </span>
@@ -1051,6 +1999,11 @@ exports[`Tabs stat tabs small snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1100,6 +2053,7 @@ exports[`Tabs stat tabs small snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 2
           </span>
@@ -1117,6 +2071,11 @@ exports[`Tabs stat tabs small snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1166,6 +2125,7 @@ exports[`Tabs stat tabs small snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 3
           </span>
@@ -1184,6 +2144,11 @@ exports[`Tabs stat tabs small snapshot 1`] = `
       disabled={true}
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1233,6 +2198,307 @@ exports[`Tabs stat tabs small snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
+          >
+            Tab 4
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Tabs stat tabs small vertical snapshot 1`] = `
+<div>
+  <div
+    className="tab-wrap small"
+    role="tablist"
+    value="tab1"
+  >
+    <button
+      aria-label="Tab 1"
+      aria-selected={true}
+      className="tab undefined active"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 1
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 2"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 2
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 3"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 3
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 4"
+      aria-selected={false}
+      className="tab undefined"
+      disabled={true}
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
           >
             Tab 4
           </span>
@@ -1261,6 +2527,11 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
       className="tab undefined active"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1310,6 +2581,7 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 1
           </span>
@@ -1362,6 +2634,11 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1411,6 +2688,7 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 2
           </span>
@@ -1463,6 +2741,11 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1512,6 +2795,7 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 3
           </span>
@@ -1565,6 +2849,11 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
       disabled={true}
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1614,6 +2903,7 @@ exports[`Tabs stat tabs with buttons snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 4
           </span>
@@ -1677,6 +2967,11 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
       className="tab undefined active"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1726,6 +3021,7 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 1
           </span>
@@ -1743,6 +3039,11 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1792,6 +3093,7 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 2
           </span>
@@ -1809,6 +3111,11 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
       className="tab undefined"
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1858,6 +3165,7 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
           >
             Tab 3
           </span>
@@ -1876,6 +3184,11 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
       disabled={true}
       onClick={[Function]}
       role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
     >
       <div
         className="stack full-width horizontal undefined gap-m"
@@ -1925,6 +3238,307 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
         >
           <span
             className="label"
+            style={null}
+          >
+            Tab 4
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Tabs stat tabs xsmall vertical snapshot 1`] = `
+<div>
+  <div
+    className="tab-wrap"
+    role="tablist"
+    value="tab1"
+  >
+    <button
+      aria-label="Tab 1"
+      aria-selected={true}
+      className="tab undefined active"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 1
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 2"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 2
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 3"
+      aria-selected={false}
+      className="tab undefined"
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
+          >
+            Tab 3
+          </span>
+          <span
+            className="label"
+          >
+             
+          </span>
+        </div>
+      </div>
+    </button>
+    <button
+      aria-label="Tab 4"
+      aria-selected={false}
+      className="tab undefined"
+      disabled={true}
+      onClick={[Function]}
+      role="tab"
+      style={
+        Object {
+          "maxWidth": undefined,
+        }
+      }
+    >
+      <div
+        className="stack full-width horizontal undefined gap-m"
+        style={
+          Object {
+            "alignItems": "center",
+            "flexWrap": undefined,
+            "justifyContent": "center",
+          }
+        }
+      >
+        <span
+          aria-hidden={false}
+          className="icon icon-wrapper"
+          role="presentation"
+          style={null}
+        >
+          <svg
+            role="presentation"
+            style={
+              Object {
+                "height": "40px",
+                "width": "40px",
+              }
+            }
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"
+              style={
+                Object {
+                  "fill": "currentColor",
+                }
+              }
+            />
+          </svg>
+        </span>
+        <div
+          className="stack full-width vertical undefined"
+          style={
+            Object {
+              "alignItems": undefined,
+              "flexWrap": undefined,
+              "justifyContent": undefined,
+            }
+          }
+        >
+          <span
+            className="label"
+            style={null}
           >
             Tab 4
           </span>
@@ -1943,6 +3557,7 @@ exports[`Tabs stat tabs xsmall snapshot 1`] = `
 exports[`Tabs tabs alignIcon end 1`] = `
 <div>
   <div
+    alignIcon="end"
     className="tab-wrap pill"
     role="tablist"
     value="tab1"
@@ -2117,6 +3732,7 @@ exports[`Tabs tabs alignIcon end 1`] = `
 exports[`Tabs tabs alignIcon start 1`] = `
 <div>
   <div
+    alignIcon="start"
     className="tab-wrap pill"
     role="tablist"
     value="tab1"
@@ -2291,6 +3907,7 @@ exports[`Tabs tabs alignIcon start 1`] = `
 exports[`Tabs tabs badgeContent 1`] = `
 <div>
   <div
+    alignIcon="start"
     className="tab-wrap pill"
     role="tablist"
     value="tab1"

--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -10,6 +10,10 @@
     border-bottom: 1px solid var(--tab-underline);
   }
 
+  &.vertical {
+    flex-direction: column;
+  }
+
   .tab {
     align-items: center;
     border: none;
@@ -238,7 +242,7 @@
     align-items: center;
     background: var(--bg);
     border: var(--border-width) solid var(--bg);
-    border-radius: $border-radius-xl;
+    border-radius: var(--stat-tab-border-radius-m);
     display: flex;
     padding: $space-ml $space-s;
     width: fit-content;
@@ -276,7 +280,7 @@
       --active-border: var(--stat-tab-active-border-color);
       --bg: var(--stat-tab-background-color);
       --border: var(--stat-tab-border-color);
-      --border-radius: var(--stat-tab-border-radius);
+      --border-radius: var(--stat-tab-border-radius-m);
       --divider-height: 84px;
       --divider-width: 1px;
       --height: 116px;
@@ -298,7 +302,7 @@
       height: var(--height);
       margin: 0 $space-s;
       min-width: var(--min-width);
-      padding: $space-ml $space-m;
+      padding: $space-m;
       transition: all $motion-duration-extra-fast $motion-easing-easeinout 0s;
       width: var(--width);
 
@@ -324,6 +328,15 @@
       .label {
         font-size: $text-font-size-3;
         line-height: $text-line-height-3;
+        white-space: normal;
+        word-break: break-all;
+
+        &.line-clamp {
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          overflow-y: hidden;
+          text-overflow: ellipsis;
+        }
       }
 
       .ratio-a {
@@ -532,17 +545,18 @@
     }
 
     &.small {
+      border-radius: var(--stat-tab-border-radius-s);
       padding: $space-s $space-xxs;
 
       .tab {
-        --border-radius: 24px;
+        --border-radius: var(--stat-tab-border-radius-s);
         --divider-height: 40px;
         --height: 72px;
         --icon-height: 48px;
         --icon-width: 48px;
         --min-width: 136px;
         margin: 0 $space-xs;
-        padding: $space-s $space-xs;
+        padding: $space-s;
 
         .icon {
           height: var(--icon-height);
@@ -552,7 +566,7 @@
 
         .label {
           font-size: $text-font-size-2;
-          line-height: $text-line-height-2;
+          line-height: $text-line-height-1;
         }
 
         .ratio-a {
@@ -579,20 +593,46 @@
           }
         }
       }
+
+      &:not(.bordered) {
+        padding: 0;
+
+        &.divider {
+          padding: 0;
+
+          .tab:not(.tab-rtl) {
+            &:first-of-type {
+              margin-left: 0;
+            }
+            &:last-of-type {
+              margin-right: 0;
+            }
+          }
+          .tab-rtl {
+            &:first-of-type {
+              margin-right: 0;
+            }
+            &:last-of-type {
+              margin-left: 0;
+            }
+          }
+        }
+      }
     }
 
     &.xsmall {
+      border-radius: var(--stat-tab-border-radius-xs);
       padding: $space-xs 0;
 
       .tab {
-        --border-radius: 20px;
+        --border-radius: var(--stat-tab-border-radius-xs);
         --divider-height: 20px;
         --height: 48px;
         --icon-height: 32px;
         --icon-width: 32px;
         --min-width: 90px;
         margin: 0 $space-xs;
-        padding: $space-xxs $space-xs;
+        padding: $space-xs;
 
         .icon {
           height: var(--icon-height);
@@ -602,7 +642,7 @@
 
         .label {
           font-size: $text-font-size-2;
-          line-height: $text-line-height-2;
+          line-height: $text-line-height-1;
         }
 
         .ratio-a {
@@ -643,6 +683,276 @@
               margin: 0 $space-s 0 $space-xs;
             }
           }
+        }
+      }
+
+      &:not(.bordered) {
+        padding: 0;
+
+        &.divider {
+          padding: 0;
+
+          .tab:not(.tab-rtl) {
+            &:first-of-type {
+              margin-left: 0;
+            }
+            &:last-of-type {
+              margin-right: 0;
+            }
+          }
+          .tab-rtl {
+            &:first-of-type {
+              margin-right: 0;
+            }
+            &:last-of-type {
+              margin-left: 0;
+            }
+          }
+        }
+      }
+    }
+
+    &.vertical {
+      padding: $space-m;
+
+      .tab {
+        --divider-height: 1px;
+        --divider-width: 100%;
+        height: auto;
+        min-height: var(--height);
+        margin: $space-xs 0;
+
+        &:first-of-type {
+          margin: 0 0 $space-xs;
+        }
+
+        &:last-of-type {
+          margin: $space-xs 0 0;
+        }
+      }
+
+      &.divider {
+        padding: 0 $space-m;
+
+        .tab {
+          margin: $space-m 0;
+
+          &:first-of-type {
+            margin: $space-m 0;
+          }
+
+          &:last-of-type {
+            margin: $space-m 0;
+          }
+
+          &:not(:last-of-type):after {
+            right: unset;
+            top: calc(100% + calc($space-m + 1px));
+          }
+          &-rtl:not(:last-of-type):after {
+            right: unset;
+            left: unset;
+          }
+
+          &-rtl {
+            &:first-of-type {
+              margin: $space-m 0;
+            }
+
+            &:last-of-type {
+              margin: $space-m 0;
+            }
+          }
+        }
+      }
+
+      &:not(.bordered) {
+        padding: 0;
+
+        &.divider {
+          padding: 0;
+
+          .tab:not(.tab-rtl) {
+            &:first-of-type {
+              margin: 0 0 $space-m;
+            }
+            &:last-of-type {
+              margin: $space-m 0 0;
+            }
+          }
+          .tab-rtl {
+            &:first-of-type {
+              margin: 0 0 $space-m;
+            }
+            &:last-of-type {
+              margin: $space-m 0 0;
+            }
+          }
+        }
+      }
+
+      &.small {
+        padding: $space-s;
+
+        .tab {
+          --divider-height: 1px;
+          --height: 80px;
+          margin: 6px 0;
+
+          &:first-of-type {
+            margin: 0 0 6px;
+          }
+
+          &:last-of-type {
+            margin: 6px 0 0;
+          }
+        }
+
+        &.divider {
+          padding: $space-s;
+
+          .tab {
+            margin: $space-s 0;
+
+            &:first-of-type {
+              margin: 0 0 $space-s;
+            }
+
+            &:last-of-type {
+              margin: $space-s 0 0;
+            }
+
+            &:not(:last-of-type):after {
+              right: unset;
+              top: calc(100% + calc($space-s + 1px));
+            }
+            &-rtl:not(:last-of-type):after {
+              right: unset;
+              left: unset;
+            }
+
+            &-rtl {
+              &:first-of-type {
+                margin: $space-s 0;
+              }
+
+              &:last-of-type {
+                margin: $space-s 0;
+              }
+            }
+          }
+        }
+
+        &:not(.bordered) {
+          padding: 0;
+
+          &.divider {
+            padding: 0;
+
+            .tab:not(.tab-rtl) {
+              &:first-of-type {
+                margin: 0 0 $space-s;
+              }
+              &:last-of-type {
+                margin: $space-s 0 0;
+              }
+            }
+            .tab-rtl {
+              &:first-of-type {
+                margin: 0 0 $space-s;
+              }
+              &:last-of-type {
+                margin: $space-s 0 0;
+              }
+            }
+          }
+        }
+      }
+
+      &.xsmall {
+        padding: $space-xs;
+
+        .tab {
+          --divider-height: 1px;
+          --height: 56px;
+          margin: $space-xxs 0;
+
+          &:first-of-type {
+            margin: 0 0 $space-xxs;
+          }
+
+          &:last-of-type {
+            margin: $space-xxs 0 0;
+          }
+        }
+
+        &.divider {
+          padding: $space-xs;
+
+          .tab {
+            margin: $space-xs 0;
+
+            &:first-of-type {
+              margin: 0 0 $space-xs;
+            }
+
+            &:last-of-type {
+              margin: $space-xs 0 0;
+            }
+
+            &:not(:last-of-type):after {
+              right: unset;
+              top: calc(100% + calc($space-xs + 1px));
+            }
+            &-rtl:not(:last-of-type):after {
+              right: unset;
+              left: unset;
+            }
+
+            &-rtl {
+              &:first-of-type {
+                margin: 0 0 $space-xs;
+              }
+
+              &:last-of-type {
+                margin: $space-xs 0 0;
+              }
+            }
+          }
+        }
+
+        &:not(.bordered) {
+          padding: 0;
+
+          &.divider {
+            padding: 0;
+
+            .tab:not(.tab-rtl) {
+              &:first-of-type {
+                margin: 0 0 $space-xs;
+              }
+              &:last-of-type {
+                margin: $space-xs 0 0;
+              }
+            }
+            .tab-rtl {
+              &:first-of-type {
+                margin: 0 0 $space-xs;
+              }
+              &:last-of-type {
+                margin: $space-xs 0 0;
+              }
+            }
+          }
+        }
+      }
+
+      &.full-width {
+        width: 100%;
+
+        .tab {
+          --min-width: 100%;
+          --width: 100%;
         }
       }
     }

--- a/src/styles/themes/_default-theme.scss
+++ b/src/styles/themes/_default-theme.scss
@@ -450,13 +450,9 @@
   // ------ Tabs theme ------
 
   // ------ Stat tab theme ------
-  --stat-tabs-border-radius: var(--border-radius-xl);
-  --stat-tabs-border-width: 1px;
-  --stat-tabs-border-style: solid;
-  --stat-tabs-border-color: var(--border-color);
-
-  // Individual tabs
-  --stat-tab-border-radius: 40px;
+  --stat-tab-border-radius-m: 40px;
+  --stat-tab-border-radius-s: 24px;
+  --stat-tab-border-radius-xs: 16px;
   --stat-tab-label-color: var(--text-secondary-color);
   --stat-tab-background-color: var(--background-color);
   --stat-tab-border-color: var(--stat-tab-background-color);


### PR DESCRIPTION
## SUMMARY:
- Adds `direction` prop for `horizontal` or `vertical` support to `stat` `variant`
- Adds `fullWidth` prop support `vertical' `stat`
- Adds `maxWidth` prop support for `stat` `variant`
- Adds `lineClamp` prop for `stat` `variant`
- Polishes border radius and insets for `stat` so they properly handle no border and no divider scenarios as well as map to the latest spec
- Adds border radius CSS vars and removes unused vars
  - `--stat-tab-border-radius-m: 40px;`
  - `--stat-tab-border-radius-s: 24px;`
  - `--stat-tab-border-radius-xs: 16px;`
- Updates stories
- Adds UTs

https://github.com/EightfoldAI/octuple/assets/99700808/4107d4fa-8dc2-4c5b-9f1a-bb5b52a010c6

## JIRA TASK (Eightfold Employees Only):
ENG-77353

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Tabs` and `Stat Tabs` stories behave as expected.