### PR TITLE
fix: menu: adds onclick handler back to main button when secondarybuttonprops fixing menu onchange

### DIFF
--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -10,7 +10,7 @@ import { Button } from '../Button';
 import { IconName } from '../Icon';
 import { RadioGroup } from '../RadioButton';
 import { SelectorSize } from '../CheckBox';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -226,5 +226,37 @@ describe('Menu', () => {
       'small'
     );
     expect(container).toMatchSnapshot();
+  });
+
+  test('Menu onChange event is triggered when item is clicked', () => {
+    const handleChange = jest.fn();
+
+    const { getByText } = render(
+      <Menu
+        onChange={handleChange}
+        items={[
+          {
+            iconProps: {
+              path: IconName.mdiCalendar,
+            },
+            text: 'Date',
+            value: 'menu 0',
+            counter: '8',
+            secondaryButtonProps: {
+              iconProps: {
+                path: IconName.mdiTrashCan,
+              },
+              onClick: () => {
+                console.log('Delete clicked');
+              },
+            },
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(getByText('Date'));
+
+    expect(handleChange).toHaveBeenCalled();
   });
 });

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -259,4 +259,33 @@ describe('Menu', () => {
 
     expect(handleChange).toHaveBeenCalled();
   });
+
+  test('secondaryButtonProps onClick event is triggered when secondary button is clicked', () => {
+    const handleClick = jest.fn();
+
+    const { getByRole } = render(
+      <Menu
+        items={[
+          {
+            iconProps: {
+              path: IconName.mdiCalendar,
+            },
+            text: 'Date',
+            value: 'menu 0',
+            counter: '8',
+            secondaryButtonProps: {
+              iconProps: {
+                path: IconName.mdiTrashCan,
+              },
+              onClick: handleClick,
+            },
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(getByRole('button'));
+
+    expect(handleClick).toHaveBeenCalled();
+  });
 });

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -122,6 +122,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
             tabIndex={tabIndex}
             type={htmlType}
             {...rest}
+            onClick={handleOnClick}
             ref={ref}
             role={role}
           >


### PR DESCRIPTION
## SUMMARY:
The `onClick` event was deferred to the `...rest` spread via `MenuItemButton` props, this caused a regression in `Menu` as the `onClick` callback was being used internally to trigger `Menu` `onChange` callback upstream.

BEFORE FIX:

https://github.com/EightfoldAI/octuple/assets/99700808/e1cebfff-6772-45c4-895e-072e7751eb24


AFTER FIX:

https://github.com/EightfoldAI/octuple/assets/99700808/87acf590-855b-4c8a-8eb0-fcc3a2eb27e8



## JIRA TASK (Eightfold Employees Only):
ENG-85650

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Menu` stories behave as expected.