### PR TITLE
fix: a11y: card focus visible styles and aria label placeholders with additional code cleanup

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -52,6 +52,7 @@ const baseCardArgs: Object = {
   style: {},
   classNames: 'my-card-class',
   bordered: true,
+  tabIndex: 0,
 };
 
 CustomCard.args = {

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -48,6 +48,7 @@ export const __namedExportsOrder = ['CustomCard'];
 
 const baseCardArgs: Object = {
   dropShadow: true,
+  insetFocusVisible: false,
   size: CardSize.Medium,
   style: {},
   classNames: 'my-card-class',

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -43,6 +43,7 @@ export const Card: FC<CardProps> = React.forwardRef(
       headerTitle,
       height,
       icon,
+      insetFocusVisible = false,
       isSelected = false,
       name,
       size = CardSize.Medium,
@@ -96,6 +97,7 @@ export const Card: FC<CardProps> = React.forwardRef(
       { [styles.cardMedium]: mergedSize === CardSize.Medium },
       { [styles.cardSmall]: mergedSize === CardSize.Small },
       { [styles.dropShadow]: dropShadow },
+      { [styles.insetFocusVisible]: insetFocusVisible },
       { [styles.cardRtl]: htmlDir === 'rtl' },
     ]);
 

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -136,6 +136,11 @@ export interface CardProps extends OcBaseProps<HTMLDivElement> {
    */
   icon?: IconName;
   /**
+   * Option to inset the :focus-visible CSS box-shadow.
+   * Use this if the :focus-visible CSS box-shadow is being clipped.
+   */
+  insetFocusVisible?: boolean;
+  /**
    * The boolean value if a list card is selected.
    */
   isSelected?: boolean;

--- a/src/components/Card/card.module.scss
+++ b/src/components/Card/card.module.scss
@@ -170,6 +170,14 @@
       &.drop-shadow {
         box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;
       }
+
+      &.inset-focus-visible {
+        box-shadow: inset var(--focus-visible-box-shadow);
+
+        &.drop-shadow {
+          box-shadow: inset var(--focus-visible-box-shadow), $shadow-object-s;
+        }
+      }
     }
   }
 }

--- a/src/components/Card/card.module.scss
+++ b/src/components/Card/card.module.scss
@@ -153,6 +153,25 @@
       }
     }
   }
