### PR TITLE
chore: drawer: makes overlay configurable for all variants

### DIFF
--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -117,8 +117,6 @@ const Hint_Story: ComponentStory<typeof Drawer> = (args) => {
         </div>
       }
       visible={visible}
-      overlay={visible}
-      maskClosable={visible}
       onVisibleChange={(visible) => setVisible(visible)}
     />
   );

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -114,6 +114,21 @@ describe('Drawer', () => {
     );
     expect(
       getByTestId('testDrawer').classList.contains('modeless')
+    ).toBeFalsy();
+  });
+
+  test('Handles DrawerVariant.Default modeless', () => {
+    const { getByTestId } = render(
+      <Drawer
+        children={<div>Test drawer</div>}
+        data-testid="testDrawer"
+        variant={DrawerVariant.Default}
+        maskClosable={false}
+        overlay={false}
+      />
+    );
+    expect(
+      getByTestId('testDrawer').classList.contains('modeless')
     ).toBeTruthy();
   });
 
@@ -128,6 +143,21 @@ describe('Drawer', () => {
     expect(
       getByTestId('testDrawer').classList.contains('modeless')
     ).toBeFalsy();
+  });
+
+  test('Handles DrawerVariant.Hint modeless', () => {
+    const { getByTestId } = render(
+      <Drawer
+        children={<div>Test drawer</div>}
+        data-testid="testDrawer"
+        variant={DrawerVariant.Hint}
+        maskClosable={false}
+        overlay={false}
+      />
+    );
+    expect(
+      getByTestId('testDrawer').classList.contains('modeless')
+    ).toBeTruthy();
   });
 
   test('Drawer visibility', () => {

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -74,8 +74,8 @@ export const Drawer: FC<DrawerProps> = React.forwardRef(
       focusTrap = true,
       zIndex,
       variant = DrawerVariant.Default,
-      maskClosable = variant === DrawerVariant.Hint,
-      overlay = variant === DrawerVariant.Hint,
+      maskClosable = true,
+      overlay = true,
       ...rest
     } = props;
 

--- a/src/components/Drawer/drawer.module.scss
+++ b/src/components/Drawer/drawer.module.scss
@@ -15,17 +15,24 @@ $handle_height: 40px;
   }
 
   &:not(.modeless) {
-    background-color: $all-backdrops;
+    pointer-events: none;
     transition: all $motion-duration-extra-fast $motion-easing-easeinout 0s;
+
+    &.visible {
+      background-color: $all-backdrops;
+      pointer-events: auto;
+    }
   }
 
   &.modeless {
     background: none;
-    pointer-events: none; // Fix blocking overlay
+    pointer-events: none;
 
     &-mask {
       &.expand {
-        pointer-events: auto;
+        &.visible {
+          pointer-events: auto;
+        }
       }
     }
   }


### PR DESCRIPTION
## SUMMARY:
- Enables `maskClosable` and `overlay` props for Hint variant
- Refines overlay hide animation


https://github.com/EightfoldAI/octuple/assets/99700808/7ce0865f-70ea-4322-8a29-b0122d8c7c7d


## JIRA TASK (Eightfold Employees Only):
ENG-87178

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request
- [x] Chore

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Drawer` stories behave as expected