### PR TITLE
feat: ssr: improve ssr support via globalobject this and use client strings

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   FC,
   Ref,

--- a/src/components/Align/Align.tsx
+++ b/src/components/Align/Align.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   addEventListenerWrapper,

--- a/src/components/Atom/Atom.tsx
+++ b/src/components/Atom/Atom.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { mergeClasses } from '../../shared/utilities';
 import { AtomProps } from './Atom.types';

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AvatarFallbackProps,

--- a/src/components/Avatar/AvatarGroup.tsx
+++ b/src/components/Avatar/AvatarGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Ref } from 'react';
 import { Avatar, AvatarGroupProps, AvatarGroupVariant } from '.';
 import { List } from '../List';

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import { BadgeProps, BadgeSize } from './Badge.types';
 import { mergeClasses } from '../../shared/utilities';

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import { OcThemeName } from '../ConfigProvider';
 import ThemeContext, {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';

--- a/src/components/Button/DefaultButton/DefaultButton.tsx
+++ b/src/components/Button/DefaultButton/DefaultButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import {
   Button,

--- a/src/components/Button/NeutralButton/NeutralButton.tsx
+++ b/src/components/Button/NeutralButton/NeutralButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import {
   Button,

--- a/src/components/Button/Nudge/InnerNudge.tsx
+++ b/src/components/Button/Nudge/InnerNudge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import { NudgeAnimation, InnerNudgeProps } from './';
 

--- a/src/components/Button/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton/PrimaryButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import {
   Button,

--- a/src/components/Button/SecondaryButton/SecondaryButton.tsx
+++ b/src/components/Button/SecondaryButton/SecondaryButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import {
   Button,

--- a/src/components/Button/SplitButton/SplitButton.tsx
+++ b/src/components/Button/SplitButton/SplitButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useRef } from 'react';
 import DisabledContext, {
   Disabled,

--- a/src/components/Button/SystemUIButton/SystemUIButton.tsx
+++ b/src/components/Button/SystemUIButton/SystemUIButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import {
   Button,

--- a/src/components/Button/TwoStateButton/TwoStateButton.tsx
+++ b/src/components/Button/TwoStateButton/TwoStateButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import DisabledContext, {
   Disabled,

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { CardProps, CardSize, CardType } from './Card.types';

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   Children,
   FC,

--- a/src/components/Carousel/Carousel.types.ts
+++ b/src/components/Carousel/Carousel.types.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   ComponentType,
   createContext,

--- a/src/components/Carousel/ItemsMap.ts
+++ b/src/components/Carousel/ItemsMap.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { separatorString } from './Carousel.types';
 import type {
   IntersectionObserverItem,

--- a/src/components/Carousel/Slide/Slide.tsx
+++ b/src/components/Carousel/Slide/Slide.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useState, useRef } from 'react';
 import { CarouselContext, CarouselSlideProps } from '../Carousel.types';
 import { useForkedRef } from '../../../hooks/useForkedRef';

--- a/src/components/Carousel/autoScrollApi.ts
+++ b/src/components/Carousel/autoScrollApi.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   filterSeparators,
   scrollToItem,

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { SizeContext, Size, OcThemeName } from '../ConfigProvider';
@@ -70,7 +72,11 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
       ref
     );
 
+    // TODO: Upgrade to React 18 and use the new `useId` hook.
+    // This way the id will match on the server and client.
+    // For now, pass an id via props if using SSR.
     const checkBoxId = useRef<string>(id || generateId());
+
     const [isChecked, setIsChecked] = useState<boolean>(
       defaultChecked || checked
     );

--- a/src/components/CheckBox/CheckBoxGroup.tsx
+++ b/src/components/CheckBox/CheckBoxGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { SizeContext, Size, OcThemeName } from '../ConfigProvider';

--- a/src/components/ConfigProvider/ConfigProvider.stories.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.stories.tsx
@@ -658,12 +658,12 @@ const ThemedComponents: FC = () => {
         </NavbarContent>
         <NavbarContent>
           <Link
-            href="https://www.twitter.com"
+            href="https://www.x.com"
             target="_self"
             variant="default"
             style={{ padding: '8px', color: 'inherit' }}
           >
-            <Icon path={IconName.mdiTwitter} />
+            <Icon path={IconName.mdiX} />
           </Link>
           <Link
             href="https://www.facebook.com"

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   createContext,
   FC,

--- a/src/components/ConfigProvider/ShapeContext.tsx
+++ b/src/components/ConfigProvider/ShapeContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { createContext, FC } from 'react';
 
 export enum Shape {

--- a/src/components/ConfigProvider/SizeContext.tsx
+++ b/src/components/ConfigProvider/SizeContext.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { createContext, FC } from 'react';
 
 export enum Size {

--- a/src/components/DateTimePicker/DatePicker/index.tsx
+++ b/src/components/DateTimePicker/DatePicker/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Dayjs } from 'dayjs';
 import dayjsGenerateConfig from '../Internal/Generate/dayjs';
 import type {

--- a/src/components/DateTimePicker/Internal/OcPicker.tsx
+++ b/src/components/DateTimePicker/Internal/OcPicker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useRef } from 'react';
 import {
   CustomFormat,

--- a/src/components/DateTimePicker/Internal/OcRangePicker.tsx
+++ b/src/components/DateTimePicker/Internal/OcRangePicker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useRef, useEffect, useState } from 'react';
 import {
   mergeClasses,

--- a/src/components/DateTimePicker/TimePicker/TimePicker.tsx
+++ b/src/components/DateTimePicker/TimePicker/TimePicker.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { forwardRef, useMemo } from 'react';
 import DatePicker from '../DatePicker';
 import { TimePickerProps, TimeRangePickerProps } from './TimePicker.types';

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useState } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';

--- a/src/components/Dialog/DialogHelper.tsx
+++ b/src/components/Dialog/DialogHelper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { DialogProps, DialogSize } from './Dialog.types';

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   cloneElement,
   FC,
@@ -83,7 +85,11 @@ export const Dropdown: FC<DropdownProps> = React.memo(
       const [closing, setClosing] = useState<boolean>(false);
       const previouslyClosing: boolean = usePreviousState(closing);
 
+      // TODO: Upgrade to React 18 and use the new `useId` hook.
+      // This way the id will match on the server and client.
+      // For now, pass an id via props if using SSR.
       const dropdownId: string = uniqueId('dropdown-');
+
       const [dropdownReferenceId, setReferenceElementId] = useState<string>(
         `${dropdownId}reference`
       );

--- a/src/components/Empty/Empty.tsx
+++ b/src/components/Empty/Empty.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import { mergeClasses } from '../../shared/utilities';
 import { EmptyMode, EmptyProps } from './Empty.types';

--- a/src/components/FadeIn/FadeIn.tsx
+++ b/src/components/FadeIn/FadeIn.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import { FadeInProps } from './FadeIn.types';
 import { animated, useSpring, UseSpringProps } from '@react-spring/web';

--- a/src/components/Form/Hooks/useForm.ts
+++ b/src/components/Form/Hooks/useForm.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import type { OcFormInstance } from '../Internal';
 import { useForm as useOcForm } from '../Internal';

--- a/src/components/Form/Internal/OcField.tsx
+++ b/src/components/Form/Internal/OcField.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import toChildrenArray from '../../../shared/utilities/toArray';
 import type {

--- a/src/components/Form/Internal/Utils/NameMap.ts
+++ b/src/components/Form/Internal/Utils/NameMap.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import type { InternalOcNamePath } from '../OcForm.types';
 
 interface KV<T> {

--- a/src/components/Form/Internal/useForm.ts
+++ b/src/components/Form/Internal/useForm.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { HOOK_MARK } from './OcFieldContext';
 import type {

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   OcRule as Rule,
   OcRuleObject as RuleObject,

--- a/src/components/Grid/Col.tsx
+++ b/src/components/Grid/Col.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Ref } from 'react';
 import { ColProps, ColSize, FlexType } from './Grid.types';
 import { mergeClasses } from '../../shared/utilities';

--- a/src/components/Grid/Row.tsx
+++ b/src/components/Grid/Row.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Ref, useEffect } from 'react';
 import { Gutter, RowProps } from './Grid.types';
 import useFlexGapSupport from '../../hooks/useFlexGapSupport';

--- a/src/components/Grid/index.ts
+++ b/src/components/Grid/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { Col } from './Col';
 import { useBreakpoint as useInternalBreakpoint } from '../../hooks/useBreakpoint';
 import { Row } from './Row';

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC } from 'react';
 import IcomoonReact from 'icomoon-react';
 

--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useState } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';

--- a/src/components/InlineSvg/InlineSvg.tsx
+++ b/src/components/InlineSvg/InlineSvg.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useMemo, useState, useRef, FC, Ref } from 'react';
 import { InlineSvgProps } from './InlineSvg.types';
 import { Icon, IconName } from '../Icon';

--- a/src/components/Inputs/SearchBox/SearchBox.tsx
+++ b/src/components/Inputs/SearchBox/SearchBox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import DisabledContext, {
   Disabled,

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useState } from 'react';
 import DisabledContext, {
   Disabled,
@@ -91,7 +93,11 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
 
     const htmlDir: string = useCanvasDirection();
 
+    // TODO: Upgrade to React 18 and use the new `useId` hook.
+    // This way the id will match on the server and client.
+    // For now, pass an id via props if using SSR.
     const textAreaId: string = !!id ? id : uniqueId('textarea-');
+
     const [inputValue, setInputValue] = useState(value);
 
     const {

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import DisabledContext, {
   Disabled,
@@ -110,6 +112,10 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
     const [inputValue, setInputValue] = useState(value);
 
     const [clearButtonShown, _setClearButtonShown] = useState<boolean>(false);
+
+    // TODO: Upgrade to React 18 and use the new `useId` hook.
+    // This way the id will match on the server and client.
+    // For now, pass an id via props if using SSR.
     const inputId: string = !!id ? id : uniqueId('input-');
 
     const clearButtonRef: React.MutableRefObject<HTMLButtonElement> =

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, useContext } from 'react';
 import { Button, ButtonSize, ButtonShape } from '../Button';
 import { SizeContext, Size } from '../ConfigProvider';

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import InternalLayout, {
   Article,
   Content,

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Ref, FC, useContext } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { OcThemeName } from '../ConfigProvider';

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Key, useEffect, useRef, useState } from 'react';
 import { ListProps } from './List.types';
 import { ExternalListItem } from './ListItem';

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC } from 'react';
 import { LoaderProps, LoaderSize } from './Loader.types';
 import { mergeClasses } from '../../shared/utilities';

--- a/src/components/LocaleProvider/LocaleReceiver.tsx
+++ b/src/components/LocaleProvider/LocaleReceiver.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import type { Locale } from '.';
 import type { LocaleContextProps } from './Context';

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import memoizeOne from 'memoize-one';
 import type { BreadcrumbLocale } from '../Breadcrumb/Breadcrumb.types';

--- a/src/components/MatchScore/MatchScore.tsx
+++ b/src/components/MatchScore/MatchScore.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import { OcThemeName } from '../ConfigProvider';
 import ThemeContext, {

--- a/src/components/Menu/CascadingMenu.tsx
+++ b/src/components/Menu/CascadingMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   cloneElement,
   FC,

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC } from 'react';
 import { MenuItemTypes, MenuProps, MenuSize, MenuVariant } from './Menu.types';
 import { List } from '../List';

--- a/src/components/MessageBar/MessageBar.tsx
+++ b/src/components/MessageBar/MessageBar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useEffect, useState } from 'react';
 import { MessageBarsProps, MessageBarType } from './MessageBar.types';
 import { InfoBarLocale } from '../InfoBar/InfoBar.types';

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';

--- a/src/components/Motion/CSSMotion.tsx
+++ b/src/components/Motion/CSSMotion.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { useRef } from 'react';
+'use client';
+
+import React, { useRef } from 'react';
 import {
   DomWrapper,
   findDOMNode,

--- a/src/components/Motion/CSSMotionList.tsx
+++ b/src/components/Motion/CSSMotionList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import OriginCSSMotion from './CSSMotion';
 import type { CSSMotionProps } from './CSSMotion.types';

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Ref, FC } from 'react';
 
 import { NavbarProps } from './';

--- a/src/components/Navbar/NavbarContent.tsx
+++ b/src/components/Navbar/NavbarContent.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Ref, FC } from 'react';
 
 import { NavbarProps } from './';

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useState } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   useContext,
   useEffect,

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useState } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';

--- a/src/components/PersistentBar/PersistentBar.tsx
+++ b/src/components/PersistentBar/PersistentBar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   FC,
   ReactNode,

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { PillIconAlign, PillProps, PillSize, PillType } from './Pills.types';

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -1,4 +1,6 @@
-import React, { FC } from 'react';
+'use client';
+
+import React, { FC, useRef } from 'react';
 import {
   PopupProps,
   PopupRef,
@@ -43,7 +45,12 @@ export const Popup: FC<PopupProps> = React.forwardRef<PopupRef, PopupProps>(
     ref: React.ForwardedRef<PopupRef>
   ) => {
     const htmlDir: string = useCanvasDirection();
+
+    // TODO: Upgrade to React 18 and use the new `useId` hook.
+    // This way the id will match on the server and client.
+    // For now, pass an id via props if using SSR.
     const popupId: string = !!id ? id : uniqueId('popup-');
+
     const popupClassNames: string = mergeClasses([
       styles.popup,
       { [styles.small]: size === PopupSize.Small },

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   forwardRef,
   useEffect,

--- a/src/components/Progress/Progress.tsx
+++ b/src/components/Progress/Progress.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useRef } from 'react';
 import { DirectionType, OcThemeName } from '../ConfigProvider';
 import ThemeContext, {

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { SizeContext, Size, OcThemeName } from '../ConfigProvider';
@@ -59,7 +61,11 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
 
     const htmlDir: string = useCanvasDirection();
 
+    // TODO: Upgrade to React 18 and use the new `useId` hook.
+    // This way the id will match on the server and client.
+    // For now, pass an id via props if using SSR.
     const radioButtonId = useRef<string>(id || generateId());
+
     const radioGroupContext = useRadioGroup();
     const [isActive, setIsActive] = useState<boolean>(
       radioGroupContext?.value === value || checked

--- a/src/components/RadioButton/RadioGroup.tsx
+++ b/src/components/RadioButton/RadioGroup.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { SizeContext, Size, OcThemeName } from '../ConfigProvider';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   FC,
   useContext,

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import {
   SkeletonAnimation,

--- a/src/components/Skill/SkillBlock.tsx
+++ b/src/components/Skill/SkillBlock.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   FC,
   Ref,
@@ -130,6 +132,9 @@ export const SkillBlock: FC<SkillBlockProps> = React.forwardRef(
       useState<MenuItemTypes[]>(menuItems);
     const [_itemMenuOnly, setItemMenuOnly] = useState<boolean>(false);
 
+    // TODO: Upgrade to React 18 and use the new `useId` hook.
+    // This way the id will match on the server and client.
+    // For now, pass an id via props if using SSR.
     const skillId: React.MutableRefObject<string> = useRef<string>(
       id || generateId()
     );
@@ -523,8 +528,8 @@ export const SkillBlock: FC<SkillBlockProps> = React.forwardRef(
           {...rest}
           aria-disabled={disabled}
           className={skillClassNames}
-          id={skillId.current}
-          key={key || `${skillId.current}-key`}
+          id={skillId?.current}
+          key={key || `${skillId?.current}-key`}
           onBlur={(e: React.FocusEvent<HTMLDivElement>) => {
             if (disabled || readonly) {
               return;

--- a/src/components/Skill/SkillTag.tsx
+++ b/src/components/Skill/SkillTag.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, ReactNode, Ref, useRef } from 'react';
 import {
   matchingSkillAssessment,
@@ -71,6 +73,10 @@ export const SkillTag: FC<SkillTagProps> = React.forwardRef(
       tooltipProps,
       ...rest
     } = props;
+
+    // TODO: Upgrade to React 18 and use the new `useId` hook.
+    // This way the id will match on the server and client.
+    // For now, pass an id via props if using SSR.
     const skillId: React.MutableRefObject<string> = useRef<string>(
       id || generateId()
     );
@@ -148,8 +154,8 @@ export const SkillTag: FC<SkillTagProps> = React.forwardRef(
         {...rest}
         aria-disabled={disabled}
         className={skillClassNames}
-        id={skillId.current}
-        key={key || `${skillId.current}-key`}
+        id={skillId?.current}
+        key={key || `${skillId?.current}-key`}
         onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
           if (disabled || readonly) {
             return;

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   createRef,
   FC,

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC } from 'react';
 import { InfoBar } from '../InfoBar';
 import { SnackbarProps } from './Snackbar.types';

--- a/src/components/Snackbar/SnackbarContainer.tsx
+++ b/src/components/Snackbar/SnackbarContainer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, useEffect, useState } from 'react';
 import {
   SnackbarContainerProps,

--- a/src/components/Snackbar/snack.ts
+++ b/src/components/Snackbar/snack.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { ISnack, SnackbarPosition, SnackbarProps } from './Snackbar.types';
 import { canUseDocElement, generateId } from '../../shared/utilities';
 import { InfoBarType } from '../InfoBar';

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC } from 'react';
 import { SpinnerProps, SpinnerSize } from './Spinner.types';
 import { Icon, IconName } from '../Icon';

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import { mergeClasses } from '../../shared/utilities';
 import { StackBreakpoint, StackProps } from './Stack.types';

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   FC,
   Ref,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   forwardRef,
   ReactNode,

--- a/src/components/Tabs/Stat/Stat.tsx
+++ b/src/components/Tabs/Stat/Stat.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref, useContext } from 'react';
 import GradientContext, {
   Gradient,

--- a/src/components/Tabs/StatTabs.stories.tsx
+++ b/src/components/Tabs/StatTabs.stories.tsx
@@ -92,7 +92,7 @@ const statTabs = [1, 2, 3, 4].map((i) => ({
   label: `Label ${i}`,
   ratioA: 2,
   ratioB: '(5%)',
-  status: i === 3 ? ('success' as StatValidationStatus) : null,
+  status: i === 3 ? ('success' as StatValidationStatus) : '',
   value: `tab${i}`,
   ...(i === 4 ? { disabled: true } : {}),
 }));
@@ -103,7 +103,7 @@ const statTabsThemed = [1, 2, 3, 4].map((i) => ({
   label: `Label ${i}`,
   ratioA: 2,
   ratioB: '(5%)',
-  status: i === 3 ? ('success' as StatValidationStatus) : null,
+  status: i === 3 ? ('success' as StatValidationStatus) : '',
   value: `tab${i}`,
   ...(i === 2 ? { theme: themes[8] } : {}),
   ...(i === 4 ? { disabled: true } : {}),
@@ -125,7 +125,7 @@ const statTabsWithButtons = [1, 2, 3, 4].map((i) => ({
   label: `Label ${i}`,
   ratioA: 2,
   ratioB: '(5%)',
-  status: i === 3 ? ('success' as StatValidationStatus) : null,
+  status: i === 3 ? ('success' as StatValidationStatus) : '',
   value: `tab${i}`,
   ...(i === 4 ? { disabled: true } : {}),
 }));

--- a/src/components/Tabs/Tab/Tab.tsx
+++ b/src/components/Tabs/Tab/Tab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import { mergeClasses } from '../../../shared/utilities';
 import { TabIconAlign, TabProps, TabSize, TabVariant } from '../Tabs.types';

--- a/src/components/Tabs/Tabs/index.tsx
+++ b/src/components/Tabs/Tabs/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC, Ref } from 'react';
 import { TabsProps } from '../Tabs.types';
 import { TabsProvider } from '../Tabs.context';

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   FC,
   SyntheticEvent,
@@ -104,9 +106,14 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         useRef<HTMLDivElement>(null);
 
       const [hiding, setHiding] = useState<boolean>(false);
+
+      // TODO: Upgrade to React 18 and use the new `useId` hook.
+      // This way the id will match on the server and client.
+      // For now, pass an id via props if using SSR.
       const tooltipId: React.MutableRefObject<string> = useRef<string>(
         id || uniqueId('tooltip-')
       );
+
       const tooltipReferenceId: React.MutableRefObject<string> = useRef<string>(
         `${tooltipId?.current}-reference`
       );

--- a/src/components/Tree/Internal/OcTree.tsx
+++ b/src/components/Tree/Internal/OcTree.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   CheckInfo,

--- a/src/components/Tree/Internal/TreeNode.tsx
+++ b/src/components/Tree/Internal/TreeNode.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   DEFAULT_TREE_NODE_TITLE,

--- a/src/components/Tree/Tree.tsx
+++ b/src/components/Tree/Tree.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import OcTree, { TreeNode } from './Internal';
 import { DraggableConfig, OcTreeNodeProps, TreeProps } from './Tree.types';

--- a/src/components/Trigger/Trigger.tsx
+++ b/src/components/Trigger/Trigger.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import type { HTMLAttributes } from 'react';
 import ReactDOM from 'react-dom';

--- a/src/components/Upload/Cropper/index.tsx
+++ b/src/components/Upload/Cropper/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { default as InternalCropper } from './Cropper';
 import { CropperProps } from './Cropper.types';
 import type { ForwardRefExoticComponent, RefAttributes } from 'react';

--- a/src/components/Upload/Internal/AjaxUploader.tsx
+++ b/src/components/Upload/Internal/AjaxUploader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /* eslint react/no-is-mounted:0,react/sort-comp:0,react/prop-types:0 */
 import React, { Component } from 'react';
 import type { ReactElement } from 'react';

--- a/src/components/Upload/Internal/OcUpload.tsx
+++ b/src/components/Upload/Internal/OcUpload.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /* eslint react/prop-types:0 */
 import React, { Component } from 'react';
 import AjaxUpload from './AjaxUploader';

--- a/src/components/Upload/Internal/uid.ts
+++ b/src/components/Upload/Internal/uid.ts
@@ -2,7 +2,10 @@ const now = +new Date();
 
 /**
  * Generates a simple unique id to be used by Upload class component
- * @param prefix The sting prefix
+ * Because AjaxUploader is currently a class component, we can't use hooks.
+ * However, it should work with functional components and SSR.
+ * TODO: Remove this once we upgrade to React 18 and replace all references with React's `useId()`.
+ * @param prefix The string prefix
  */
 export const uniqueId = ((): ((prefix: string) => string) => {
   let counter: number = 0;

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { flushSync } from 'react-dom';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';

--- a/src/components/Upload/index.tsx
+++ b/src/components/Upload/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Dropzone from './Dropzone';
 import type { UploadProps } from './Upload';
 import InternalUpload, { LIST_IGNORE } from './Upload';

--- a/src/components/VirtualList/ScrollBar.tsx
+++ b/src/components/VirtualList/ScrollBar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   MIN_SCROLL_BAR_SIZE,

--- a/src/components/VirtualList/VirtualList.tsx
+++ b/src/components/VirtualList/VirtualList.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { mergeClasses } from '../../shared/utilities';
 import Filler from './Filler';

--- a/src/components/VirtualList/utils/CacheMap.ts
+++ b/src/components/VirtualList/utils/CacheMap.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import type React from 'react';
 
 // Firefox has low performance of map.

--- a/src/hooks/useBoolean.ts
+++ b/src/hooks/useBoolean.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { useConst } from './useConst';
 

--- a/src/hooks/useCanvasDirection.ts
+++ b/src/hooks/useCanvasDirection.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useEffect, useState } from 'react';
 import { canUseDocElement, canUseDom } from '../shared/utilities';
 

--- a/src/hooks/useGestures.ts
+++ b/src/hooks/useGestures.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo, useRef, useState, useCallback } from 'react';
 export enum Gestures {
   SwipeUp = 'SwipeUp',

--- a/src/hooks/useMatchMedia.ts
+++ b/src/hooks/useMatchMedia.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useEffect, useState } from 'react';
 import { canUseDom } from '../shared/utilities';
 

--- a/src/hooks/useMaxVisibleSections.ts
+++ b/src/hooks/useMaxVisibleSections.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useEffect, useState } from 'react';
 
 export const useMaxVisibleSections = (

--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { RefObject, useCallback, useEffect } from 'react';
 import { canUseDocElement } from '../shared/utilities';
 

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useCallback, useEffect, useRef } from 'react';
 
 /**

--- a/src/shared/FocusTrap/FocusTrap.tsx
+++ b/src/shared/FocusTrap/FocusTrap.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { FC } from 'react';
 import { useFocusTrap } from './hooks/useFocusTrap';
 import { OcBaseProps } from '../../components/OcBase';

--- a/src/shared/FocusTrap/hooks/useFocusTrap.ts
+++ b/src/shared/FocusTrap/hooks/useFocusTrap.ts
@@ -1,3 +1,5 @@
+'use client';
+
 // Based on https://hiddedevries.nl/en/blog/2017-01-29-using-javascript-to-trap-focus-in-an-element
 import { useRef, useEffect } from 'react';
 import { eventKeys } from '../../utilities/eventKeys';

--- a/src/shared/ResizeObserver/ResizeObserver.tsx
+++ b/src/shared/ResizeObserver/ResizeObserver.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { toArray } from '../utilities';
 import { SingleObserver } from './SingleObserver/SingleObserver';

--- a/src/shared/ResizeObserver/SingleObserver/SingleObserver.tsx
+++ b/src/shared/ResizeObserver/SingleObserver/SingleObserver.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, {
   isValidElement,
   Ref,

--- a/src/shared/utilities/domWrapper.tsx
+++ b/src/shared/utilities/domWrapper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { Component } from 'react';
 
 export interface DomWrapperProps {

--- a/src/shared/utilities/generateId.ts
+++ b/src/shared/utilities/generateId.ts
@@ -1,5 +1,9 @@
 /**
- * Get unique id
+ * Generates a simple unique id.
+ * Because this helper is currently used by other helpers, we can't use hooks.
+ * However, it should work with functional components and SSR.
+ * TODO: Remove this once we upgrade to React 18 and replace all references with React's `useId()`.
+ * @param prefix The string prefix
  */
 export const generateId = (prefix?: string) => {
   return `${prefix ?? ''}${Math.random().toString(36).substring(2, 9)}`;

--- a/src/shared/utilities/uniqueId.ts
+++ b/src/shared/utilities/uniqueId.ts
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
+
 /**
- * Generates a simple unique id
- * @param prefix The sting prefix
+ * Generates a simple unique id.
+ * useMemo only executes on the client side,
+ * so it should work with functional components and SSR.
+ * TODO: Remove this once we upgrade to React 18 and replace all references with React's `useId()`.
+ * @param prefix The string prefix
  */
 export const uniqueId = ((): ((prefix: string) => string) => {
   let counter: number = 0;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -68,5 +68,6 @@ module.exports = (_, { mode }) => ({
     library: 'Octuple',
     filename: '[name].js',
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
 });


### PR DESCRIPTION
## SUMMARY:
- Adds `'use client';` string to component files
- Updates webpack to output `globalObject: 'this'`
- Adds comments

## JIRA TASK (Eightfold Employees Only):
ENG-85282

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify all components behave as expected.

Generate a local tarball using this guidance (internal only) --> https://eightfoldai.atlassian.net/l/cp/p2HdQHfh

clone https://github.com/EightfoldAI/qa-octuple

Read its `README` to learn about running the project locally

run `yarn add <path to tarball>` in the qa-octuple dir

run the project to ensure it runs using your new tarball

run `yarn build` to test nextjs build process.