### PR TITLE
fix: ssr: remove memoizeone dep and replace it with local function in locale

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -108,15 +108,6 @@ Install with npm: `npm install lottie-web`<br/>
 Install with yarn: `yarn add lottie-web`
 
 ---
-## memoize-one
-A memoization library which only remembers the latest invocation
-
-[npm](http://npmjs.org/memoize-one) - [Homepage](https://github.com/alexreardon/memoize-one#readme) - [Repository](https://github.com/alexreardon/memoize-one) - [Issues](https://github.com/alexreardon/memoize-one/issues) - Licence: MIT
-
-Install with npm: `npm install memoize-one`<br/>
-Install with yarn: `yarn add memoize-one`
-
----
 ## react-easy-crop
 A React component to crop images/videos with easy interactions
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "dayjs": "1.11.3",
     "dom-align": "1.12.3",
     "lottie-web": "5.8.1",
-    "memoize-one": "6.0.0",
     "react-easy-crop": "4.6.1",
     "react-flip-toolkit": "7.0.13",
     "react-is": "18.1.0",

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import memoizeOne from 'memoize-one';
 import type { BreadcrumbLocale } from '../Breadcrumb/Breadcrumb.types';
 import type { DialogLocale } from '../Dialog/BaseDialog/BaseDialog.types';
 import type { PaginationLocale } from '../Pagination';
@@ -48,16 +47,30 @@ export default class LocaleProvider extends React.Component<
     locale: {},
   };
 
+  lastLocale: Locale | null = null;
+  lastContextValue: (Locale & { exist?: boolean }) | null = null;
+
   constructor(props: LocaleProviderProps) {
     super(props);
   }
 
-  getMemoizedContextValue = memoizeOne(
-    (localeValue: Locale): Locale & { exist?: boolean } => ({
+  getMemoizedContextValue = (
+    localeValue: Locale
+  ): Locale & { exist?: boolean } => {
+    // If the input hasn't changed, return the memoized result
+    if (this.lastLocale && this.lastLocale === localeValue) {
+      return this.lastContextValue!;
+    }
+
+    // Otherwise, compute the result and store it for future use
+    const contextValue = {
       ...localeValue,
       exist: true,
-    })
-  );
+    };
+    this.lastLocale = localeValue;
+    this.lastContextValue = contextValue;
+    return contextValue;
+  };
 
   render() {
     const { locale, children } = this.props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12333,11 +12333,6 @@ memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.3"
 
-memoize-one@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
-  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
-
 "memoize-one@>=3.1.1 <6":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"


### PR DESCRIPTION
## SUMMARY:
`memoize-one` dep contains a line referencing `globalThis` and falls back to `global` and `self`. This was incompatible with SSR, so I replaced it with logic that accomplishes the same memoization goal.

## JIRA TASK (Eightfold Employees Only):
ENG-85282

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `ConfigProvider` `Locale` story behaves as expected.