### PR TITLE
fix: form: ensure form item label custom node content display is inline

### DIFF
--- a/src/components/Form/FormItemLabel.tsx
+++ b/src/components/Form/FormItemLabel.tsx
@@ -126,7 +126,7 @@ const FormItemLabel: React.FC<FormItemLabelProps & { required?: boolean }> = ({
               {!requiredMark && !required && labelChildren}
               {(requiredMark === 'optional' || required) && (
                 <span>
-                  {labelChildren}
+                  <span className={styles.inlineEnforce}>{labelChildren}</span>
                   <span
                     className={mergeClasses([
                       styles.formItemOptional,

--- a/src/components/Form/form.module.scss
+++ b/src/components/Form/form.module.scss
@@ -125,6 +125,10 @@
       font-weight: $text-font-weight-semibold;
       line-height: $text-line-height-2;
 
+      .inline-enforce * {
+        display: inline;
+      }
+
       .form-item-optional {
         display: inline-block;
         color: var(--form-item-optional-text-color);


### PR DESCRIPTION
## SUMMARY:
Backports v2.48.1 hotfix into main