+
+  // Hides the browser default keyboard focus-visible styles.
+  // Use the ConfigProvider instead.
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+:global(.focus-visible) {
+  .card {
+    &.focus-visible,
+    &:focus-visible {
+      box-shadow: var(--focus-visible-box-shadow);
+
+      &.drop-shadow {
+        box-shadow: var(--focus-visible-box-shadow), $shadow-object-s;
+      }
+    }
+  }
 }
 
 @import './Styles/rtl';

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -23,6 +23,11 @@ export interface DropdownProps {
    */
   ariaRef?: React.MutableRefObject<HTMLElement>;
   /**
+   * The child renderer.
+   * @deprecated Wrap your element instead, e.g. `<Dropdown><MyElement /></Dropdown>`.
+   */
+  children?: React.ReactNode;
+  /**
    * Class names of the main wrapper
    */
   classNames?: string;

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -113,6 +113,10 @@ export interface ReadOnlyProps {
 export interface SearchBoxProps
   extends Omit<InputProps<HTMLInputElement>, 'htmlType'> {
   /**
+   * The input search button aria label text.
+   */
+  searchButtonAriaLabel?: string;
+  /**
    * onclear event handler.
    */
   onClear?: React.MouseEventHandler<Element>;

--- a/src/components/Inputs/SearchBox/SearchBox.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.tsx
@@ -66,6 +66,8 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
       readonly = false,
       readOnlyProps,
       reset = false,
+      role,
+      searchButtonAriaLabel,
       shape = TextInputShape.Pill,
       size = TextInputSize.Medium,
       status,
@@ -123,6 +125,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
           htmlType="search"
           iconProps={iconProps}
           iconButtonProps={{
+            ariaLabel: searchButtonAriaLabel ? searchButtonAriaLabel : 'Search',
             htmlType: 'button',
             iconProps: {
               path: IconName.mdiMagnify,
@@ -147,6 +150,7 @@ export const SearchBox: FC<SearchBoxProps> = React.forwardRef(
           readonly={readonly}
           readOnlyProps={readOnlyProps}
           reset={reset}
+          role={role}
           shape={mergedShape}
           size={mergedSize}
           status={mergedStatus}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -105,6 +105,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       textInputProps = {},
       theme,
       themeContainerId,
+      toggleButtonAriaLabel,
       'data-test-id': dataTestId,
     },
     ref: Ref<HTMLDivElement>
@@ -766,6 +767,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
       inputWidth: inputWidth,
       iconButtonProps: !readonly
         ? {
+            ariaLabel: toggleButtonAriaLabel
+              ? toggleButtonAriaLabel
+              : 'Toggle dropdown',
             htmlType: 'button',
             iconProps: {
               path: dropdownVisible

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -218,4 +218,8 @@ export interface SelectProps
    * Use with `theme` to generate a unique container or a common one.
    */
   themeContainerId?: string;
+  /**
+   * The Select toggle dropdown chevron button aria label.
+   */
+  toggleButtonAriaLabel?: string;
 }

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Select Renders empty options in multiple mode without crashing 1`] = `
                 />
                 <button
                   aria-disabled="false"
+                  aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                   type="button"
                 >
@@ -116,6 +117,7 @@ exports[`Select Renders empty options in single mode without crashing 1`] = `
                 />
                 <button
                   aria-disabled="false"
+                  aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                   type="button"
                 >
@@ -189,6 +191,7 @@ exports[`Select Renders null options in multiple mode without crashing 1`] = `
                 />
                 <button
                   aria-disabled="false"
+                  aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                   type="button"
                 >
@@ -262,6 +265,7 @@ exports[`Select Renders null options in single mode without crashing 1`] = `
                 />
                 <button
                   aria-disabled="false"
+                  aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                   type="button"
                 >
@@ -335,6 +339,7 @@ exports[`Select Renders with default value 1`] = `
                 />
                 <button
                   aria-disabled="false"
+                  aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                   type="button"
                 >
@@ -478,6 +483,7 @@ exports[`Select Renders with default values when multiple 1`] = `
                 />
                 <button
                   aria-disabled="false"
+                  aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                   type="button"
                 >
@@ -551,6 +557,7 @@ exports[`Select Renders without crashing 1`] = `
                 />
                 <button
                   aria-disabled="false"
+                  aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                   type="button"
                 >
@@ -623,6 +630,7 @@ exports[`Select Select is large 1`] = `
               />
               <button
                 aria-disabled="false"
+                aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-large icon-left"
                 type="button"
               >
@@ -694,6 +702,7 @@ exports[`Select Select is medium 1`] = `
               />
               <button
                 aria-disabled="false"
+                aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                 type="button"
               >
@@ -765,6 +774,7 @@ exports[`Select Select is pill shaped 1`] = `
               />
               <button
                 aria-disabled="false"
+                aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium round-shape icon-left"
                 type="button"
               >
@@ -836,6 +846,7 @@ exports[`Select Select is rectangle shaped 1`] = `
               />
               <button
                 aria-disabled="false"
+                aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                 type="button"
               >
@@ -907,6 +918,7 @@ exports[`Select Select is small 1`] = `
               />
               <button
                 aria-disabled="false"
+                aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-small icon-left"
                 type="button"
               >
@@ -978,6 +990,7 @@ exports[`Select Select is underline shaped 1`] = `
               />
               <button
                 aria-disabled="false"
+                aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
                 type="button"
               >

--- a/src/components/Skill/SkillTag.tsx
+++ b/src/components/Skill/SkillTag.tsx
@@ -58,7 +58,7 @@ export const SkillTag: FC<SkillTagProps> = React.forwardRef(
       removable = false,
       removeButtonAriaLabel,
       removeButtonProps,
-      role,
+      role = clickable ? 'button' : undefined,
       showLabelAssessmentIcon = true,
       size = SkillSize.Medium,
       status = SkillStatus.Default,
@@ -160,7 +160,7 @@ export const SkillTag: FC<SkillTagProps> = React.forwardRef(
         tabIndex={!allowDisabledFocus && disabled ? null : tabIndex}
         title={title}
         ref={ref}
-        role={clickable ? 'button' : role}
+        role={role}
       >
         <div
           className={styles.background}

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -48,6 +48,7 @@ import {
 import {
   CheckBox,
   CheckBoxGroup,
+  CheckboxValueType,
   LabelPosition,
   LabelAlign,
   SelectorSize,
@@ -368,6 +369,7 @@ export {
   CascadingMenu,
   CheckBox,
   CheckBoxGroup,
+  CheckboxValueType,
   Col,
   ColumnGroupType,
   ColumnType,


### PR DESCRIPTION
## SUMMARY:
- Adds aria label props and placeholders to `Select` and `Input` buttons
- Adds `focus-visible` styles to `Card` and an `insetFocusVisible` prop
- Loosens-up `role` prop of `SkillTag` to consider select scenarios
- Makes `children` prop of `Dropdown` optional and marks it as deprecated
- Adds `role` prop to `SearchBox` so that it may be configured
- Exports CheckBoxValueType

## JIRA TASK (Eightfold Employees Only):
ENG-84999

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Card`, `Select`, `SearchBox`, `SkillTag`, `TextInput`, and `Dropdown` stories behave as expected.