### PR TITLE
feat: accordion: adds rendercontentalways prop managed by expanded

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -122,6 +122,7 @@ export const __namedExportsOrder = [
 ];
 
 Single.args = {
+  renderContentAlways: true,
   children: (
     <>
       <div style={{ height: 'auto' }}>

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -10,6 +10,7 @@ import Layout from '../Layout';
 import { List } from '../List';
 import { Stack } from '../Stack';
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -219,5 +220,31 @@ describe('Accordion', () => {
     );
     expect(() => container).not.toThrowError();
     expect(container).toMatchSnapshot();
+  });
+
+  test('renders content always when renderContentAlways is true', () => {
+    const { queryByText } = render(
+      <Accordion {...accordionProps} renderContentAlways={true}>
+        <div>Test Content</div>
+      </Accordion>
+    );
+
+    expect(queryByText('Test Content')).not.toBeNull();
+  });
+
+  test('does not render content when renderContentAlways is false and expanded is false', async () => {
+    const { queryByText } = render(
+      <Accordion
+        {...accordionProps}
+        renderContentAlways={false}
+        expanded={false}
+      >
+        <div>Test Content</div>
+      </Accordion>
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Test Content')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -119,20 +119,20 @@ export const AccordionBody: FC<AccordionBodyProps> = ({
   renderContentAlways,
   ...rest
 }) => {
-  const [shouldRender, setShouldRender] =
+  const [shouldRenderContent, setShouldRenderContent] =
     useState<boolean>(renderContentAlways);
 
   let timeout: ReturnType<typeof setTimeout>;
 
   useEffect(() => {
     if (renderContentAlways) {
-      setShouldRender(true);
+      setShouldRenderContent(true);
     } else if (expanded) {
-      setShouldRender(true);
+      setShouldRenderContent(true);
       if (timeout) clearTimeout(timeout);
     } else {
       timeout = setTimeout(() => {
-        setShouldRender(false);
+        setShouldRenderContent(false);
       }, ANIMATION_DURATION);
     }
     return () => {
@@ -166,7 +166,9 @@ export const AccordionBody: FC<AccordionBodyProps> = ({
       role="region"
       {...rest}
     >
-      <div className={accordionBodyStyles}>{shouldRender && children}</div>
+      <div className={accordionBodyStyles}>
+        {shouldRenderContent && children}
+      </div>
     </div>
   );
 };

--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -55,6 +55,11 @@ interface AccordionBaseProps extends OcBaseProps<HTMLDivElement> {
    */
   onIconButtonClick?: React.MouseEventHandler<HTMLButtonElement>;
   /**
+   * Whether to render Accordion Body content when Accordion `expanded` is `false`.
+   * @default true
+   */
+  renderContentAlways?: boolean;
+  /**
    * Shape of the accordion
    * @default AccordionShape.Pill
    */


### PR DESCRIPTION
## SUMMARY:
- Adds `renderContentAlways` prop to `Accordion`, improving keyboard and assistive tech usability config upstream
- Adds UTs
- Updates Stories

We useEffect to first check if `renderContentAlways` is `true`. If it is, we set `shouldRender` to `true` and skip the rest of the checks. If `renderContentAlways` is `false`, we then check if `expanded` is `true`. If it is, we set `shouldRender` to `true` and clear any existing timeout. If `expanded` is `false`, we start a timeout that sets `shouldRender` to `false` after `400ms`, affording time for the animation to complete.


https://github.com/EightfoldAI/octuple/assets/99700808/ca9a3c01-b74a-4f85-8772-2d2675a7ecc4


## JIRA TASK (Eightfold Employees Only):
ENG-86284

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Accordion` stories behave as expected.