### PR TITLE
feat: select: performance optimizations and features

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,7 +1,10 @@
-import React, { FC, useState, useRef } from 'react';
+import React, { FC, useState, useRef, useCallback } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { OcThemeName } from '../ConfigProvider';
 import { IconName } from '../Icon';
+import { Label, LabelSize } from '../Label';
+import { List } from '../List';
+import { Stack } from '../Stack';
 import { Select } from './';
 import {
   SelectOption,
@@ -10,6 +13,7 @@ import {
   SelectSize,
 } from './Select.types';
 import { Stories } from '@storybook/addon-docs';
+import { TextInputWidth } from '../Inputs';
 
 const defaultOptions: SelectOption[] = [
   {
@@ -52,6 +56,236 @@ const defaultOptions: SelectOption[] = [
     iconProps: { path: IconName.mdiBell },
     text: 'Bell',
     value: 'bell',
+  },
+];
+
+export const locations = {
+  current: 'Current location',
+  bengalaru: 'Bengalaru, Karnataka, India',
+  noida: 'Noida, Uttar Pradesh, India',
+  santa: 'Santa Clara, CA, United States',
+  london: 'London, England, United Kingdom',
+  hybrid: 'Hybrid',
+};
+
+const locationOptions: SelectOption[] = [
+  {
+    text: 'Current location',
+    value: locations.current,
+  },
+  {
+    text: 'Bengalaru, Karnataka, India',
+    value: locations.bengalaru,
+  },
+  {
+    text: 'Noida, Uttar Pradesh, India',
+    value: locations.noida,
+  },
+  {
+    text: 'Santa Clara, CA, United States',
+    value: locations.santa,
+  },
+  {
+    text: 'London, England, United Kingdom',
+    value: locations.london,
+  },
+  {
+    text: 'Hybrid',
+    value: locations.hybrid,
+  },
+];
+
+export interface Role {
+  current?: boolean;
+  geo?: string | string[];
+  index?: number;
+  location?: string;
+  role?: string;
+  selected?: boolean;
+  title?: string;
+}
+
+export const sampleRoleList: Role[] = [
+  {
+    current: false,
+    geo: 'Bangalore, Karnataka, India',
+    index: 0,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Software Engineer, Customer Engineering',
+  },
+  {
+    current: false,
+    geo: ['Bangalore, Karnataka, India', 'Noida, Uttar Pradesh, India'],
+    index: 1,
+    location: 'Hybrid',
+    role: 'Product',
+    selected: false,
+    title: 'Product Manager II - Talent Management',
+  },
+  {
+    current: false,
+    geo: 'Bangalore, Karnataka, India',
+    index: 2,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Lead SDET (Accessibility)',
+  },
+  {
+    current: true,
+    geo: 'Santa Clara, CA, United States',
+    index: 3,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Staff Machine Learning Engineer',
+  },
+  {
+    current: false,
+    geo: 'London, England, United Kingdom',
+    index: 4,
+    location: 'Hybrid',
+    role: 'Operations',
+    selected: false,
+    title: 'Senior Director, Field Operations - EMEA & APJ',
+  },
+  {
+    current: true,
+    geo: 'Santa Clara, CA, United States',
+    index: 5,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Machine Learning Engineer - AI/ML',
+  },
+  {
+    current: false,
+    geo: ['Bangalore, Karnataka, India', 'Noida, Uttar Pradesh, India'],
+    index: 6,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Lead Engineer - Backend',
+  },
+  {
+    current: false,
+    geo: 'Bangalore, Karnataka, India',
+    index: 7,
+    location: 'Hybrid',
+    role: 'Product',
+    selected: false,
+    title: 'Sr Product Manager - Talent Management',
+  },
+  {
+    current: false,
+    geo: ['Bangalore, Karnataka, India', 'Noida, Uttar Pradesh, India'],
+    index: 8,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Senior Engineer',
+  },
+  {
+    current: false,
+    geo: ['Bengalaru, Karnataka, India', 'Noida, Uttar Pradesh, India'],
+    index: 9,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Staff/Lead Engineer - Frontend',
+  },
+  {
+    current: true,
+    geo: 'Santa Clara, CA, United States',
+    index: 10,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Senior Software Engineer - AI Product Dev Teams',
+  },
+  {
+    current: false,
+    geo: 'Bangalore, Karnataka, India',
+    index: 11,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title: 'Support Language Specialist (On Contract)',
+  },
+  {
+    current: false,
+    geo: ['Bangalore, Karnataka, India', 'Noida, Uttar Pradesh, India'],
+    index: 12,
+    location: 'Hybrid',
+    role: 'Product',
+    selected: false,
+    title: 'UX Designer',
+  },
+  {
+    current: true,
+    geo: 'Santa Clara, CA, United States',
+    index: 13,
+    location: 'Hybrid',
+    role: 'Engineering',
+    selected: false,
+    title:
+      'Staff Software Engineer - Core Infrastructure (Distributed Systems)',
+  },
+  {
+    current: true,
+    geo: 'San Francisco, CA, United States',
+    index: 14,
+    location: 'Hybrid',
+    role: 'Marketing',
+    selected: false,
+    title: 'Senior Events Marketing Contractor',
+  },
+  {
+    current: false,
+    geo: 'London, England, United Kingdom',
+    index: 15,
+    location: 'Hybrid',
+    role: 'Operations',
+    selected: false,
+    title: 'Deal Desk Manager - EMEA',
+  },
+  {
+    current: false,
+    geo: ['Bangalore, Karnataka, India', 'Noida, Uttar Pradesh, India'],
+    index: 16,
+    location: 'Hybrid',
+    role: 'Customer Support',
+    selected: false,
+    title: 'Senior Technical Support Engineer',
+  },
+  {
+    current: false,
+    geo: ['Bangalaru, Karnataka, India', 'Noida, Uttar Pradesh, India'],
+    index: 17,
+    location: 'Hybrid',
+    role: 'G&A',
+    selected: false,
+    title: 'Sr. Accountant',
+  },
+  {
+    current: false,
+    geo: 'London, England, United Kingdom',
+    index: 18,
+    location: 'Hybrid',
+    role: 'Product Delivery',
+    selected: false,
+    title: 'Product Delivery Manager - EMEA',
+  },
+  {
+    current: true,
+    geo: 'Santa Clara, CA, United States',
+    index: 19,
+    location: 'Hybrid',
+    role: 'Sales',
+    selected: false,
+    title: 'Senior Solutions Consultant',
   },
 ];
 
@@ -173,6 +407,118 @@ const Dynamic_Story: ComponentStory<typeof Select> = (args) => (
   <DynamicSelect {...args} />
 );
 
+const Shared_State_Story: ComponentStory<typeof Select> = (args) => {
+  const [filteredRoleList, setFilteredRoleList] =
+    useState<Role[]>(sampleRoleList);
+  const [myLocation, setMyLocation] = useState(null);
+
+  const locationSelectOneRef = useRef<HTMLDivElement>(null);
+  const locationSelectTwoRef = useRef<HTMLDivElement>(null);
+
+  const onLocationSelectChange = useCallback(
+    async (options: SelectOption[]) => {
+      for (const option of options) {
+        setMyLocation(option);
+
+        const getLocationResults = async (
+          option: SelectOption
+        ): Promise<Role[]> => {
+          if (option === locations.current) {
+            return sampleRoleList.filter((role) => role.current);
+          } else {
+            return sampleRoleList.filter((role) =>
+              Object.values(role).some((value) =>
+                value.toString().includes(option)
+              )
+            );
+          }
+        };
+
+        const results = await getLocationResults(option);
+        setFilteredRoleList(results.map((role, index) => ({ ...role, index })));
+      }
+    },
+    [sampleRoleList, filteredRoleList]
+  );
+
+  return (
+    <Stack direction="vertical" flexGap="xxl" fullWidth>
+      <Stack direction="vertical" flexGap="xs" fullWidth>
+        <Label id="select-one-label" size={LabelSize.Medium} text="Select A" />
+        <Select
+          {...args}
+          aria-labelledby="select-one-label"
+          clearable
+          value={myLocation}
+          filterable
+          initialFocus={false}
+          inputWidth={TextInputWidth.fill}
+          onClear={() => {
+            setMyLocation('');
+            setFilteredRoleList(sampleRoleList);
+          }}
+          onOptionsChange={(options: SelectOption[]) =>
+            onLocationSelectChange(options)
+          }
+          options={locationOptions}
+          ref={locationSelectOneRef}
+          shape={SelectShape.Pill}
+          style={{ minWidth: 'fit-content' }}
+          textInputProps={{
+            iconProps: { path: IconName.mdiMapMarkerOutline },
+            placeholder: 'City, state, zip code, or "hybrid"',
+          }}
+        />
+      </Stack>
+      <Stack direction="vertical" flexGap="xs" fullWidth>
+        <Label id="select-two-label" size={LabelSize.Medium} text="Select B" />
+        <Select
+          {...args}
+          aria-labelledby="select-two-label"
+          clearable
+          value={myLocation}
+          filterable
+          initialFocus={false}
+          inputWidth={TextInputWidth.fill}
+          onClear={() => {
+            setMyLocation('');
+            setFilteredRoleList(sampleRoleList);
+          }}
+          onOptionsChange={(options: SelectOption[]) =>
+            onLocationSelectChange(options)
+          }
+          options={locationOptions}
+          ref={locationSelectTwoRef}
+          shape={SelectShape.Pill}
+          style={{ minWidth: 'fit-content' }}
+          textInputProps={{
+            iconProps: { path: IconName.mdiMapMarkerOutline },
+            placeholder: 'City, state, zip code, or "hybrid"',
+          }}
+        />
+      </Stack>
+      <Stack direction="vertical" flexGap="xs" fullWidth>
+        <Label
+          id="filtered-location-label"
+          size={LabelSize.Medium}
+          text="Filtered location"
+        />
+        <List
+          aria-labelledby="filtered-location-label"
+          items={filteredRoleList}
+          layout="vertical"
+          renderItem={(item: Role) => (
+            <p>
+              {typeof item.geo === 'string' ? item.geo : item.geo?.join(' • ')}{' '}
+              - {item.location ? item.location : 'Remote'}
+            </p>
+          )}
+        />
+      </Stack>
+    </Stack>
+  );
+};
+
 export type SelectStory = ComponentStory<React.FC<SelectProps>>;
 
 export const Basic: SelectStory = Basic_Story.bind({});
@@ -186,6 +532,7 @@ export const Filterable: SelectStory = Basic_Story.bind({});
 export const Multiple: SelectStory = Basic_Story.bind({});
 export const Multiple_With_No_Filter: SelectStory = Basic_Story.bind({});
 export const Dynamic: SelectStory = Dynamic_Story.bind({});
+export const Shared_State: SelectStory = Shared_State_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
@@ -202,6 +549,7 @@ export const __namedExportsOrder = [
   'Multiple',
   'Multiple_With_No_Filter',
   'Dynamic',
+  'Shared_State',
 ];
 
 const SelectArgs: SelectProps = {
@@ -214,6 +562,8 @@ const SelectArgs: SelectProps = {
   },
   theme: '' as OcThemeName,
   themeContainerId: 'my-textinput-theme-container',
+  toggleOptions: true,
+  maxPillCount: true,
   disabled: false,
   status: '',
   readonly: false,

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -4,6 +4,7 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import { SelectShape, SelectSize } from './Select.types';
 import { Select } from './';
+import { ANIMATION_DURATION } from '../Tooltip';
 import { Stack } from '../Stack';
 import { TextInputWidth } from '../Inputs/Input.types';
 import { sleep } from '../../tests/Utilities';
@@ -896,5 +897,29 @@ describe('Select', () => {
     expect(container.querySelector('.select-input').getAttribute('value')).toBe(
       ''
     );
+  });
+
+  test('selects first filtered option when Enter is pressed', () => {
+    const onInputChange = jest.fn();
+    const { container } = render(
+      <Select filterable onOptionsChange={onInputChange} options={options} />
+    );
+    const input = container.querySelector('.select-input');
+    fireEvent.change(input, { target: { value: 'option1' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    // Wait for the click event to be fired
+    setTimeout(() => {
+      expect(onInputChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({
+            value: 'option1',
+          }),
+        })
+      );
+
+      // Check that the first filtered option is selected
+      expect(input.getAttribute('value')).toBe('Option 1');
+    }, ANIMATION_DURATION);
   });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -42,7 +42,7 @@ import {
 } from './Select.types';
 import { Spinner, SpinnerSize } from '../Spinner';
 import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
-import { Tooltip, TooltipTheme } from '../Tooltip';
+import { ANIMATION_DURATION, Tooltip, TooltipTheme } from '../Tooltip';
 import { FormItemInputContext } from '../Form/Context';
 import { ResizeObserver } from '../../shared/ResizeObserver/ResizeObserver';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
@@ -296,7 +296,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
       // When dropdown not visible and select is filterable
       // reset the search query and visibility of the options.
       if (prevDropdownVisible && !dropdownVisible && filterable) {
-        resetSelectOnDropdownHide();
+        setTimeout(() => {
+          resetSelectOnDropdownHide();
+        }, ANIMATION_DURATION);
       }
 
       // Resets closeOnReferenceClick
@@ -854,7 +856,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
     ): void => {
       if (filterable && !multiple && !dropdownVisible) {
         resetSingleSelectOnDropdownToggle();
-        resetSelectOnDropdownHide();
+        setTimeout(() => {
+          resetSelectOnDropdownHide();
+        }, ANIMATION_DURATION);
       }
       onBlur?.(event);
     };
@@ -872,6 +876,17 @@ export const Select: FC<SelectProps> = React.forwardRef(
         document.activeElement === event.target
       ) {
         dropdownRef.current?.focusFirstElement?.();
+      }
+      if (
+        filterable &&
+        event?.key === eventKeys.ENTER &&
+        document.activeElement === event.target
+      ) {
+        event.preventDefault();
+        dropdownRef.current?.focusFirstElement?.();
+        setTimeout(() => {
+          (document.activeElement as HTMLElement)?.click();
+        }, ANIMATION_DURATION);
       }
     };
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -296,9 +296,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       // When dropdown not visible and select is filterable
       // reset the search query and visibility of the options.
       if (prevDropdownVisible && !dropdownVisible && filterable) {
-        setTimeout(() => {
-          resetSelectOnDropdownHide();
-        }, ANIMATION_DURATION);
+        resetSelectOnDropdownHide();
       }
 
       // Resets closeOnReferenceClick
@@ -856,9 +854,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     ): void => {
       if (filterable && !multiple && !dropdownVisible) {
         resetSingleSelectOnDropdownToggle();
-        setTimeout(() => {
-          resetSelectOnDropdownHide();
-        }, ANIMATION_DURATION);
+        resetSelectOnDropdownHide();
       }
       onBlur?.(event);
     };
@@ -882,7 +878,6 @@ export const Select: FC<SelectProps> = React.forwardRef(
         event?.key === eventKeys.ENTER &&
         document.activeElement === event.target
       ) {
-        event.preventDefault();
         dropdownRef.current?.focusFirstElement?.();
         setTimeout(() => {
           (document.activeElement as HTMLElement)?.click();

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -8,6 +8,8 @@ import React, {
   useRef,
   useState,
   Ref,
+  useCallback,
+  useMemo,
 } from 'react';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import {
@@ -56,7 +58,7 @@ import {
 import styles from './select.module.scss';
 import themedComponentStyles from './select.theme.module.scss';
 
-const inputPaddingHorizontal: number = +styles.inputPaddingHorizontal;
+const inputPadding: number = +styles.inputPadding;
 const multiSelectCountOffset: number = +styles.multiSelectCountOffset;
 
 export const Select: FC<SelectProps> = React.forwardRef(
@@ -86,6 +88,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       inputWidth = TextInputWidth.fill,
       isLoading,
       loadOptions,
+      maxPillCount = true,
       menuProps = {},
       multiple = false,
       onBlur,
@@ -108,7 +111,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
       theme,
       themeContainerId,
       toggleButtonAriaLabel,
+      toggleOptions = true,
+      value,
       'data-test-id': dataTestId,
+      'data-testid': dataTestIdv2,
     },
     ref: Ref<HTMLDivElement>
   ) => {
@@ -127,6 +133,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const dropdownRef: React.MutableRefObject<DropdownRef> =
       useRef<DropdownRef>(null);
     const pillRefs = useRef<HTMLElement[]>([]);
+    const pillWrapperRef = useRef<HTMLDivElement>(null);
     const currentlySelectedOption: React.MutableRefObject<SelectOption> =
       useRef<SelectOption>(null);
     const selectMenuId: React.MutableRefObject<string> = useRef<string>(
@@ -153,6 +160,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const [selectedOptionText, setSelectedOptionText] = useState<string>('');
     const [resetTextInput, setResetTextInput] = useState<boolean>(false);
     const [_initialFocus, setInitialFocus] = useState<boolean>(false);
+    const [selectedOrder, setSelectedOrder] = useState<SelectOption[]>([]);
 
     const { isFormItemInput } = useContext(FormItemInputContext);
     const mergedFormItemInput: boolean = isFormItemInput || formItemInput;
@@ -181,15 +189,15 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
     const prevDropdownVisible: boolean = usePreviousState(dropdownVisible);
 
-    const getSelectedOptionValues = (): SelectOption['value'][] => {
+    const getSelectedOptionValues = useCallback((): SelectOption['value'][] => {
       return (options || [])
         .filter((option: SelectOption) => option.selected)
         .map((option: SelectOption) => option.value);
-    };
+    }, [options]);
 
-    const getSelectedOptions = (): SelectOption['value'][] => {
+    const getSelectedOptions = useCallback((): SelectOption['value'][] => {
       return (options || []).filter((option: SelectOption) => option.selected);
-    };
+    }, [options]);
 
     const { count, filled, width } = useMaxVisibleSections(
       inputRef,
@@ -200,34 +208,16 @@ export const Select: FC<SelectProps> = React.forwardRef(
       getSelectedOptionValues().length
     );
 
-    // Populate options on component render
-    useEffect(() => {
-      const selected: SelectOption[] = (options || []).filter(
-        (opt: SelectOption) => opt.selected
-      );
-      setOptions(
-        (_options || []).map((option: SelectOption, index: number) => ({
-          selected: !!selected.find((opt) => opt.value === option.value),
-          hideOption: false,
-          id: option.text + '-' + index,
-          object: option.object,
-          role: 'option',
-          'aria-selected': option.selected,
-          ...option,
-        }))
-      );
-    }, [_options]);
-
-    // Populate options on isLoading change
-    useEffect(() => {
-      const selected: SelectOption[] = (options || []).filter(
-        (opt: SelectOption) => opt.selected
-      );
+    const setOptionsWithSelection = (
+      selectedOptions: SelectOption[],
+      defaultValue: string | string[] = null
+    ) => {
       setOptions(
         (_options || []).map((option: SelectOption, index: number) => ({
           selected:
-            !!selected.find((opt) => opt.value === option.value) ||
-            option.value === defaultValue,
+            !!selectedOptions.find(
+              (opt: SelectOption) => opt.value === option.value
+            ) || option.value === defaultValue,
           hideOption: false,
           id: option.text + '-' + index,
           object: option.object,
@@ -236,51 +226,65 @@ export const Select: FC<SelectProps> = React.forwardRef(
           ...option,
         }))
       );
-    }, [isLoading]);
+    };
 
-    // Update options on change
+    // Populate options on component render and isLoading change
     useEffect(() => {
+      const selected: SelectOption[] = (options || []).filter(
+        (opt: SelectOption) => opt.selected
+      );
+      setOptionsWithSelection(selected, defaultValue);
+    }, [_options, isLoading]);
+
+    const updateOptions = () => {
       onOptionsChange?.(getSelectedOptionValues(), getSelectedOptions());
 
-      // Determine first render to help verify the Select interaction is intentional
-      if (firstRender.current) {
-        firstRender.current = false;
-        return;
-      }
-      if (multiple && prevDropdownVisible) {
-        setTimeout(() => {
-          const currentOption: HTMLElement = document.getElementById(
-            currentlySelectedOption.current?.id
-          );
-          if (currentOption) {
-            dropdownRef.current?.focusOnElement(currentOption);
-          }
-        }, NO_ANIMATION_DURATION);
+      if (multiple) {
+        if (prevDropdownVisible) {
+          setTimeout(() => {
+            const currentOption: HTMLElement = document.getElementById(
+              currentlySelectedOption.current?.id
+            );
+            if (currentOption) {
+              dropdownRef.current?.focusOnElement(currentOption);
+            }
+          }, NO_ANIMATION_DURATION);
+        }
       } else {
         getSelectedOptionText();
-        if (filterable && prevDropdownVisible) {
-          inputRef.current?.focus();
-        }
       }
+
+      if (filterable && prevDropdownVisible) {
+        inputRef.current?.focus();
+      }
+
       if (filterable && multiple) {
         setClearInput(false);
       }
-    }, [getSelectedOptionValues().join('')]);
+    };
 
-    useEffect(() => {
-      const updatedOptions = (options || []).map((opt) => ({
+    const resetSelectOnDropdownHide = (): void => {
+      setSearchQuery('');
+
+      const updatedOptions = (options || []).map((opt: SelectOption) => ({
         ...opt,
-        selected:
-          (defaultValue !== undefined &&
-            (multiple
-              ? defaultValue.includes(opt.value)
-              : opt.value === defaultValue)) ||
-          opt.selected,
+        hideOption: false,
       }));
-      setOptions(updatedOptions);
-    }, [defaultValue]);
 
-    useEffect(() => {
+      setOptions(updatedOptions);
+    };
+
+    const resetSingleSelectOnDropdownToggle = (): void => {
+      const isSelected = (options || []).some(
+        (opt: SelectOption) => opt.selected
+      );
+
+      if (isSelected && inputRef.current?.value !== selectedOptionText) {
+        setResetTextInput(true);
+      }
+    };
+
+    const resetSelect = () => {
       // When filterable and not multiple if the input value does not match
       // the selected value, ensure it's restored.
       if (filterable && !multiple) {
@@ -304,6 +308,18 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (clear) {
         onInputClear();
       }
+    };
+
+    useEffect(() => {
+      if (firstRender.current) {
+        firstRender.current = false;
+      } else {
+        updateOptions();
+      }
+    }, [firstRender, getSelectedOptionValues().join('')]);
+
+    useEffect(() => {
+      resetSelect();
     }, [clear, dropdownVisible, filterable]);
 
     useEffect(() => {
@@ -313,19 +329,52 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (!dropdownVisible && prevDropdownVisible) {
         inputRef.current?.focus();
       }
-    }, [readonly, dropdownVisible, prevDropdownVisible]);
+    }, [dropdownVisible, readonly, prevDropdownVisible]);
 
     useEffect(() => {
+      const updatedOptions = (options || []).map((opt: SelectOption) => {
+        let selected = false;
+
+        if (value !== undefined) {
+          selected = multiple ? value.includes(opt.value) : opt.value === value;
+        } else if (defaultValue !== undefined) {
+          selected = multiple
+            ? defaultValue.includes(opt.value)
+            : opt.value === defaultValue;
+        }
+
+        return {
+          ...opt,
+          selected,
+        };
+      });
+
+      setOptions(updatedOptions);
+      if (multiple) {
+        setSelectedOrder(
+          updatedOptions.filter((opt: SelectOption) => opt.selected)
+        );
+      }
+    }, [defaultValue, multiple, value]);
+
+    const setInitialFocusValue = (
+      filterable: boolean,
+      initialFocus: boolean
+    ) => {
       if (!filterable && !initialFocus) {
         setInitialFocus(true);
-      } else if (!filterable && initialFocus !== null) {
+      } else if (!filterable && initialFocus) {
         setInitialFocus(initialFocus);
       }
       if (filterable && !initialFocus) {
         setInitialFocus(false);
-      } else if (filterable && initialFocus !== null) {
+      } else if (filterable && initialFocus) {
         setInitialFocus(initialFocus);
       }
+    };
+
+    useEffect(() => {
+      setInitialFocusValue(filterable, initialFocus);
     }, [filterable, initialFocus]);
 
     const toggleOption = (option: SelectOption): void => {
@@ -344,30 +393,25 @@ export const Select: FC<SelectProps> = React.forwardRef(
         };
       });
 
-      // Update the state with the updated options
       setOptions(updatedOptions);
+
+      if (multiple) {
+        setSelectedOrder((prevSelectedOrder) => {
+          const alreadySelected = prevSelectedOrder.some(
+            (opt: SelectOption) => opt.value === option.value
+          );
+          if (alreadySelected) {
+            return prevSelectedOrder.filter(
+              (opt: SelectOption) => opt.value !== option.value
+            );
+          } else {
+            return [...prevSelectedOrder, option];
+          }
+        });
+      }
 
       if (filterable && multiple && inputRef.current?.value !== '') {
         setClearInput(true);
-      }
-    };
-
-    const resetSelectOnDropdownHide = (): void => {
-      setSearchQuery('');
-      setOptions(
-        (options || []).map((opt: SelectOption) => ({
-          ...opt,
-          hideOption: false,
-        }))
-      );
-    };
-
-    const resetSingleSelectOnDropdownToggle = (): void => {
-      const selected: SelectOption[] = (options || []).filter(
-        (opt: SelectOption) => opt.selected
-      );
-      if (selected.length && inputRef.current?.value !== selectedOptionText) {
-        setResetTextInput(true);
       }
     };
 
@@ -396,6 +440,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
           }))
         );
       }
+      if (!multiple) {
+        setSelectedOptionText('');
+      }
       onClear?.();
       inputRef.current?.focus();
     };
@@ -403,6 +450,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const onInputChange = (
       event: React.ChangeEvent<HTMLInputElement>
     ): void => {
+      const { target } = event;
+      const value: string = target?.value || '';
+      const valueLowerCase: string = value?.toLowerCase();
+
+      setSearchQuery(value);
+
       // When single mode filterable, the input value changes, the dropdown is not previously or
       // currently visible and there's no currently selected option, ensure the dropdown is visible
       // to enable filtering when backspace or clear button is used to deselect the previously
@@ -418,41 +471,37 @@ export const Select: FC<SelectProps> = React.forwardRef(
         inputRef.current?.click();
       }
 
-      const { target } = event;
-      const value: string = target?.value || '';
-      const valueLowerCase: string = value?.toLowerCase();
-      setSearchQuery(value);
       if (loadOptions) {
         return loadOptions(value);
       }
-      if (value) {
-        setOptions(
-          (options || []).map((opt: SelectOption) => ({
-            ...opt,
-            hideOption: filterOption
-              ? !filterOption(opt, value)
-              : !opt.text.toLowerCase().includes(valueLowerCase),
-          }))
-        );
-      } else {
-        setSearchQuery('');
-        // When not in multiple mode and the value is empty
-        // deselect and execute onClear.
-        setOptions(
-          (options || []).map((opt: SelectOption) => {
-            const selected: boolean = multiple ? opt.selected : false;
-            return {
-              ...opt,
-              hideOption: false,
-              selected: selected,
-            };
-          })
-        );
-        if (!multiple) {
-          onClear?.();
+
+      const updatedOptions = (options || []).map((opt: SelectOption) => {
+        let hideOption = false;
+        let selected = opt.selected;
+
+        if (value) {
+          hideOption = filterOption
+            ? !filterOption(opt, value)
+            : !opt.text.toLowerCase().includes(valueLowerCase);
+        } else {
+          selected = multiple ? opt.selected : false;
         }
+
+        return {
+          ...opt,
+          hideOption,
+          selected,
+        };
+      });
+
+      setOptions(updatedOptions);
+
+      // When not in multiple mode and the value is empty
+      // deselect and execute onClear.
+      if (!value && !multiple) {
+        onClear?.();
       }
-      // Update dropdown position on options change
+
       dropdownRef.current?.update();
     };
 
@@ -480,6 +529,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const dropdownMenuOverlayClassNames: string = mergeClasses([
       dropdownProps.dropdownClassNames,
       styles.selectDropdownOverlay,
+    ]);
+
+    const multiSelectPillsClassNames: string = mergeClasses([
+      styles.multiSelectPills,
+      { [styles.multiSelectPillsMaxCount]: !!maxPillCount },
+      { [styles.multiSelectPillsDivider]: filterable && !maxPillCount },
     ]);
 
     const pillClassNames: string = mergeClasses([
@@ -524,10 +579,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     ]);
 
     const showPills = (): boolean => {
-      const selected: SelectOption[] = (options || []).filter(
-        (opt: SelectOption) => opt.selected
-      );
-      const selectedCount: number = selected.length;
+      const selectedCount: number = selectedOrder.length;
       return selectedCount !== 0 && multiple;
     };
 
@@ -552,22 +604,21 @@ export const Select: FC<SelectProps> = React.forwardRef(
       [SelectSize.Small, PillSize.Small],
     ]);
 
-    const isPillEllipsisActive = (element: HTMLElement) => {
+    const isPillEllipsisActive = (element: HTMLElement): boolean => {
       const labelElement: HTMLSpanElement =
         element?.firstElementChild as HTMLSpanElement;
-      return labelElement?.offsetWidth < labelElement?.scrollWidth;
+      return (
+        labelElement && labelElement.offsetWidth < labelElement.scrollWidth
+      );
     };
 
     const getPills = (): JSX.Element => {
-      const selected: SelectOption[] = (options || []).filter(
-        (opt: SelectOption) => opt.selected
-      );
+      const selected: SelectOption[] = selectedOrder;
 
       const selectedCount: number = selected.length;
       const pills: React.ReactElement[] = [];
       let moreOptionsCount: number = selectedCount;
 
-      // TODO: Mutate Array based on order of selection.
       selected.forEach((opt: SelectOption, index: number) => {
         const pill = (): JSX.Element => (
           <Pill
@@ -578,12 +629,16 @@ export const Select: FC<SelectProps> = React.forwardRef(
             key={`select-pill-${index}`}
             label={opt.text}
             onClose={() => toggleOption(opt)}
-            size={selectSizeToPillSizeMap.get(size)}
+            size={selectSizeToPillSizeMap.get(mergedSize)}
             tabIndex={0}
             theme={'blueGreen'}
             type={readonly ? PillType.default : PillType.closable}
             style={{
-              visibility: index < count ? 'visible' : 'hidden',
+              visibility: maxPillCount
+                ? index < count
+                  ? 'visible'
+                  : 'hidden'
+                : 'visible',
             }}
             {...pillProps}
           />
@@ -597,7 +652,6 @@ export const Select: FC<SelectProps> = React.forwardRef(
               classNames={styles.selectTooltip}
               content={opt.text}
               id={`selectTooltip${index}`}
-              key={`select-tooltip-${index}`}
               placement={'top'}
               portal
               theme={TooltipTheme.dark}
@@ -608,7 +662,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         } else {
           pills.push(pill());
         }
-        if (pills?.length === count && filled) {
+        if (maxPillCount && pills.length === count && filled) {
           pills.push(
             <Pill
               classNames={countPillClassNames}
@@ -625,7 +679,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
         }
       });
 
-      return <div className={styles.multiSelectPills}>{pills}</div>;
+      return (
+        <div className={multiSelectPillsClassNames} ref={pillWrapperRef}>
+          {pills}
+        </div>
+      );
     };
 
     const getSelectedOptionText = (): void => {
@@ -633,12 +691,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
         setSelectedOptionText(searchQuery);
         return;
       }
-      const selectedOption = (options || [])
-        .filter((opt: SelectOption) => opt.selected)
-        .map((opt: SelectOption) => opt.text)
-        .join(', ')
-        .toLocaleString();
-      setSelectedOptionText(selectedOption);
+
+      const selectedOption: SelectOption = (options || []).find(
+        (opt: SelectOption) => opt.selected
+      );
+
+      setSelectedOptionText(selectedOption ? selectedOption.text : '');
     };
 
     const OptionMenu = ({
@@ -646,60 +704,127 @@ export const Select: FC<SelectProps> = React.forwardRef(
     }: {
       options: SelectOption[];
     }): JSX.Element => {
-      const filteredOptions = (options || []).filter(
-        (opt: SelectOption) => !opt.hideOption
-      );
-      const updatedItems: SelectOption[] = filteredOptions.map(
-        ({ hideOption, ...opt }) => ({
+      const updatedItems: SelectOption[] = (options || [])
+        .filter((opt: SelectOption) => !opt.hideOption)
+        .map(({ hideOption, ...opt }) => ({
           ...opt,
           classNames: mergeClasses([{ [styles.selectedOption]: opt.selected }]),
           role: 'option',
           'aria-selected': opt.selected,
-        })
-      );
-      if (filteredOptions.length > 0) {
-        return (
-          <Menu
-            aria-multiselectable={multiple ? 'true' : undefined}
-            id={selectMenuId?.current}
-            {...menuProps}
-            items={updatedItems}
-            onChange={(value) => {
-              const option = updatedItems.find(
-                (opt: SelectOption) => opt.value === value
-              );
-              currentlySelectedOption.current = option;
-              toggleOption(option);
-            }}
-            role="listbox"
-          />
-        );
-      } else {
+        }));
+
+      if (updatedItems.length === 0) {
         return <div className={styles.selectMenuEmpty}>{emptyText}</div>;
       }
+
+      return (
+        <Menu
+          aria-multiselectable={multiple ? 'true' : undefined}
+          id={selectMenuId?.current}
+          {...menuProps}
+          items={updatedItems}
+          onChange={(value) => {
+            const option = updatedItems.find(
+              (opt: SelectOption) => opt.value === value
+            );
+            if (multiple || toggleOptions) {
+              toggleOption(option);
+              currentlySelectedOption.current = option;
+            } else {
+              if (
+                !currentlySelectedOption.current ||
+                currentlySelectedOption.current?.value !== option.value
+              ) {
+                toggleOption(option);
+                currentlySelectedOption.current = option;
+              }
+            }
+          }}
+          role="listbox"
+        />
+      );
     };
 
+    const getPillWrapperOffset = (): number[] => {
+      let offset: number[];
+      if (largeScreenActive) {
+        offset = [28, 48];
+      } else if (mediumScreenActive) {
+        offset = [36, 56];
+      } else if (smallScreenActive) {
+        offset = [36, 56];
+      } else if (xSmallScreenActive) {
+        offset = [44, 72];
+      }
+      return offset;
+    };
+
+    const selectSizeToPillWrapperOffsetMap = new Map<
+      SelectSize | Size,
+      number[]
+    >([
+      [SelectSize.Flex, getPillWrapperOffset()],
+      [SelectSize.Large, [44, 72]],
+      [SelectSize.Medium, [36, 56]],
+      [SelectSize.Small, [28, 48]],
+    ]);
+
     const getStyle = (): React.CSSProperties => {
-      if (filterable && multiple && dropdownVisible && showPills()) {
+      if (!multiple) {
+        return {};
+      }
+
+      const pillWrapperOffsetHeight: number =
+        pillWrapperRef.current?.offsetHeight || 0;
+      const pillWrapperOffset: number[] =
+        selectSizeToPillWrapperOffsetMap.get(mergedSize);
+
+      if (!maxPillCount && showPills() && pillWrapperRef.current) {
+        const pillOffsetStyles = {
+          height: `${Math.floor(
+            pillWrapperOffsetHeight + pillWrapperOffset[0]
+          )}px`,
+          padding: '4px 8px',
+          paddingTop: `${Math.floor(pillWrapperOffsetHeight)}px`,
+        };
+
+        if (filterable) {
+          return {
+            ...pillOffsetStyles,
+            [htmlDir === 'rtl' ? 'paddingLeft' : 'paddingRight']:
+              pillWrapperOffset[1],
+          };
+        } else {
+          return { height: `${Math.floor(pillWrapperOffsetHeight)}px` };
+        }
+      } else if (maxPillCount && showPills() && pillWrapperRef.current) {
         const paddingValue: number =
           width > 0
             ? filled
               ? width + multiSelectCountOffset
-              : width + inputPaddingHorizontal
-            : inputPaddingHorizontal;
-        if (htmlDir === 'rtl') {
-          return {
-            paddingRight: paddingValue,
-          };
-        } else {
-          return {
-            paddingLeft: paddingValue,
-          };
-        }
-      } else {
-        return undefined;
+              : width + inputPadding
+            : inputPadding;
+        return {
+          [htmlDir === 'rtl'
+            ? 'paddingRight'
+            : 'paddingLeft']: `${paddingValue}px`,
+          [htmlDir === 'rtl' ? 'paddingLeft' : 'paddingRight']:
+            pillWrapperOffset[1],
+        };
       }
+      return {};
     };
+
+    const [textInputStyle, setTextInputStyle] = useState<React.CSSProperties>(
+      getStyle()
+    );
+
+    useEffect(() => {
+      if (!multiple) {
+        return;
+      }
+      setTextInputStyle(getStyle());
+    }, [maxPillCount, mergedSize, multiple, options, selectWidth]);
 
     const restoreCloseOnReferenceClickAsync = async (): Promise<void> => {
       if (filterable && !multiple) {
@@ -752,39 +877,51 @@ export const Select: FC<SelectProps> = React.forwardRef(
 
     const clearButtonClassNames: string = mergeClasses([
       styles.selectClearButton,
-      { [styles.selectClearButtonEnd]: multiple && filterable && showPills() },
+      { [styles.selectClearButtonEnd]: multiple && filterable },
       { [styles.selectClearButtonStart]: !multiple },
       {
         [styles.selectClearButtonEndRtl]:
-          htmlDir === 'rtl' && multiple && filterable && showPills(),
+          htmlDir === 'rtl' && multiple && filterable,
       },
       { [styles.selectClearButtonStartRtl]: htmlDir === 'rtl' && !multiple },
     ]);
 
-    const selectInputProps: TextInputProps = {
-      placeholder: showPills() && !!options ? '' : placeholder,
-      alignIcon: TextInputIconAlign.Right,
-      clearable: clearable && !readonly,
-      clearButtonClassNames: clearButtonClassNames,
-      inputWidth: inputWidth,
-      iconButtonProps: !readonly
-        ? {
-            ariaLabel: toggleButtonAriaLabel
-              ? toggleButtonAriaLabel
-              : 'Toggle dropdown',
-            htmlType: 'button',
-            iconProps: {
-              path: dropdownVisible
-                ? IconName.mdiChevronUp
-                : IconName.mdiChevronDown,
+    const selectInputProps: TextInputProps = useMemo(
+      () => ({
+        placeholder: showPills() && !!options ? '' : placeholder,
+        alignIcon: TextInputIconAlign.Right,
+        clearable: clearable && !readonly,
+        clearButtonClassNames: clearButtonClassNames,
+        inputWidth: inputWidth,
+        iconButtonProps: readonly
+          ? null
+          : {
+              ariaLabel: toggleButtonAriaLabel || 'Toggle dropdown',
+              htmlType: 'button',
+              iconProps: {
+                path: dropdownVisible
+                  ? IconName.mdiChevronUp
+                  : IconName.mdiChevronDown,
+              },
+              onClick: handleToggleButtonClick,
             },
-            onClick: handleToggleButtonClick,
-          }
-        : null,
-      style: getStyle(),
-      onClear: onInputClear,
-      ...textInputProps,
-    };
+        onClear: onInputClear,
+        ...textInputProps,
+        style: { ...textInputProps.style, ...textInputStyle },
+      }),
+      [
+        placeholder,
+        clearable,
+        textInputStyle,
+        readonly,
+        clearButtonClassNames,
+        inputWidth,
+        toggleButtonAriaLabel,
+        dropdownVisible,
+        onInputClear,
+        textInputProps,
+      ]
+    );
 
     const selectShapeToTextInputShapeMap = new Map<
       SelectShape | Shape,
@@ -813,14 +950,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
         return;
       }
 
-      const inputWidth: number = inputRef.current?.offsetWidth;
-      let dropdownUpdatedWidth: number =
-        inputRef.current?.offsetWidth > dropdownDefaultWidth
-          ? inputRef.current?.offsetWidth
-          : dropdownDefaultWidth;
+      const inputWidth: number = inputRef.current.offsetWidth;
+      const dropdownUpdatedWidth: number = Math.max(
+        inputWidth > dropdownDefaultWidth ? inputWidth : dropdownDefaultWidth
+      );
 
       setSelectWidth(inputWidth);
       setDropdownWidth(dropdownUpdatedWidth);
+      dropdownRef.current?.update();
     };
 
     useLayoutEffect(() => {
@@ -838,7 +975,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
             ref={ref}
             aria-owns={dropdownVisible ? selectMenuId?.current : undefined}
             className={componentClassNames}
-            data-test-id={dataTestId}
+            data-test-id={dataTestId} // TODO: Remove in v3.0.0
+            data-testid={dataTestIdv2}
             id={id}
             style={style}
           >

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -132,6 +132,11 @@ export interface SelectProps
    */
   loadOptions?: (inputValue: string) => void;
   /**
+   * Auto collapse to pill with responsive behavior.
+   * @default true
+   */
+  maxPillCount?: boolean;
+  /**
    * The Dropdown Menu props.
    * @default {}
    */
@@ -222,4 +227,15 @@ export interface SelectProps
    * The Select toggle dropdown chevron button aria label.
    */
   toggleButtonAriaLabel?: string;
+  /**
+   * Selected options may be toggled.
+   * Use when multiple is false as this is mutually exclusive.
+   * @default true
+   */
+  toggleOptions?: boolean;
+  /**
+   * The select value.
+   * @default undefined
+   */
+  value?: string | string[];
 }

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -376,7 +376,7 @@ exports[`Select Renders with default values when multiple 1`] = `
     class="select-wrapper select-wrapper-multiple select-medium"
   >
     <div
-      class="multi-select-pills"
+      class="multi-select-pills multi-select-pills-max-count"
     >
       <div
         class="tag-pills multi-select-pill blue-green medium"
@@ -471,6 +471,7 @@ exports[`Select Renders with default values when multiple 1`] = `
                 placeholder=""
                 readonly=""
                 role="combobox"
+                style="padding-right: 56px;"
                 tabindex="0"
                 type="text"
                 value=""

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -1,9 +1,13 @@
-$input-padding-horizontal: $space-xs;
+$input-padding: $space-xs;
 $multi-select-count-offset: 54px;
+$multi-select-pill-gap: $space-xs;
+$multi-select-pill-large-padding: 6px;
+$multi-select-pill-medium-padding: 5px;
+$multi-select-pill-small-padding: 4px;
 
 // Export values for typescript consumption.
 :export {
-  inputPaddingHorizontal: strip-units($input-padding-horizontal);
+  inputPadding: strip-units($input-padding);
   multiSelectCountOffset: strip-units($multi-select-count-offset);
 }
 
@@ -49,26 +53,45 @@ $multi-select-count-offset: 54px;
     align-items: center;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
+    gap: $multi-select-pill-gap;
     left: $space-xs;
     right: $space-xxl;
+    padding: $multi-select-pill-medium-padding 0;
     pointer-events: none;
     position: absolute;
-    top: 6px;
+    top: 0;
+    white-space: normal;
     z-index: 1;
-  }
 
-  .multi-select-pill {
-    margin-right: $space-xs;
-    max-width: 144px;
-    text-align: center;
-    display: flex;
-    justify-content: center;
-    padding: 3px $space-xs;
-    pointer-events: all;
+    &.multi-select-pills-divider {
+      border-bottom: 1px solid var(--grey-tertiary-color);
+      right: $space-xs;
+    }
 
-    span {
-      @include text-overflow;
-      max-width: 128px;
+    .multi-select-pill {
+      max-width: 100%;
+      text-align: start;
+      display: flex;
+      justify-content: center;
+      min-width: fit-content;
+      pointer-events: all;
+    }
+
+    &-max-count {
+      flex-wrap: nowrap;
+      white-space: inherit;
+
+      .multi-select-pill {
+        max-width: 144px;
+        min-width: unset;
+        text-align: center;
+
+        span {
+          @include text-overflow;
+          max-width: 128px;
+        }
+      }
     }
   }
 
@@ -79,11 +102,18 @@ $multi-select-count-offset: 54px;
 
   &.select-large {
     .multi-select-pills {
-      top: 7px;
+      padding: $multi-select-pill-large-padding 0;
 
-      .multi-select-count,
       .multi-select-pill {
-        padding: 3px $space-xs;
+        height: auto;
+        min-height: $space-xl;
+      }
+
+      &-max-count {
+        .multi-select-count,
+        .multi-select-pill {
+          height: $space-xl;
+        }
       }
     }
 
@@ -107,11 +137,18 @@ $multi-select-count-offset: 54px;
 
   &.select-medium {
     .multi-select-pills {
-      top: 5px;
+      padding: $multi-select-pill-medium-padding 0;
 
-      .multi-select-count,
       .multi-select-pill {
-        padding: 3px $space-xs;
+        height: auto;
+        min-height: 26px;
+      }
+
+      &-max-count {
+        .multi-select-count,
+        .multi-select-pill {
+          height: 26px;
+        }
       }
     }
 
@@ -134,12 +171,24 @@ $multi-select-count-offset: 54px;
   }
 
   &.select-small {
-    .multi-select-pills {
-      top: $space-xxs;
+    .multi-select-count {
+      margin-left: $space-xs;
+      margin-right: 0;
+    }
 
-      .multi-select-count,
+    .multi-select-pills {
+      padding: $multi-select-pill-small-padding 0;
+
       .multi-select-pill {
-        padding: $space-xxxs $space-s;
+        height: auto;
+        min-height: $space-ml;
+      }
+
+      &-max-count {
+        .multi-select-count,
+        .multi-select-pill {
+          height: $space-ml;
+        }
       }
     }
 


### PR DESCRIPTION
## SUMMARY:
- Adds `value` prop, making life a bit easier enabling scenarios like a shared upstream state or externally controlled state to determine the value of the `Select` `TextInput`, along with its selected option determined by the value of `SelectOption` desired
- memoizes `selectInputProps`, `getSelectedOptionValues` and `getSelectedOptions`
- Adds `maxPillCount` `boolean` prop. When `multiple`, and `maxPillCount` is `true`, the `Pill` don't wrap and those that cannot be displayed are represented by a count `Pill`. When `multiple` and `maxPillCount` is `false`, the `Pill` wrap
- When `Select` is multiple, the `Pill` now render in the order selected and the date returned by `Select` also reflects that order
- Adds `toggleOptions` `boolean` prop. When `false` and `Select` is not `multiple`, its options become mutually exclusive
- Fixes bug where `onOptionsChange` callback was being triggered upon render, this no longer happens
- When `filterable` pressing enter key now selects the first filtered option when available
- Optimizes code by reducing some redundancies
- Adds UTs
- Adds a shared state story, demonstrating newly supported functionality common in PCS applications
- Updates snap


https://github.com/EightfoldAI/octuple/assets/99700808/4d473881-86f6-4b9c-a750-4a9349f34daa


## JIRA TASK (Eightfold Employees Only):
ENG-48962
ENG-48961
ENG-69417

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Select` stories behave as expected.