### PR TITLE
fix: accordion: ensure expand button props are passed down to the button

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -84,6 +84,7 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
         {badgeProps && <Badge classNames={styles.badge} {...badgeProps} />}
       </div>
       <Button
+        {...expandButtonProps}
         disabled={disabled}
         gradient={gradient}
         iconProps={{ classNames: iconStyles, ...expandIconProps }}


### PR DESCRIPTION
## SUMMARY:
- Fixes issue where the prop was not being referenced as intended

## JIRA TASK (Eightfold Employees Only):
ENG-84999

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Accordion` story behaves as expected.