### PR TITLE
fix: list: move external item into its own function component to address hook bug

### DIFF
--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { List } from './';
+import { Stack } from '../Stack';
+import { Button } from '../Button';
 
 export default {
   title: 'List',
@@ -47,21 +49,54 @@ interface User {
   img: string;
 }
 
-const sampleList: User[] = [1, 2, 3, 4, 5].map((i) => ({
+const sampleList: User[] = [0, 1, 2, 3, 4].map((i) => ({
   name: `User ${i}`,
-  summary: `Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.`,
+  summary:
+    "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
   img: '',
 }));
 
 const List_Story: ComponentStory<typeof List> = (args) => <List {...args} />;
 
+const Update_List_Story: ComponentStory<typeof List> = (args) => {
+  const [list, setSampleList] = useState<User[]>(sampleList);
+  const addItem = (i: number) => {
+    setSampleList((prevSampleList) => [
+      ...prevSampleList,
+      {
+        name: `User ${i}`,
+        summary:
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.",
+        img: '',
+      },
+    ]);
+  };
+  const removeItem = () => {
+    setSampleList((prevSampleList) => prevSampleList.slice(0, -1));
+  };
+  return (
+    <Stack direction="vertical" flexGap="xl" fullWidth>
+      <Stack direction="horizontal" flexGap="s">
+        <Button onClick={() => addItem(list.length)} text="Add item" />
+        <Button
+          disabled={list.length === 0}
+          onClick={() => removeItem()}
+          text="Remove item"
+        />
+      </Stack>
+      <List {...args} items={list} />
+    </Stack>
+  );
+};
+
 export const Vertical = List_Story.bind({});
 export const Horizontal = List_Story.bind({});
+export const Update = Update_List_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
 // See https://www.npmjs.com/package/babel-plugin-named-exports-order
-export const __namedExportsOrder = ['Vertical', 'Horizontal'];
+export const __namedExportsOrder = ['Vertical', 'Horizontal', 'Update'];
 
 const listArgs: Object = {
   items: sampleList,
@@ -98,4 +133,8 @@ Vertical.args = {
 Horizontal.args = {
   ...listArgs,
   layout: 'horizontal',
+};
+
+Update.args = {
+  ...listArgs,
 };

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,13 +1,12 @@
 import React, { Key, useEffect, useRef, useState } from 'react';
 import { ListProps } from './List.types';
+import { ExternalListItem } from './ListItem';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 import {
-  cloneElement,
   eventKeys,
   focusable,
   mergeClasses,
   SELECTORS,
-  uniqueId,
 } from '../../shared/utilities';
 
 import styles from './list.module.scss';
@@ -219,23 +218,20 @@ export const List = <T extends any>({
     if (!node) {
       return null;
     }
-    const item = React.Children.only(node) as React.ReactElement<HTMLElement>;
-    const itemId: string = item.props.id
-      ? item.props.id
-      : uniqueId(`listItem${index}-`);
-    const referenceElement: HTMLElement | null =
-      document.getElementById(itemId);
-    itemRef(referenceElement);
-    itemRefs.current[index] = referenceElement;
-    return cloneElement(item, {
-      id: itemId,
-      ref: itemRef,
-      tabIndex: 0,
-      onKeyDown: (event: KeyboardEvent) => {
-        item.props.onkeydown?.(event);
-        handleItemKeyDown(event, index, true);
-      },
-    });
+    const item: React.ReactElement<
+      HTMLElement,
+      string | React.JSXElementConstructor<any>
+    > = React.Children.only(node) as React.ReactElement<HTMLElement>;
+    return (
+      <ExternalListItem
+        handleItemKeyDown={handleItemKeyDown}
+        id={item?.props?.id}
+        index={index}
+        item={item}
+        itemRefs={itemRefs}
+        itemRef={itemRef}
+      />
+    );
   };
 
   const getItems = (): React.ReactNode[] =>

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -1,15 +1,13 @@
-import { HTMLAttributes, Key, ReactNode } from 'react';
+import { Key, ReactNode } from 'react';
 import * as React from 'react';
 import { OcBaseProps } from '../OcBase';
+import { ListItemProps } from './ListItem';
 
 export type ItemLayout = 'horizontal' | 'vertical';
 
-export interface ListItemProps
-  extends Omit<HTMLAttributes<HTMLLIElement>, 'onClick'> {}
-
 export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
   /**
-   * Additonal item.
+   * Optional additonal list item.
    */
   additionalItem?: T;
   /**
@@ -24,15 +22,15 @@ export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
    */
   disableKeys?: boolean;
   /**
-   * List footer renderer
+   * List footer renderer.
    */
   footer?: ReactNode;
   /**
-   * Get custom list item
+   * Get custom list item.
    */
   getItem?: (item: T, index: number) => ReactNode;
   /**
-   * List header renderer
+   * List header renderer.
    */
   header?: ReactNode;
   /**
@@ -40,11 +38,11 @@ export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
    */
   itemClassNames?: string;
   /**
-   * List item props
+   * List item props.
    */
   itemProps?: ListItemProps;
   /**
-   * Array of items
+   * Array of list items.
    */
   items: T[];
   /**
@@ -57,11 +55,11 @@ export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
    */
   layout?: ItemLayout;
   /**
-   * Custom classes for the list
+   * Custom classes for the list.
    */
   listClassNames?: string;
   /**
-   * The list html type
+   * The list html type.
    * @default ul
    */
   listType?: 'ul' | 'ol';
@@ -80,7 +78,7 @@ export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
    */
   role?: string;
   /**
-   * Unique key for the item
+   * Unique key for the list item.
    * @param item
    */
   rowKey?: (item: T) => Key | keyof T;

--- a/src/components/List/ListItem/ExternalListItem.tsx
+++ b/src/components/List/ListItem/ExternalListItem.tsx
@@ -1,0 +1,26 @@
+import React, { FC, useRef } from 'react';
+import { ExternalListItemProps } from './';
+import { cloneElement, uniqueId } from '../../../shared/utilities';
+
+export const ExternalListItem: FC<ExternalListItemProps> = (
+  props: ExternalListItemProps
+) => {
+  const { handleItemKeyDown, id, index, item, itemRefs, itemRef } = props;
+  const itemId: React.MutableRefObject<string> = useRef<string>(
+    id || uniqueId(`listItem${index}-`)
+  );
+  const referenceElement: HTMLElement | null = document?.getElementById(
+    itemId?.current
+  );
+  itemRef?.(referenceElement);
+  itemRefs.current[index] = referenceElement;
+  return cloneElement(item, {
+    id: itemId?.current,
+    ref: itemRef,
+    tabIndex: 0,
+    onKeyDown: (event: KeyboardEvent) => {
+      item.props.onkeydown?.(event);
+      handleItemKeyDown?.(event, index, true);
+    },
+  });
+};

--- a/src/components/List/ListItem/ListItem.types.ts
+++ b/src/components/List/ListItem/ListItem.types.ts
@@ -1,0 +1,43 @@
+import { HTMLAttributes, Key, ReactNode } from 'react';
+import * as React from 'react';
+
+export interface ExternalListItemProps {
+  /**
+   * The keydown event handler applied to the cloned list item.
+   * @param event The keyboard event.
+   * @param index The list item index.
+   * @param external Informs the keyboard handler this is an external item.
+   */
+  handleItemKeyDown?: (
+    event: KeyboardEvent | React.KeyboardEvent<HTMLElement>,
+    index: number,
+    external?: boolean
+  ) => void;
+  /**
+   * The id of the cloned list item.
+   */
+  id?: string;
+  /**
+   * The index of the cloned list item.
+   */
+  index?: number;
+  /**
+   * The list item.
+   */
+  item?: React.ReactElement<
+    HTMLElement,
+    string | React.JSXElementConstructor<any>
+  >;
+  /**
+   * The cloned list item refs.
+   */
+  itemRefs?: React.MutableRefObject<HTMLElement[]>;
+  /**
+   * The cloned list item ref.
+   * @param el The list item element.
+   */
+  itemRef?: (el: HTMLElement | null) => void;
+}
+
+export interface ListItemProps
+  extends Omit<HTMLAttributes<HTMLLIElement>, 'onClick'> {}

--- a/src/components/List/ListItem/index.ts
+++ b/src/components/List/ListItem/index.ts
@@ -1,0 +1,2 @@
+export * from './ExternalListItem';
+export * from './ListItem.types';


### PR DESCRIPTION
## SUMMARY:
the `uniqueId` helper implements a `useMemo` hook. This caused an issue where the `externalItem` function of `List` raised React errors regarding hooks.

- Abstracts out to `ExternalListItem` so useMemo will work as expected
- Refactors `List` to consume `ExternalListItem`
- Updates stories to include a `List` `Update` story where you may Add/Remove list items from `List`


https://github.com/EightfoldAI/octuple/assets/99700808/ed99253d-8723-4f75-81e5-f645b1963d72


## JIRA TASK (Eightfold Employees Only):
ENG-81890

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `List` stories behave as expected.