### PR TITLE
chore: locale: exports uselocalereceiver hook

### DIFF
--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,4 +1,5 @@
 import type { Locale } from './components/LocaleProvider';
+import { useLocaleReceiver } from './components/LocaleProvider/LocaleReceiver';
 
 // Supported locales
 import arSA from './components/Locale/ar_SA'; // العربية
@@ -85,6 +86,7 @@ export {
   thTH,
   trTR,
   ukUA,
+  useLocaleReceiver,
   viVN,
   zhCN,
   zhTW,


### PR DESCRIPTION
## SUMMARY:
- Exports the `useLocaleReceiver` hook via locale.ts to assist in mapping localized text by component.

## JIRA TASK (Eightfold Employees Only):
ENG-87175

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request
- [x] Chore

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
N/A