### PR TITLE
fix: [Menu]: Add role = 'presentation' to MenuItem for accessibility issue

### DIFF
--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -169,6 +169,10 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
       return dropdownMenuItems ? dropdownMenuButton() : menuButton();
     };
 
-    return <li className={menuItemClassNames}>{renderedItem()}</li>;
+    return (
+      <li role="presentation" className={menuItemClassNames}>
+        {renderedItem()}
+      </li>
+    );
   }
 );

--- a/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
+++ b/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
@@ -21,7 +21,7 @@ export const MenuItemCustom: FC<MenuItemCustomProps> = forwardRef(
     ]);
 
     return (
-      <li className={menuItemClassNames}>
+      <li role="presentation" className={menuItemClassNames}>
         {item.render({ index, value: item, onChange, ref: ref })}
       </li>
     );

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -68,7 +68,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
     );
 
     return (
-      <li className={menuItemClassNames}>
+      <li role="presentation" className={menuItemClassNames}>
         <Link
           classNames={styles.menuLink}
           disabled={disabled}

--- a/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
+++ b/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
@@ -22,7 +22,7 @@ export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = forwardRef(
       classNames,
     ]);
     return (
-      <li className={subHeaderClassNames}>
+      <li role="presentation" className={subHeaderClassNames}>
         <span data-disabled {...rest} tabIndex={-1} ref={ref}>
           {text}
         </span>

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`Menu Menu is large 1`] = `
         >
           <li
             class="menu-item large neutral my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -82,6 +83,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item large neutral disabled my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -108,6 +110,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item-sub-header large my-menu-item-class"
+            role="presentation"
           >
             <span
               data-disabled="true"
@@ -120,6 +123,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item large neutral my-menu-item-class"
+            role="presentation"
           >
             <a
               aria-disabled="false"
@@ -147,6 +151,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item-custom large my-menu-item-class"
+            role="presentation"
           >
             <div
               aria-label="Radio Group"
@@ -279,6 +284,7 @@ exports[`Menu Menu is medium 1`] = `
         >
           <li
             class="menu-item medium neutral my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -323,6 +329,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item medium neutral disabled my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -349,6 +356,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item-sub-header medium my-menu-item-class"
+            role="presentation"
           >
             <span
               data-disabled="true"
@@ -361,6 +369,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item medium neutral my-menu-item-class"
+            role="presentation"
           >
             <a
               aria-disabled="false"
@@ -388,6 +397,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item-custom medium my-menu-item-class"
+            role="presentation"
           >
             <div
               aria-label="Radio Group"
@@ -520,6 +530,7 @@ exports[`Menu Menu is small 1`] = `
         >
           <li
             class="menu-item small neutral my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -564,6 +575,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item small neutral disabled my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -590,6 +602,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item-sub-header small my-menu-item-class"
+            role="presentation"
           >
             <span
               data-disabled="true"
@@ -602,6 +615,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item small neutral my-menu-item-class"
+            role="presentation"
           >
             <a
               aria-disabled="false"
@@ -629,6 +643,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item-custom small my-menu-item-class"
+            role="presentation"
           >
             <div
               aria-label="Radio Group"


### PR DESCRIPTION
## SUMMARY:
fixes issue: list item does not have a `<ul>` or `<ol>` parent element without a role, or a role="list"


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-79383

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
- Open story book > Menu
- Click on Menu
- Run axe DevTools accessibility tests
Before:
<img width="400" alt="Screenshot 2024-02-23 at 2 20 15 AM" src="https://github.com/EightfoldAI/octuple/assets/96047250/66338a5a-5b9f-4185-bee0-ab4a6ae1680b">

After:
<img width="400" alt="Screenshot 2024-02-23 at 2 20 36 AM" src="https://github.com/EightfoldAI/octuple/assets/96047250/ce501bf9-1010-42f3-b1f7-a81b0e1951cb">

- Should not see list item does not have a `<ul>` or `<ol>` parent element without a role, or a role="list" issue.
