### PR TITLE
feat: accordion: deep accessibility updates

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -270,7 +270,7 @@ Custom.args = {
                 ariaLabel={item.ariaLabel}
                 disruptive={item.disruptive}
                 iconProps={{ path: item.icon }}
-                onClick={(e) => e.preventDefault()} // prevent accordion toggle, then apply your own logic.
+                onClick={(e) => e.stopPropagation()} // prevent accordion toggle, then apply your own logic.
                 shape={ButtonShape.Round}
                 variant={item.variant}
               />

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -251,7 +251,7 @@ Custom.args = {
             className="octuple-content"
             style={{ color: 'var(--grey-tertiary-color)', fontWeight: 400 }}
           >
-            Supporting text
+            <span>Supporting text</span>
           </div>
         </Stack>
         <Stack

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -90,15 +90,15 @@ describe('Accordion', () => {
     const { container } = render(
       <Accordion {...accordionProps} size={AccordionSize.Large} />
     );
-    const summary = container.querySelector('.accordion-summary');
-    fireEvent.click(summary);
+    const summaryClickableArea = container.querySelector('.clickable-area');
+    fireEvent.click(summaryClickableArea);
     await waitFor(() =>
       expect(
         container.getElementsByClassName('accordion-summary-expanded')
       ).toHaveLength(1)
     );
     expect(container.querySelector('.show')).toBeTruthy();
-    fireEvent.click(summary);
+    fireEvent.click(summaryClickableArea);
     await waitFor(() =>
       expect(
         container.getElementsByClassName('accordion-summary-expanded')
@@ -149,8 +149,8 @@ describe('Accordion', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('Accordion renders custom content', () => {
-    const { container } = render(
+  test('Accordion renders custom content and its buttons are clickable', () => {
+    const { container, getByRole, getByText } = render(
       <Accordion
         {...accordionProps}
         expanded={true}
@@ -187,7 +187,7 @@ describe('Accordion', () => {
                     fontWeight: 400,
                   }}
                 >
-                  Supporting text
+                  <span>Supporting text</span>
                 </div>
               </Stack>
               <Stack
@@ -218,6 +218,13 @@ describe('Accordion', () => {
         }
       />
     );
+    const textElement = getByText('Supporting text');
+    expect(textElement).toBeInTheDocument();
+    buttons.forEach((button) => {
+      const buttonElement = getByRole('button', { name: button.ariaLabel });
+      fireEvent.click(buttonElement);
+      expect(buttonElement).toBeEnabled();
+    });
     expect(() => container).not.toThrowError();
     expect(container).toMatchSnapshot();
   });

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -15,6 +15,7 @@ import ThemeContext, {
 } from '../ConfigProvider/ThemeContext';
 import {
   AccordionBodyProps,
+  AccordionLocale,
   AccordionProps,
   AccordionShape,
   AccordionSize,
@@ -24,6 +25,10 @@ import { Badge } from '../Badge';
 import { Button, ButtonShape, ButtonVariant } from '../Button';
 import { Icon, IconName } from '../Icon';
 import { eventKeys, mergeClasses, uniqueId } from '../../shared/utilities';
+import LocaleReceiver, {
+  useLocaleReceiver,
+} from '../LocaleProvider/LocaleReceiver';
+import enUS from './Locale/en_US';
 
 import styles from './accordion.module.scss';
 import themedComponentStyles from './accordion.theme.module.scss';
@@ -34,7 +39,9 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
   badgeProps,
   children,
   classNames,
+  collapseAriaLabelText,
   disabled,
+  expandAriaLabelText,
   expandButtonProps,
   expanded,
   expandIconProps,
@@ -77,24 +84,28 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
   );
 
   return (
-    <div
-      aria-expanded={expanded}
-      aria-controls={`${id}-content`}
-      className={headerClassnames}
-      onClick={onClick}
-      onKeyDown={handleKeyDown}
-      id={`${id}-header`}
-      role="button"
-      tabIndex={0}
-      {...rest}
-    >
+    <div className={headerClassnames} id={`${id}-header`} {...rest}>
+      <div
+        aria-controls={`${id}-content`}
+        aria-label={expanded ? collapseAriaLabelText : expandAriaLabelText}
+        aria-expanded={expanded}
+        className={styles.clickableArea}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+      ></div>
       <div className={styles.accordionHeaderContainer}>
         {iconProps && <Icon {...iconProps} />}
-        <span className={styles.accordionHeader}>{children}</span>
+        <div className={styles.accordionHeader}>
+          {typeof children === 'string' ? <span>{children}</span> : children}
+        </div>
         {badgeProps && <Badge classNames={styles.badge} {...badgeProps} />}
       </div>
       <Button
-        {...expandButtonProps}
+        aria-controls={`${id}-content`}
+        ariaLabel={expanded ? collapseAriaLabelText : expandAriaLabelText}
+        aria-expanded={expanded}
         disabled={disabled}
         gradient={gradient}
         iconProps={{ classNames: iconButtonClassNames, ...expandIconProps }}
@@ -174,18 +185,20 @@ export const AccordionBody: FC<AccordionBodyProps> = ({
 };
 
 export const Accordion: FC<AccordionProps> = React.forwardRef(
-  (
-    {
+  (props: AccordionProps, ref: Ref<HTMLDivElement>) => {
+    const {
       badgeProps,
       bodyProps,
       bordered = true,
       children,
       classNames,
+      collapseAriaLabelText: defaultCollapseAriaLabelText,
       configContextProps = {
         noGradientContext: false,
         noThemeContext: false,
       },
       disabled,
+      expandAriaLabelText: defaultExpandAriaLabelText,
       expandButtonProps,
       expanded = false,
       expandIconProps = { path: IconName.mdiChevronDown },
@@ -193,6 +206,7 @@ export const Accordion: FC<AccordionProps> = React.forwardRef(
       headerProps,
       iconProps,
       id = uniqueId('accordion-'),
+      locale = enUS,
       onAccordionChange,
       renderContentAlways = true,
       shape = AccordionShape.Pill,
@@ -201,9 +215,7 @@ export const Accordion: FC<AccordionProps> = React.forwardRef(
       theme,
       themeContainerId,
       ...rest
-    },
-    ref: Ref<HTMLDivElement>
-  ) => {
+    } = props;
     const [isExpanded, setIsExpanded] = useState<boolean>(expanded);
 
     const contextualGradient: Gradient = useContext(GradientContext);
@@ -219,6 +231,38 @@ export const Accordion: FC<AccordionProps> = React.forwardRef(
     useEffect(() => {
       setIsExpanded(expanded);
     }, [expanded]);
+
+    // ============================ Strings ===========================
+    const [accordionLocale] = useLocaleReceiver('Accordion');
+    let mergedLocale: AccordionLocale;
+
+    if (props.locale) {
+      mergedLocale = props.locale;
+    } else {
+      mergedLocale = accordionLocale || props.locale;
+    }
+
+    const [collapseAriaLabelText, setCollapseAriaLabelText] = useState<string>(
+      defaultCollapseAriaLabelText
+    );
+    const [expandAriaLabelText, setExpandAriaLabelText] = useState<string>(
+      defaultExpandAriaLabelText
+    );
+
+    // Locs: if the prop isn't provided use the loc defaults.
+    // If the mergedLocale is changed, update.
+    useEffect(() => {
+      setCollapseAriaLabelText(
+        props.collapseAriaLabelText
+          ? props.collapseAriaLabelText
+          : mergedLocale.lang!.collapseAriaLabelText
+      );
+      setExpandAriaLabelText(
+        props.expandAriaLabelText
+          ? props.expandAriaLabelText
+          : mergedLocale.lang!.expandAriaLabelText
+      );
+    }, [mergedLocale]);
 
     const toggleAccordion = (expand: boolean): void => {
       setIsExpanded(expand);
@@ -238,41 +282,49 @@ export const Accordion: FC<AccordionProps> = React.forwardRef(
     );
 
     return (
-      <ThemeContextProvider
-        componentClassName={themedComponentStyles.theme}
-        containerId={themeContainerId}
-        theme={mergedTheme}
-      >
-        <div className={accordionContainerStyle} ref={ref} {...rest}>
-          <AccordionSummary
-            badgeProps={badgeProps}
-            disabled={disabled}
-            expanded={isExpanded}
-            expandIconProps={expandIconProps}
-            expandButtonProps={expandButtonProps}
-            gradient={gradient}
-            iconProps={iconProps}
-            id={id}
-            onIconButtonClick={() => toggleAccordion(!isExpanded)}
-            onClick={() => toggleAccordion(!isExpanded)}
-            size={size}
-            {...headerProps}
-          >
-            {summary}
-          </AccordionSummary>
-          <AccordionBody
-            bordered={bordered}
-            expanded={isExpanded}
-            gradient={gradient}
-            id={id}
-            renderContentAlways={renderContentAlways}
-            size={size}
-            {...bodyProps}
-          >
-            {children}
-          </AccordionBody>
-        </div>
-      </ThemeContextProvider>
+      <LocaleReceiver componentName={'Accordion'} defaultLocale={enUS}>
+        {(_contextLocale: AccordionLocale) => {
+          return (
+            <ThemeContextProvider
+              componentClassName={themedComponentStyles.theme}
+              containerId={themeContainerId}
+              theme={mergedTheme}
+            >
+              <div className={accordionContainerStyle} ref={ref} {...rest}>
+                <AccordionSummary
+                  badgeProps={badgeProps}
+                  collapseAriaLabelText={collapseAriaLabelText}
+                  disabled={disabled}
+                  expandAriaLabelText={expandAriaLabelText}
+                  expanded={isExpanded}
+                  expandIconProps={expandIconProps}
+                  expandButtonProps={expandButtonProps}
+                  gradient={gradient}
+                  iconProps={iconProps}
+                  id={id}
+                  onIconButtonClick={() => toggleAccordion(!isExpanded)}
+                  onClick={() => toggleAccordion(!isExpanded)}
+                  size={size}
+                  {...headerProps}
+                >
+                  {summary}
+                </AccordionSummary>
+                <AccordionBody
+                  bordered={bordered}
+                  expanded={isExpanded}
+                  gradient={gradient}
+                  id={id}
+                  renderContentAlways={renderContentAlways}
+                  size={size}
+                  {...bodyProps}
+                >
+                  {children}
+                </AccordionBody>
+              </div>
+            </ThemeContextProvider>
+          );
+        }}
+      </LocaleReceiver>
     );
   }
 );

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -87,7 +87,7 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
     <div className={headerClassnames} id={`${id}-header`} {...rest}>
       <div
         aria-controls={`${id}-content`}
-        aria-label={expanded ? collapseAriaLabelText : expandAriaLabelText}
+        aria-label={expanded ? expandAriaLabelText : collapseAriaLabelText}
         aria-expanded={expanded}
         className={styles.clickableArea}
         onClick={onClick}
@@ -104,7 +104,7 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
       </div>
       <Button
         aria-controls={`${id}-content`}
-        ariaLabel={expanded ? collapseAriaLabelText : expandAriaLabelText}
+        ariaLabel={expanded ? expandAriaLabelText : collapseAriaLabelText}
         aria-expanded={expanded}
         disabled={disabled}
         gradient={gradient}

--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -11,11 +11,11 @@ type Locale = {
    */
   locale: string;
   /**
-   * The Accordion `Collapse content` aria label string.
+   * The Accordion `Close content` aria label string.
    */
   collapseAriaLabelText?: string;
   /**
-   * The Accordion `Expand content` aria label string.
+   * The Accordion `Open content` aria label string.
    */
   expandAriaLabelText?: string;
 };
@@ -41,7 +41,7 @@ interface AccordionBaseProps extends OcBaseProps<HTMLDivElement> {
    */
   bordered?: boolean;
   /**
-   * The Accordion `Collapse content` aria label string.
+   * The Accordion `Close content` aria label string.
    */
   collapseAriaLabelText?: string;
   /**
@@ -53,7 +53,7 @@ interface AccordionBaseProps extends OcBaseProps<HTMLDivElement> {
    */
   disabled?: boolean;
   /**
-   * The Accordion `Expand content` aria label string.
+   * The Accordion `Open content` aria label string.
    */
   expandAriaLabelText?: string;
   /**

--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -5,6 +5,25 @@ import { IconProps } from '../Icon';
 import { BadgeProps } from '../Badge';
 import { ButtonProps } from '../Button';
 
+type Locale = {
+  /**
+   * The Accordion locale.
+   */
+  locale: string;
+  /**
+   * The Accordion `Collapse content` aria label string.
+   */
+  collapseAriaLabelText?: string;
+  /**
+   * The Accordion `Expand content` aria label string.
+   */
+  expandAriaLabelText?: string;
+};
+
+export type AccordionLocale = {
+  lang: Locale;
+};
+
 export enum AccordionShape {
   Pill = 'pill',
   Rectangle = 'rectangle',
@@ -22,6 +41,10 @@ interface AccordionBaseProps extends OcBaseProps<HTMLDivElement> {
    */
   bordered?: boolean;
   /**
+   * The Accordion `Collapse content` aria label string.
+   */
+  collapseAriaLabelText?: string;
+  /**
    * Configure how contextual props are consumed
    */
   configContextProps?: ConfigContextProps;
@@ -29,6 +52,10 @@ interface AccordionBaseProps extends OcBaseProps<HTMLDivElement> {
    * If the accordion is disabled
    */
   disabled?: boolean;
+  /**
+   * The Accordion `Expand content` aria label string.
+   */
+  expandAriaLabelText?: string;
   /**
    * Accordion is in an expanded state or not
    * @default false
@@ -48,6 +75,11 @@ interface AccordionBaseProps extends OcBaseProps<HTMLDivElement> {
    * @default false
    */
   gradient?: boolean;
+  /**
+   * The Accordion locale.
+   * @default 'enUS'
+   */
+  locale?: AccordionLocale;
   /**
    * The onClick callback for the accordion.
    * @param event

--- a/src/components/Accordion/Locale/ar_SA.tsx
+++ b/src/components/Accordion/Locale/ar_SA.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ar_SA',
-    collapseAriaLabelText: 'أغلق المحتوى',
-    expandAriaLabelText: 'افتح المحتوى',
+    collapseAriaLabelText: 'أكورديون',
+    expandAriaLabelText: 'أكورديون',
   },
 };
 

--- a/src/components/Accordion/Locale/ar_SA.tsx
+++ b/src/components/Accordion/Locale/ar_SA.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ar_SA',
-    collapseAriaLabelText: 'طي المحتوى',
-    expandAriaLabelText: 'توسيع المحتوى',
+    collapseAriaLabelText: 'أغلق المحتوى',
+    expandAriaLabelText: 'افتح المحتوى',
   },
 };
 

--- a/src/components/Accordion/Locale/ar_SA.tsx
+++ b/src/components/Accordion/Locale/ar_SA.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'ar_SA',
+    collapseAriaLabelText: 'طي المحتوى',
+    expandAriaLabelText: 'توسيع المحتوى',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/bg_BG.tsx
+++ b/src/components/Accordion/Locale/bg_BG.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'bg_BG',
-    collapseAriaLabelText: 'Close content',
-    expandAriaLabelText: 'Open content',
+    collapseAriaLabelText: 'Акордеон',
+    expandAriaLabelText: 'Акордеон',
   },
 };
 

--- a/src/components/Accordion/Locale/bg_BG.tsx
+++ b/src/components/Accordion/Locale/bg_BG.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'bg_BG',
-    collapseAriaLabelText: 'Свиване на съдържанието',
-    expandAriaLabelText: 'Разширяване на съдържанието',
+    collapseAriaLabelText: 'Close content',
+    expandAriaLabelText: 'Open content',
   },
 };
 

--- a/src/components/Accordion/Locale/bg_BG.tsx
+++ b/src/components/Accordion/Locale/bg_BG.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'bg_BG',
+    collapseAriaLabelText: 'Свиване на съдържанието',
+    expandAriaLabelText: 'Разширяване на съдържанието',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/cs_CZ.tsx
+++ b/src/components/Accordion/Locale/cs_CZ.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'cs_CZ',
+    collapseAriaLabelText: 'Sbalit obsah',
+    expandAriaLabelText: 'Rozbalit obsah',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/cs_CZ.tsx
+++ b/src/components/Accordion/Locale/cs_CZ.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'cs_CZ',
-    collapseAriaLabelText: 'Zavřít obsah',
-    expandAriaLabelText: 'Otevřít obsah',
+    collapseAriaLabelText: 'Akordeon',
+    expandAriaLabelText: 'Akordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/cs_CZ.tsx
+++ b/src/components/Accordion/Locale/cs_CZ.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'cs_CZ',
-    collapseAriaLabelText: 'Sbalit obsah',
-    expandAriaLabelText: 'Rozbalit obsah',
+    collapseAriaLabelText: 'Zavřít obsah',
+    expandAriaLabelText: 'Otevřít obsah',
   },
 };
 

--- a/src/components/Accordion/Locale/da_DK.tsx
+++ b/src/components/Accordion/Locale/da_DK.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'da_DK',
-    collapseAriaLabelText: 'Luk indhold',
-    expandAriaLabelText: 'Åbn indhold',
+    collapseAriaLabelText: 'Akkordeon',
+    expandAriaLabelText: 'Akkordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/da_DK.tsx
+++ b/src/components/Accordion/Locale/da_DK.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'da_DK',
+    collapseAriaLabelText: 'Skjul indhold',
+    expandAriaLabelText: 'Udvid indhold',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/da_DK.tsx
+++ b/src/components/Accordion/Locale/da_DK.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'da_DK',
-    collapseAriaLabelText: 'Skjul indhold',
-    expandAriaLabelText: 'Udvid indhold',
+    collapseAriaLabelText: 'Luk indhold',
+    expandAriaLabelText: 'Åbn indhold',
   },
 };
 

--- a/src/components/Accordion/Locale/de_DE.tsx
+++ b/src/components/Accordion/Locale/de_DE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'de_DE',
-    collapseAriaLabelText: 'Inhalt schließen',
-    expandAriaLabelText: 'Inhalt öffnen',
+    collapseAriaLabelText: 'Akkordeon',
+    expandAriaLabelText: 'Akkordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/de_DE.tsx
+++ b/src/components/Accordion/Locale/de_DE.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'de_DE',
+    collapseAriaLabelText: 'Inhalt einklappen',
+    expandAriaLabelText: 'Inhalt ausklappen',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/de_DE.tsx
+++ b/src/components/Accordion/Locale/de_DE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'de_DE',
-    collapseAriaLabelText: 'Inhalt einklappen',
-    expandAriaLabelText: 'Inhalt ausklappen',
+    collapseAriaLabelText: 'Inhalt schließen',
+    expandAriaLabelText: 'Inhalt öffnen',
   },
 };
 

--- a/src/components/Accordion/Locale/el_GR.tsx
+++ b/src/components/Accordion/Locale/el_GR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'el_GR',
-    collapseAriaLabelText: 'Κλείστε το περιεχόμενο',
-    expandAriaLabelText: 'Ανοίξτε το περιεχόμενο',
+    collapseAriaLabelText: 'Ακορντεόν',
+    expandAriaLabelText: 'Ακορντεόν',
   },
 };
 

--- a/src/components/Accordion/Locale/el_GR.tsx
+++ b/src/components/Accordion/Locale/el_GR.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'el_GR',
+    collapseAriaLabelText: 'Σύμπτυξη περιεχομένου',
+    expandAriaLabelText: 'Επέκταση περιεχομένου',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/el_GR.tsx
+++ b/src/components/Accordion/Locale/el_GR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'el_GR',
-    collapseAriaLabelText: 'Σύμπτυξη περιεχομένου',
-    expandAriaLabelText: 'Επέκταση περιεχομένου',
+    collapseAriaLabelText: 'Κλείστε το περιεχόμενο',
+    expandAriaLabelText: 'Ανοίξτε το περιεχόμενο',
   },
 };
 

--- a/src/components/Accordion/Locale/en_GB.tsx
+++ b/src/components/Accordion/Locale/en_GB.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'en_GB',
-    collapseAriaLabelText: 'Collapse content',
-    expandAriaLabelText: 'Expand content',
+    collapseAriaLabelText: 'Close content',
+    expandAriaLabelText: 'Open content',
   },
 };
 

--- a/src/components/Accordion/Locale/en_GB.tsx
+++ b/src/components/Accordion/Locale/en_GB.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'en_GB',
-    collapseAriaLabelText: 'Close content',
-    expandAriaLabelText: 'Open content',
+    collapseAriaLabelText: 'Accordion',
+    expandAriaLabelText: 'Accordion',
   },
 };
 

--- a/src/components/Accordion/Locale/en_GB.tsx
+++ b/src/components/Accordion/Locale/en_GB.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'en_GB',
+    collapseAriaLabelText: 'Collapse content',
+    expandAriaLabelText: 'Expand content',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/en_US.tsx
+++ b/src/components/Accordion/Locale/en_US.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'en_US',
+    collapseAriaLabelText: 'Collapse content',
+    expandAriaLabelText: 'Expand content',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/en_US.tsx
+++ b/src/components/Accordion/Locale/en_US.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'en_US',
-    collapseAriaLabelText: 'Close content',
-    expandAriaLabelText: 'Open content',
+    collapseAriaLabelText: 'Accordion',
+    expandAriaLabelText: 'Accordion',
   },
 };
 

--- a/src/components/Accordion/Locale/en_US.tsx
+++ b/src/components/Accordion/Locale/en_US.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'en_US',
-    collapseAriaLabelText: 'Collapse content',
-    expandAriaLabelText: 'Expand content',
+    collapseAriaLabelText: 'Close content',
+    expandAriaLabelText: 'Open content',
   },
 };
 

--- a/src/components/Accordion/Locale/es_DO.tsx
+++ b/src/components/Accordion/Locale/es_DO.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'es_DO',
-    collapseAriaLabelText: 'Cerrar contenido',
-    expandAriaLabelText: 'Abrir contenido',
+    collapseAriaLabelText: 'Acordeón',
+    expandAriaLabelText: 'Acordeón',
   },
 };
 

--- a/src/components/Accordion/Locale/es_DO.tsx
+++ b/src/components/Accordion/Locale/es_DO.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'es_DO',
-    collapseAriaLabelText: 'Contraer contenido',
-    expandAriaLabelText: 'Expandir contenido',
+    collapseAriaLabelText: 'Cerrar contenido',
+    expandAriaLabelText: 'Abrir contenido',
   },
 };
 

--- a/src/components/Accordion/Locale/es_DO.tsx
+++ b/src/components/Accordion/Locale/es_DO.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'es_DO',
+    collapseAriaLabelText: 'Contraer contenido',
+    expandAriaLabelText: 'Expandir contenido',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/es_ES.tsx
+++ b/src/components/Accordion/Locale/es_ES.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'es_ES',
-    collapseAriaLabelText: 'Cerrar contenido',
-    expandAriaLabelText: 'Abrir contenido',
+    collapseAriaLabelText: 'Acordeón',
+    expandAriaLabelText: 'Acordeón',
   },
 };
 

--- a/src/components/Accordion/Locale/es_ES.tsx
+++ b/src/components/Accordion/Locale/es_ES.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'es_ES',
-    collapseAriaLabelText: 'Contraer contenido',
-    expandAriaLabelText: 'Expandir contenido',
+    collapseAriaLabelText: 'Cerrar contenido',
+    expandAriaLabelText: 'Abrir contenido',
   },
 };
 

--- a/src/components/Accordion/Locale/es_ES.tsx
+++ b/src/components/Accordion/Locale/es_ES.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'es_ES',
+    collapseAriaLabelText: 'Contraer contenido',
+    expandAriaLabelText: 'Expandir contenido',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/es_MX.tsx
+++ b/src/components/Accordion/Locale/es_MX.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'es_MX',
-    collapseAriaLabelText: 'Contraer contenido',
-    expandAriaLabelText: 'Expandir contenido',
+    collapseAriaLabelText: 'Cerrar contenido',
+    expandAriaLabelText: 'Abrir contenido',
   },
 };
 

--- a/src/components/Accordion/Locale/es_MX.tsx
+++ b/src/components/Accordion/Locale/es_MX.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'es_MX',
+    collapseAriaLabelText: 'Contraer contenido',
+    expandAriaLabelText: 'Expandir contenido',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/es_MX.tsx
+++ b/src/components/Accordion/Locale/es_MX.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'es_MX',
-    collapseAriaLabelText: 'Cerrar contenido',
-    expandAriaLabelText: 'Abrir contenido',
+    collapseAriaLabelText: 'Acordeón',
+    expandAriaLabelText: 'Acordeón',
   },
 };
 

--- a/src/components/Accordion/Locale/fi_FI.tsx
+++ b/src/components/Accordion/Locale/fi_FI.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fi_FI',
-    collapseAriaLabelText: 'Sulje sisältö',
-    expandAriaLabelText: 'Avaa sisältö',
+    collapseAriaLabelText: 'Haitari',
+    expandAriaLabelText: 'Haitari',
   },
 };
 

--- a/src/components/Accordion/Locale/fi_FI.tsx
+++ b/src/components/Accordion/Locale/fi_FI.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fi_FI',
-    collapseAriaLabelText: 'Pienennä sisältö',
-    expandAriaLabelText: 'Laajenna sisältö',
+    collapseAriaLabelText: 'Sulje sisältö',
+    expandAriaLabelText: 'Avaa sisältö',
   },
 };
 

--- a/src/components/Accordion/Locale/fi_FI.tsx
+++ b/src/components/Accordion/Locale/fi_FI.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'fi_FI',
+    collapseAriaLabelText: 'Pienennä sisältö',
+    expandAriaLabelText: 'Laajenna sisältö',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/fr_BE.tsx
+++ b/src/components/Accordion/Locale/fr_BE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fr_BE',
-    collapseAriaLabelText: 'Fermer le contenu',
-    expandAriaLabelText: 'Ouvrir le contenu',
+    collapseAriaLabelText: 'Accordéon',
+    expandAriaLabelText: 'Accordéon',
   },
 };
 

--- a/src/components/Accordion/Locale/fr_BE.tsx
+++ b/src/components/Accordion/Locale/fr_BE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fr_BE',
-    collapseAriaLabelText: 'Réduire le contenu',
-    expandAriaLabelText: 'Développer le contenu',
+    collapseAriaLabelText: 'Fermer le contenu',
+    expandAriaLabelText: 'Ouvrir le contenu',
   },
 };
 

--- a/src/components/Accordion/Locale/fr_BE.tsx
+++ b/src/components/Accordion/Locale/fr_BE.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'fr_BE',
+    collapseAriaLabelText: 'Réduire le contenu',
+    expandAriaLabelText: 'Développer le contenu',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/fr_CA.tsx
+++ b/src/components/Accordion/Locale/fr_CA.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fr_CA',
-    collapseAriaLabelText: 'Fermer le contenu',
-    expandAriaLabelText: 'Ouvrir le contenu',
+    collapseAriaLabelText: 'Accordéon',
+    expandAriaLabelText: 'Accordéon',
   },
 };
 

--- a/src/components/Accordion/Locale/fr_CA.tsx
+++ b/src/components/Accordion/Locale/fr_CA.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fr_CA',
-    collapseAriaLabelText: 'Réduire le contenu',
-    expandAriaLabelText: 'Étendre le contenu',
+    collapseAriaLabelText: 'Fermer le contenu',
+    expandAriaLabelText: 'Ouvrir le contenu',
   },
 };
 

--- a/src/components/Accordion/Locale/fr_CA.tsx
+++ b/src/components/Accordion/Locale/fr_CA.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'fr_CA',
+    collapseAriaLabelText: 'Réduire le contenu',
+    expandAriaLabelText: 'Étendre le contenu',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/fr_FR.tsx
+++ b/src/components/Accordion/Locale/fr_FR.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'fr_FR',
+    collapseAriaLabelText: 'Réduire le contenu',
+    expandAriaLabelText: 'Étendre le contenu',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/fr_FR.tsx
+++ b/src/components/Accordion/Locale/fr_FR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fr_FR',
-    collapseAriaLabelText: 'Réduire le contenu',
-    expandAriaLabelText: 'Étendre le contenu',
+    collapseAriaLabelText: 'Fermer le contenu',
+    expandAriaLabelText: 'Ouvrir le contenu',
   },
 };
 

--- a/src/components/Accordion/Locale/fr_FR.tsx
+++ b/src/components/Accordion/Locale/fr_FR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'fr_FR',
-    collapseAriaLabelText: 'Fermer le contenu',
-    expandAriaLabelText: 'Ouvrir le contenu',
+    collapseAriaLabelText: 'Accordéon',
+    expandAriaLabelText: 'Accordéon',
   },
 };
 

--- a/src/components/Accordion/Locale/he_IL.tsx
+++ b/src/components/Accordion/Locale/he_IL.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'he_IL',
+    collapseAriaLabelText: 'כווץ תוכן',
+    expandAriaLabelText: 'הרחב תוכן',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/he_IL.tsx
+++ b/src/components/Accordion/Locale/he_IL.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'he_IL',
-    collapseAriaLabelText: 'כווץ תוכן',
-    expandAriaLabelText: 'הרחב תוכן',
+    collapseAriaLabelText: 'סגור תוכן',
+    expandAriaLabelText: 'פתח תוכן',
   },
 };
 

--- a/src/components/Accordion/Locale/he_IL.tsx
+++ b/src/components/Accordion/Locale/he_IL.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'he_IL',
-    collapseAriaLabelText: 'סגור תוכן',
-    expandAriaLabelText: 'פתח תוכן',
+    collapseAriaLabelText: 'אקורדיון',
+    expandAriaLabelText: 'אקורדיון',
   },
 };
 

--- a/src/components/Accordion/Locale/hi_IN.tsx
+++ b/src/components/Accordion/Locale/hi_IN.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'hi_IN',
-    collapseAriaLabelText: 'सामग्री बंद करें',
-    expandAriaLabelText: 'सामग्री खोलें',
+    collapseAriaLabelText: 'अकॉर्डियन',
+    expandAriaLabelText: 'अकॉर्डियन',
   },
 };
 

--- a/src/components/Accordion/Locale/hi_IN.tsx
+++ b/src/components/Accordion/Locale/hi_IN.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'hi_IN',
+    collapseAriaLabelText: 'सामग्री संकुचित करें',
+    expandAriaLabelText: 'सामग्री विस्तारित करें',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/hi_IN.tsx
+++ b/src/components/Accordion/Locale/hi_IN.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'hi_IN',
-    collapseAriaLabelText: 'सामग्री संकुचित करें',
-    expandAriaLabelText: 'सामग्री विस्तारित करें',
+    collapseAriaLabelText: 'सामग्री बंद करें',
+    expandAriaLabelText: 'सामग्री खोलें',
   },
 };
 

--- a/src/components/Accordion/Locale/hr_HR.tsx
+++ b/src/components/Accordion/Locale/hr_HR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'hr_HR',
-    collapseAriaLabelText: 'Zatvori sadržaj',
-    expandAriaLabelText: 'Otvori sadržaj',
+    collapseAriaLabelText: 'Harmonika',
+    expandAriaLabelText: 'Harmonika',
   },
 };
 

--- a/src/components/Accordion/Locale/hr_HR.tsx
+++ b/src/components/Accordion/Locale/hr_HR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'hr_HR',
-    collapseAriaLabelText: 'Smanji sadržaj',
-    expandAriaLabelText: 'Proširi sadržaj',
+    collapseAriaLabelText: 'Zatvori sadržaj',
+    expandAriaLabelText: 'Otvori sadržaj',
   },
 };
 

--- a/src/components/Accordion/Locale/hr_HR.tsx
+++ b/src/components/Accordion/Locale/hr_HR.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'hr_HR',
+    collapseAriaLabelText: 'Smanji sadržaj',
+    expandAriaLabelText: 'Proširi sadržaj',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ht_HT.tsx
+++ b/src/components/Accordion/Locale/ht_HT.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ht_HT',
-    collapseAriaLabelText: 'Fèmen kontni',
-    expandAriaLabelText: 'Louvri kontni',
+    collapseAriaLabelText: 'Akòdeyon',
+    expandAriaLabelText: 'Akòdeyon',
   },
 };
 

--- a/src/components/Accordion/Locale/ht_HT.tsx
+++ b/src/components/Accordion/Locale/ht_HT.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'ht_HT',
+    collapseAriaLabelText: 'Redwi kontni',
+    expandAriaLabelText: 'Elaji kontni',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ht_HT.tsx
+++ b/src/components/Accordion/Locale/ht_HT.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ht_HT',
-    collapseAriaLabelText: 'Redwi kontni',
-    expandAriaLabelText: 'Elaji kontni',
+    collapseAriaLabelText: 'Fèmen kontni',
+    expandAriaLabelText: 'Louvri kontni',
   },
 };
 

--- a/src/components/Accordion/Locale/hu_HU.tsx
+++ b/src/components/Accordion/Locale/hu_HU.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'hu_HU',
-    collapseAriaLabelText: 'Tartalom összecsukása',
-    expandAriaLabelText: 'Tartalom kibontása',
+    collapseAriaLabelText: 'Tartalom bezárása',
+    expandAriaLabelText: 'Tartalom megnyitása',
   },
 };
 

--- a/src/components/Accordion/Locale/hu_HU.tsx
+++ b/src/components/Accordion/Locale/hu_HU.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'hu_HU',
-    collapseAriaLabelText: 'Tartalom bezárása',
-    expandAriaLabelText: 'Tartalom megnyitása',
+    collapseAriaLabelText: 'Harmonika',
+    expandAriaLabelText: 'Harmonika',
   },
 };
 

--- a/src/components/Accordion/Locale/hu_HU.tsx
+++ b/src/components/Accordion/Locale/hu_HU.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'hu_HU',
+    collapseAriaLabelText: 'Tartalom összecsukása',
+    expandAriaLabelText: 'Tartalom kibontása',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/it_IT.tsx
+++ b/src/components/Accordion/Locale/it_IT.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'it_IT',
-    collapseAriaLabelText: 'Chiudi contenuto',
-    expandAriaLabelText: 'Apri contenuto',
+    collapseAriaLabelText: 'Fisarmonica',
+    expandAriaLabelText: 'Fisarmonica',
   },
 };
 

--- a/src/components/Accordion/Locale/it_IT.tsx
+++ b/src/components/Accordion/Locale/it_IT.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'it_IT',
-    collapseAriaLabelText: 'Comprimi contenuto',
-    expandAriaLabelText: 'Espandi contenuto',
+    collapseAriaLabelText: 'Chiudi contenuto',
+    expandAriaLabelText: 'Apri contenuto',
   },
 };
 

--- a/src/components/Accordion/Locale/it_IT.tsx
+++ b/src/components/Accordion/Locale/it_IT.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'it_IT',
+    collapseAriaLabelText: 'Comprimi contenuto',
+    expandAriaLabelText: 'Espandi contenuto',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ja_JP.tsx
+++ b/src/components/Accordion/Locale/ja_JP.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ja_JP',
-    collapseAriaLabelText: 'コンテンツを閉じる',
-    expandAriaLabelText: 'コンテンツを開く',
+    collapseAriaLabelText: 'アコーディオン',
+    expandAriaLabelText: 'アコーディオン',
   },
 };
 

--- a/src/components/Accordion/Locale/ja_JP.tsx
+++ b/src/components/Accordion/Locale/ja_JP.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'ja_JP',
+    collapseAriaLabelText: 'コンテンツを折りたたむ',
+    expandAriaLabelText: 'コンテンツを展開する',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ja_JP.tsx
+++ b/src/components/Accordion/Locale/ja_JP.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ja_JP',
-    collapseAriaLabelText: 'コンテンツを折りたたむ',
-    expandAriaLabelText: 'コンテンツを展開する',
+    collapseAriaLabelText: 'コンテンツを閉じる',
+    expandAriaLabelText: 'コンテンツを開く',
   },
 };
 

--- a/src/components/Accordion/Locale/ko_KR.tsx
+++ b/src/components/Accordion/Locale/ko_KR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ko_KR',
-    collapseAriaLabelText: '내용 닫기',
-    expandAriaLabelText: '내용 열기',
+    collapseAriaLabelText: '아코디언',
+    expandAriaLabelText: '아코디언',
   },
 };
 

--- a/src/components/Accordion/Locale/ko_KR.tsx
+++ b/src/components/Accordion/Locale/ko_KR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ko_KR',
-    collapseAriaLabelText: '내용 축소',
-    expandAriaLabelText: '내용 확장',
+    collapseAriaLabelText: '내용 닫기',
+    expandAriaLabelText: '내용 열기',
   },
 };
 

--- a/src/components/Accordion/Locale/ko_KR.tsx
+++ b/src/components/Accordion/Locale/ko_KR.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'ko_KR',
+    collapseAriaLabelText: '내용 축소',
+    expandAriaLabelText: '내용 확장',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ms_MY.tsx
+++ b/src/components/Accordion/Locale/ms_MY.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ms_MY',
-    collapseAriaLabelText: 'Tutup kandungan',
-    expandAriaLabelText: 'Buka kandungan',
+    collapseAriaLabelText: 'Akordeon',
+    expandAriaLabelText: 'Akordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/ms_MY.tsx
+++ b/src/components/Accordion/Locale/ms_MY.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'ms_MY',
+    collapseAriaLabelText: 'Runtuhkan kandungan',
+    expandAriaLabelText: 'Kembangkan kandungan',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ms_MY.tsx
+++ b/src/components/Accordion/Locale/ms_MY.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ms_MY',
-    collapseAriaLabelText: 'Runtuhkan kandungan',
-    expandAriaLabelText: 'Kembangkan kandungan',
+    collapseAriaLabelText: 'Tutup kandungan',
+    expandAriaLabelText: 'Buka kandungan',
   },
 };
 

--- a/src/components/Accordion/Locale/nb_NO.tsx
+++ b/src/components/Accordion/Locale/nb_NO.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'nb_NO',
+    collapseAriaLabelText: 'Skjul innhold',
+    expandAriaLabelText: 'Utvid innhold',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/nb_NO.tsx
+++ b/src/components/Accordion/Locale/nb_NO.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'nb_NO',
-    collapseAriaLabelText: 'Lukk innhold',
-    expandAriaLabelText: 'Åpne innhold',
+    collapseAriaLabelText: 'Trekkspill',
+    expandAriaLabelText: 'Trekkspill',
   },
 };
 

--- a/src/components/Accordion/Locale/nb_NO.tsx
+++ b/src/components/Accordion/Locale/nb_NO.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'nb_NO',
-    collapseAriaLabelText: 'Skjul innhold',
-    expandAriaLabelText: 'Utvid innhold',
+    collapseAriaLabelText: 'Lukk innhold',
+    expandAriaLabelText: 'Åpne innhold',
   },
 };
 

--- a/src/components/Accordion/Locale/nl_BE.tsx
+++ b/src/components/Accordion/Locale/nl_BE.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'nl_BE',
+    collapseAriaLabelText: 'Inhoud inklappen',
+    expandAriaLabelText: 'Inhoud uitklappen',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/nl_BE.tsx
+++ b/src/components/Accordion/Locale/nl_BE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'nl_BE',
-    collapseAriaLabelText: 'Inhoud sluiten',
-    expandAriaLabelText: 'Inhoud openen',
+    collapseAriaLabelText: 'Accordeon',
+    expandAriaLabelText: 'Accordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/nl_BE.tsx
+++ b/src/components/Accordion/Locale/nl_BE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'nl_BE',
-    collapseAriaLabelText: 'Inhoud inklappen',
-    expandAriaLabelText: 'Inhoud uitklappen',
+    collapseAriaLabelText: 'Inhoud sluiten',
+    expandAriaLabelText: 'Inhoud openen',
   },
 };
 

--- a/src/components/Accordion/Locale/nl_NL.tsx
+++ b/src/components/Accordion/Locale/nl_NL.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'nl_NL',
-    collapseAriaLabelText: 'Inhoud inklappen',
-    expandAriaLabelText: 'Inhoud uitklappen',
+    collapseAriaLabelText: 'Inhoud sluiten',
+    expandAriaLabelText: 'Inhoud openen',
   },
 };
 

--- a/src/components/Accordion/Locale/nl_NL.tsx
+++ b/src/components/Accordion/Locale/nl_NL.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'nl_NL',
+    collapseAriaLabelText: 'Inhoud inklappen',
+    expandAriaLabelText: 'Inhoud uitklappen',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/nl_NL.tsx
+++ b/src/components/Accordion/Locale/nl_NL.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'nl_NL',
-    collapseAriaLabelText: 'Inhoud sluiten',
-    expandAriaLabelText: 'Inhoud openen',
+    collapseAriaLabelText: 'Accordeon',
+    expandAriaLabelText: 'Accordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/pl_PL.tsx
+++ b/src/components/Accordion/Locale/pl_PL.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'pl_PL',
-    collapseAriaLabelText: 'Zamknij zawartość',
-    expandAriaLabelText: 'Otwórz zawartość',
+    collapseAriaLabelText: 'Akordeon',
+    expandAriaLabelText: 'Akordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/pl_PL.tsx
+++ b/src/components/Accordion/Locale/pl_PL.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'pl_PL',
-    collapseAriaLabelText: 'Zwiń zawartość',
-    expandAriaLabelText: 'Rozwiń zawartość',
+    collapseAriaLabelText: 'Zamknij zawartość',
+    expandAriaLabelText: 'Otwórz zawartość',
   },
 };
 

--- a/src/components/Accordion/Locale/pl_PL.tsx
+++ b/src/components/Accordion/Locale/pl_PL.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'pl_PL',
+    collapseAriaLabelText: 'Zwiń zawartość',
+    expandAriaLabelText: 'Rozwiń zawartość',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/pt_BR.tsx
+++ b/src/components/Accordion/Locale/pt_BR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'pt_BR',
-    collapseAriaLabelText: 'Recolher conteúdo',
-    expandAriaLabelText: 'Expandir conteúdo',
+    collapseAriaLabelText: 'Fechar conteúdo',
+    expandAriaLabelText: 'Abrir conteúdo',
   },
 };
 

--- a/src/components/Accordion/Locale/pt_BR.tsx
+++ b/src/components/Accordion/Locale/pt_BR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'pt_BR',
-    collapseAriaLabelText: 'Fechar conteúdo',
-    expandAriaLabelText: 'Abrir conteúdo',
+    collapseAriaLabelText: 'Acordeão',
+    expandAriaLabelText: 'Acordeão',
   },
 };
 

--- a/src/components/Accordion/Locale/pt_BR.tsx
+++ b/src/components/Accordion/Locale/pt_BR.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'pt_BR',
+    collapseAriaLabelText: 'Recolher conteúdo',
+    expandAriaLabelText: 'Expandir conteúdo',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/pt_PT.tsx
+++ b/src/components/Accordion/Locale/pt_PT.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'pt_PT',
-    collapseAriaLabelText: 'Recolher conteúdo',
-    expandAriaLabelText: 'Expandir conteúdo',
+    collapseAriaLabelText: 'Fechar conteúdo',
+    expandAriaLabelText: 'Abrir conteúdo',
   },
 };
 

--- a/src/components/Accordion/Locale/pt_PT.tsx
+++ b/src/components/Accordion/Locale/pt_PT.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'pt_PT',
+    collapseAriaLabelText: 'Recolher conteúdo',
+    expandAriaLabelText: 'Expandir conteúdo',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/pt_PT.tsx
+++ b/src/components/Accordion/Locale/pt_PT.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'pt_PT',
-    collapseAriaLabelText: 'Fechar conteúdo',
-    expandAriaLabelText: 'Abrir conteúdo',
+    collapseAriaLabelText: 'Acordeão',
+    expandAriaLabelText: 'Acordeão',
   },
 };
 

--- a/src/components/Accordion/Locale/ro_RO.tsx
+++ b/src/components/Accordion/Locale/ro_RO.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ro_RO',
-    collapseAriaLabelText: 'Închide conținutul',
-    expandAriaLabelText: 'Deschide conținutul',
+    collapseAriaLabelText: 'Acordeon',
+    expandAriaLabelText: 'Acordeon',
   },
 };
 

--- a/src/components/Accordion/Locale/ro_RO.tsx
+++ b/src/components/Accordion/Locale/ro_RO.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'ro_RO',
+    collapseAriaLabelText: 'Restrânge conținutul',
+    expandAriaLabelText: 'Extinde conținutul',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ro_RO.tsx
+++ b/src/components/Accordion/Locale/ro_RO.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ro_RO',
-    collapseAriaLabelText: 'Restrânge conținutul',
-    expandAriaLabelText: 'Extinde conținutul',
+    collapseAriaLabelText: 'Închide conținutul',
+    expandAriaLabelText: 'Deschide conținutul',
   },
 };
 

--- a/src/components/Accordion/Locale/ru_RU.tsx
+++ b/src/components/Accordion/Locale/ru_RU.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'ru_RU',
+    collapseAriaLabelText: 'Свернуть содержимое',
+    expandAriaLabelText: 'Развернуть содержимое',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/ru_RU.tsx
+++ b/src/components/Accordion/Locale/ru_RU.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ru_RU',
-    collapseAriaLabelText: 'Свернуть содержимое',
-    expandAriaLabelText: 'Развернуть содержимое',
+    collapseAriaLabelText: 'Закрыть содержимое',
+    expandAriaLabelText: 'Открыть содержимое',
   },
 };
 

--- a/src/components/Accordion/Locale/ru_RU.tsx
+++ b/src/components/Accordion/Locale/ru_RU.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'ru_RU',
-    collapseAriaLabelText: 'Закрыть содержимое',
-    expandAriaLabelText: 'Открыть содержимое',
+    collapseAriaLabelText: 'Аккордеон',
+    expandAriaLabelText: 'Аккордеон',
   },
 };
 

--- a/src/components/Accordion/Locale/sk_SK.tsx
+++ b/src/components/Accordion/Locale/sk_SK.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'sk_SK',
-    collapseAriaLabelText: 'Zbaliť obsah',
-    expandAriaLabelText: 'Rozbaliť obsah',
+    collapseAriaLabelText: 'Zatvoriť obsah',
+    expandAriaLabelText: 'Otvoriť obsah',
   },
 };
 

--- a/src/components/Accordion/Locale/sk_SK.tsx
+++ b/src/components/Accordion/Locale/sk_SK.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'sk_SK',
-    collapseAriaLabelText: 'Zatvoriť obsah',
-    expandAriaLabelText: 'Otvoriť obsah',
+    collapseAriaLabelText: 'Akordeón',
+    expandAriaLabelText: 'Akordeón',
   },
 };
 

--- a/src/components/Accordion/Locale/sk_SK.tsx
+++ b/src/components/Accordion/Locale/sk_SK.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'sk_SK',
+    collapseAriaLabelText: 'Zbaliť obsah',
+    expandAriaLabelText: 'Rozbaliť obsah',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/sr_RS.tsx
+++ b/src/components/Accordion/Locale/sr_RS.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'sr_RS',
+    collapseAriaLabelText: 'Скупи садржај',
+    expandAriaLabelText: 'Прошири садржај',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/sr_RS.tsx
+++ b/src/components/Accordion/Locale/sr_RS.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'sr_RS',
-    collapseAriaLabelText: 'Скупи садржај',
-    expandAriaLabelText: 'Прошири садржај',
+    collapseAriaLabelText: 'Zatvori sadržaj',
+    expandAriaLabelText: 'Otvori sadržaj',
   },
 };
 

--- a/src/components/Accordion/Locale/sr_RS.tsx
+++ b/src/components/Accordion/Locale/sr_RS.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'sr_RS',
-    collapseAriaLabelText: 'Zatvori sadržaj',
-    expandAriaLabelText: 'Otvori sadržaj',
+    collapseAriaLabelText: 'Harmonika',
+    expandAriaLabelText: 'Harmonika',
   },
 };
 

--- a/src/components/Accordion/Locale/sv_SE.tsx
+++ b/src/components/Accordion/Locale/sv_SE.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'sv_SE',
+    collapseAriaLabelText: 'Fäll ihop innehåll',
+    expandAriaLabelText: 'Expandera innehåll',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/sv_SE.tsx
+++ b/src/components/Accordion/Locale/sv_SE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'sv_SE',
-    collapseAriaLabelText: 'Fäll ihop innehåll',
-    expandAriaLabelText: 'Expandera innehåll',
+    collapseAriaLabelText: 'Stäng innehåll',
+    expandAriaLabelText: 'Öppna innehåll',
   },
 };
 

--- a/src/components/Accordion/Locale/sv_SE.tsx
+++ b/src/components/Accordion/Locale/sv_SE.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'sv_SE',
-    collapseAriaLabelText: 'Stäng innehåll',
-    expandAriaLabelText: 'Öppna innehåll',
+    collapseAriaLabelText: 'Dragspel',
+    expandAriaLabelText: 'Dragspel',
   },
 };
 

--- a/src/components/Accordion/Locale/te_IN.tsx
+++ b/src/components/Accordion/Locale/te_IN.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'te_IN',
-    collapseAriaLabelText: 'కంటెంట్ మూసివేయండి',
-    expandAriaLabelText: 'కంటెంట్ తెరవండి',
+    collapseAriaLabelText: 'అకార్డియన్',
+    expandAriaLabelText: 'అకార్డియన్',
   },
 };
 

--- a/src/components/Accordion/Locale/te_IN.tsx
+++ b/src/components/Accordion/Locale/te_IN.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'te_IN',
-    collapseAriaLabelText: 'కంటెంట్ కుదించు',
-    expandAriaLabelText: 'కంటెంట్ విస్తరించు',
+    collapseAriaLabelText: 'కంటెంట్ మూసివేయండి',
+    expandAriaLabelText: 'కంటెంట్ తెరవండి',
   },
 };
 

--- a/src/components/Accordion/Locale/te_IN.tsx
+++ b/src/components/Accordion/Locale/te_IN.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'te_IN',
+    collapseAriaLabelText: 'కంటెంట్ కుదించు',
+    expandAriaLabelText: 'కంటెంట్ విస్తరించు',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/th_TH.tsx
+++ b/src/components/Accordion/Locale/th_TH.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'th_TH',
-    collapseAriaLabelText: 'ย่อเนื้อหา',
-    expandAriaLabelText: 'ขยายเนื้อหา',
+    collapseAriaLabelText: 'ปิดเนื้อหา',
+    expandAriaLabelText: 'เปิดเนื้อหา',
   },
 };
 

--- a/src/components/Accordion/Locale/th_TH.tsx
+++ b/src/components/Accordion/Locale/th_TH.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'th_TH',
+    collapseAriaLabelText: 'ย่อเนื้อหา',
+    expandAriaLabelText: 'ขยายเนื้อหา',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/th_TH.tsx
+++ b/src/components/Accordion/Locale/th_TH.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'th_TH',
-    collapseAriaLabelText: 'ปิดเนื้อหา',
-    expandAriaLabelText: 'เปิดเนื้อหา',
+    collapseAriaLabelText: 'แอคคอร์เดียน',
+    expandAriaLabelText: 'แอคคอร์เดียน',
   },
 };
 

--- a/src/components/Accordion/Locale/tr_TR.tsx
+++ b/src/components/Accordion/Locale/tr_TR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'tr_TR',
-    collapseAriaLabelText: 'İçeriği daralt',
-    expandAriaLabelText: 'İçeriği genişlet',
+    collapseAriaLabelText: 'İçeriği kapat',
+    expandAriaLabelText: 'İçeriği aç',
   },
 };
 

--- a/src/components/Accordion/Locale/tr_TR.tsx
+++ b/src/components/Accordion/Locale/tr_TR.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'tr_TR',
+    collapseAriaLabelText: 'İçeriği daralt',
+    expandAriaLabelText: 'İçeriği genişlet',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/tr_TR.tsx
+++ b/src/components/Accordion/Locale/tr_TR.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'tr_TR',
-    collapseAriaLabelText: 'İçeriği kapat',
-    expandAriaLabelText: 'İçeriği aç',
+    collapseAriaLabelText: 'Akordiyon',
+    expandAriaLabelText: 'Akordiyon',
   },
 };
 

--- a/src/components/Accordion/Locale/uk_UA.tsx
+++ b/src/components/Accordion/Locale/uk_UA.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'uk_UA',
-    collapseAriaLabelText: 'Згорнути вміст',
-    expandAriaLabelText: 'Розгорнути вміст',
+    collapseAriaLabelText: 'Закрити вміст',
+    expandAriaLabelText: 'Відкрити вміст',
   },
 };
 

--- a/src/components/Accordion/Locale/uk_UA.tsx
+++ b/src/components/Accordion/Locale/uk_UA.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'uk_UA',
+    collapseAriaLabelText: 'Згорнути вміст',
+    expandAriaLabelText: 'Розгорнути вміст',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/uk_UA.tsx
+++ b/src/components/Accordion/Locale/uk_UA.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'uk_UA',
-    collapseAriaLabelText: 'Закрити вміст',
-    expandAriaLabelText: 'Відкрити вміст',
+    collapseAriaLabelText: 'Акордеон',
+    expandAriaLabelText: 'Акордеон',
   },
 };
 

--- a/src/components/Accordion/Locale/vi_VN.tsx
+++ b/src/components/Accordion/Locale/vi_VN.tsx
@@ -1,10 +1,13 @@
 import type { AccordionLocale } from '../Accordion.types';
 
+/**
+ * Please note that 'Accordion' does not have a direct translation in Vietnamese and is commonly used as is.
+ */
 const locale: AccordionLocale = {
   lang: {
     locale: 'vi_VN',
-    collapseAriaLabelText: 'Đóng nội dung',
-    expandAriaLabelText: 'Mở nội dung',
+    collapseAriaLabelText: 'Accordion',
+    expandAriaLabelText: 'Accordion',
   },
 };
 

--- a/src/components/Accordion/Locale/vi_VN.tsx
+++ b/src/components/Accordion/Locale/vi_VN.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'vi_VN',
-    collapseAriaLabelText: 'Thu gọn nội dung',
-    expandAriaLabelText: 'Mở rộng nội dung',
+    collapseAriaLabelText: 'Đóng nội dung',
+    expandAriaLabelText: 'Mở nội dung',
   },
 };
 

--- a/src/components/Accordion/Locale/vi_VN.tsx
+++ b/src/components/Accordion/Locale/vi_VN.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'vi_VN',
+    collapseAriaLabelText: 'Thu gọn nội dung',
+    expandAriaLabelText: 'Mở rộng nội dung',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/zh_CN.tsx
+++ b/src/components/Accordion/Locale/zh_CN.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'zh_CN',
-    collapseAriaLabelText: '关闭内容',
-    expandAriaLabelText: '打开内容',
+    collapseAriaLabelText: '手风琴',
+    expandAriaLabelText: '手风琴',
   },
 };
 

--- a/src/components/Accordion/Locale/zh_CN.tsx
+++ b/src/components/Accordion/Locale/zh_CN.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'zh_CN',
+    collapseAriaLabelText: '折叠内容',
+    expandAriaLabelText: '展开内容',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/zh_CN.tsx
+++ b/src/components/Accordion/Locale/zh_CN.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'zh_CN',
-    collapseAriaLabelText: '折叠内容',
-    expandAriaLabelText: '展开内容',
+    collapseAriaLabelText: '关闭内容',
+    expandAriaLabelText: '打开内容',
   },
 };
 

--- a/src/components/Accordion/Locale/zh_TW.tsx
+++ b/src/components/Accordion/Locale/zh_TW.tsx
@@ -1,0 +1,11 @@
+import type { AccordionLocale } from '../Accordion.types';
+
+const locale: AccordionLocale = {
+  lang: {
+    locale: 'zh_TW',
+    collapseAriaLabelText: '摺疊內容',
+    expandAriaLabelText: '展開內容',
+  },
+};
+
+export default locale;

--- a/src/components/Accordion/Locale/zh_TW.tsx
+++ b/src/components/Accordion/Locale/zh_TW.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'zh_TW',
-    collapseAriaLabelText: '關閉內容',
-    expandAriaLabelText: '開啟內容',
+    collapseAriaLabelText: '手風琴',
+    expandAriaLabelText: '手風琴',
   },
 };
 

--- a/src/components/Accordion/Locale/zh_TW.tsx
+++ b/src/components/Accordion/Locale/zh_TW.tsx
@@ -3,8 +3,8 @@ import type { AccordionLocale } from '../Accordion.types';
 const locale: AccordionLocale = {
   lang: {
     locale: 'zh_TW',
-    collapseAriaLabelText: '摺疊內容',
-    expandAriaLabelText: '展開內容',
+    collapseAriaLabelText: '關閉內容',
+    expandAriaLabelText: '開啟內容',
   },
 };
 

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Accordion Accordion is large 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -54,7 +54,7 @@ exports[`Accordion Accordion is large 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -108,7 +108,7 @@ exports[`Accordion Accordion is medium 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -149,7 +149,7 @@ exports[`Accordion Accordion is medium 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -203,7 +203,7 @@ exports[`Accordion Accordion is not bordered 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -244,7 +244,7 @@ exports[`Accordion Accordion is not bordered 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -298,7 +298,7 @@ exports[`Accordion Accordion is pill shaped 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -339,7 +339,7 @@ exports[`Accordion Accordion is pill shaped 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -393,7 +393,7 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -434,7 +434,7 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -489,7 +489,7 @@ exports[`Accordion Accordion renders custom content and its buttons are clickabl
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="true"
-        aria-label="Open content"
+        aria-label="Accordion"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -624,7 +624,7 @@ exports[`Accordion Accordion renders custom content and its buttons are clickabl
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="true"
-        aria-label="Open content"
+        aria-label="Accordion"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -678,7 +678,7 @@ exports[`Accordion Renders without crashing 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -719,7 +719,7 @@ exports[`Accordion Renders without crashing 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Close content"
+        aria-label="Accordion"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -7,13 +7,17 @@ exports[`Accordion Accordion is large 1`] = `
     data-testid="test-accordion"
   >
     <div
-      aria-controls="myAccordionId-content"
-      aria-expanded="false"
       class="accordion-summary large"
       id="myAccordionId-header"
-      role="button"
-      tabindex="0"
     >
+      <div
+        aria-controls="myAccordionId-content"
+        aria-expanded="false"
+        aria-label="Expand content"
+        class="clickable-area"
+        role="button"
+        tabindex="0"
+      />
       <div
         class="accordion-header-container"
       >
@@ -33,11 +37,13 @@ exports[`Accordion Accordion is large 1`] = `
             />
           </svg>
         </span>
-        <span
+        <div
           class="accordion-header"
         >
-          Accordion Header
-        </span>
+          <span>
+            Accordion Header
+          </span>
+        </div>
         <span
           class="badge badge-medium badge"
         >
@@ -45,7 +51,10 @@ exports[`Accordion Accordion is large 1`] = `
         </span>
       </div>
       <button
+        aria-controls="myAccordionId-content"
         aria-disabled="false"
+        aria-expanded="false"
+        aria-label="Expand content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -93,13 +102,17 @@ exports[`Accordion Accordion is medium 1`] = `
     data-testid="test-accordion"
   >
     <div
-      aria-controls="myAccordionId-content"
-      aria-expanded="false"
       class="accordion-summary medium"
       id="myAccordionId-header"
-      role="button"
-      tabindex="0"
     >
+      <div
+        aria-controls="myAccordionId-content"
+        aria-expanded="false"
+        aria-label="Expand content"
+        class="clickable-area"
+        role="button"
+        tabindex="0"
+      />
       <div
         class="accordion-header-container"
       >
@@ -119,11 +132,13 @@ exports[`Accordion Accordion is medium 1`] = `
             />
           </svg>
         </span>
-        <span
+        <div
           class="accordion-header"
         >
-          Accordion Header
-        </span>
+          <span>
+            Accordion Header
+          </span>
+        </div>
         <span
           class="badge badge-medium badge"
         >
@@ -131,7 +146,10 @@ exports[`Accordion Accordion is medium 1`] = `
         </span>
       </div>
       <button
+        aria-controls="myAccordionId-content"
         aria-disabled="false"
+        aria-expanded="false"
+        aria-label="Expand content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -179,13 +197,17 @@ exports[`Accordion Accordion is not bordered 1`] = `
     data-testid="test-accordion"
   >
     <div
-      aria-controls="myAccordionId-content"
-      aria-expanded="false"
       class="accordion-summary large"
       id="myAccordionId-header"
-      role="button"
-      tabindex="0"
     >
+      <div
+        aria-controls="myAccordionId-content"
+        aria-expanded="false"
+        aria-label="Expand content"
+        class="clickable-area"
+        role="button"
+        tabindex="0"
+      />
       <div
         class="accordion-header-container"
       >
@@ -205,11 +227,13 @@ exports[`Accordion Accordion is not bordered 1`] = `
             />
           </svg>
         </span>
-        <span
+        <div
           class="accordion-header"
         >
-          Accordion Header
-        </span>
+          <span>
+            Accordion Header
+          </span>
+        </div>
         <span
           class="badge badge-medium badge"
         >
@@ -217,7 +241,10 @@ exports[`Accordion Accordion is not bordered 1`] = `
         </span>
       </div>
       <button
+        aria-controls="myAccordionId-content"
         aria-disabled="false"
+        aria-expanded="false"
+        aria-label="Expand content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -265,13 +292,17 @@ exports[`Accordion Accordion is pill shaped 1`] = `
     data-testid="test-accordion"
   >
     <div
-      aria-controls="myAccordionId-content"
-      aria-expanded="false"
       class="accordion-summary large"
       id="myAccordionId-header"
-      role="button"
-      tabindex="0"
     >
+      <div
+        aria-controls="myAccordionId-content"
+        aria-expanded="false"
+        aria-label="Expand content"
+        class="clickable-area"
+        role="button"
+        tabindex="0"
+      />
       <div
         class="accordion-header-container"
       >
@@ -291,11 +322,13 @@ exports[`Accordion Accordion is pill shaped 1`] = `
             />
           </svg>
         </span>
-        <span
+        <div
           class="accordion-header"
         >
-          Accordion Header
-        </span>
+          <span>
+            Accordion Header
+          </span>
+        </div>
         <span
           class="badge badge-medium badge"
         >
@@ -303,7 +336,10 @@ exports[`Accordion Accordion is pill shaped 1`] = `
         </span>
       </div>
       <button
+        aria-controls="myAccordionId-content"
         aria-disabled="false"
+        aria-expanded="false"
+        aria-label="Expand content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -351,13 +387,17 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
     data-testid="test-accordion"
   >
     <div
-      aria-controls="myAccordionId-content"
-      aria-expanded="false"
       class="accordion-summary large"
       id="myAccordionId-header"
-      role="button"
-      tabindex="0"
     >
+      <div
+        aria-controls="myAccordionId-content"
+        aria-expanded="false"
+        aria-label="Expand content"
+        class="clickable-area"
+        role="button"
+        tabindex="0"
+      />
       <div
         class="accordion-header-container"
       >
@@ -377,11 +417,13 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
             />
           </svg>
         </span>
-        <span
+        <div
           class="accordion-header"
         >
-          Accordion Header
-        </span>
+          <span>
+            Accordion Header
+          </span>
+        </div>
         <span
           class="badge badge-medium badge"
         >
@@ -389,7 +431,10 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
         </span>
       </div>
       <button
+        aria-controls="myAccordionId-content"
         aria-disabled="false"
+        aria-expanded="false"
+        aria-label="Expand content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -430,21 +475,25 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
 </div>
 `;
 
-exports[`Accordion Accordion renders custom content 1`] = `
+exports[`Accordion Accordion renders custom content and its buttons are clickable 1`] = `
 <div>
   <div
     class="accordion-container accordion-border pill"
     data-testid="test-accordion"
   >
     <div
-      aria-controls="myAccordionId-content"
-      aria-expanded="true"
       class="accordion-summary accordion-summary-full-width medium accordion-summary-expanded"
       id="myAccordionId-header"
-      role="button"
       style="gap: 8px;"
-      tabindex="0"
     >
+      <div
+        aria-controls="myAccordionId-content"
+        aria-expanded="true"
+        aria-label="Collapse content"
+        class="clickable-area"
+        role="button"
+        tabindex="0"
+      />
       <div
         class="accordion-header-container"
       >
@@ -464,7 +513,7 @@ exports[`Accordion Accordion renders custom content 1`] = `
             />
           </svg>
         </span>
-        <span
+        <div
           class="accordion-header"
         >
           <div
@@ -493,7 +542,9 @@ exports[`Accordion Accordion renders custom content 1`] = `
                   class="octuple-content"
                   style="font-weight: 400;"
                 >
-                  Supporting text
+                  <span>
+                    Supporting text
+                  </span>
                 </div>
               </div>
               <div
@@ -562,7 +613,7 @@ exports[`Accordion Accordion renders custom content 1`] = `
               </div>
             </div>
           </div>
-        </span>
+        </div>
         <span
           class="badge badge-medium badge"
         >
@@ -570,7 +621,10 @@ exports[`Accordion Accordion renders custom content 1`] = `
         </span>
       </div>
       <button
+        aria-controls="myAccordionId-content"
         aria-disabled="false"
+        aria-expanded="true"
+        aria-label="Collapse content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -618,13 +672,17 @@ exports[`Accordion Renders without crashing 1`] = `
     data-testid="test-accordion"
   >
     <div
-      aria-controls="myAccordionId-content"
-      aria-expanded="false"
       class="accordion-summary large"
       id="myAccordionId-header"
-      role="button"
-      tabindex="0"
     >
+      <div
+        aria-controls="myAccordionId-content"
+        aria-expanded="false"
+        aria-label="Expand content"
+        class="clickable-area"
+        role="button"
+        tabindex="0"
+      />
       <div
         class="accordion-header-container"
       >
@@ -644,11 +702,13 @@ exports[`Accordion Renders without crashing 1`] = `
             />
           </svg>
         </span>
-        <span
+        <div
           class="accordion-header"
         >
-          Accordion Header
-        </span>
+          <span>
+            Accordion Header
+          </span>
+        </div>
         <span
           class="badge badge-medium badge"
         >
@@ -656,7 +716,10 @@ exports[`Accordion Renders without crashing 1`] = `
         </span>
       </div>
       <button
+        aria-controls="myAccordionId-content"
         aria-disabled="false"
+        aria-expanded="false"
+        aria-label="Expand content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Accordion Accordion is large 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -54,7 +54,7 @@ exports[`Accordion Accordion is large 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -108,7 +108,7 @@ exports[`Accordion Accordion is medium 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -149,7 +149,7 @@ exports[`Accordion Accordion is medium 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -203,7 +203,7 @@ exports[`Accordion Accordion is not bordered 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -244,7 +244,7 @@ exports[`Accordion Accordion is not bordered 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -298,7 +298,7 @@ exports[`Accordion Accordion is pill shaped 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -339,7 +339,7 @@ exports[`Accordion Accordion is pill shaped 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -393,7 +393,7 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -434,7 +434,7 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -489,7 +489,7 @@ exports[`Accordion Accordion renders custom content and its buttons are clickabl
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="true"
-        aria-label="Collapse content"
+        aria-label="Open content"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -624,7 +624,7 @@ exports[`Accordion Accordion renders custom content and its buttons are clickabl
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="true"
-        aria-label="Collapse content"
+        aria-label="Open content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span
@@ -678,7 +678,7 @@ exports[`Accordion Renders without crashing 1`] = `
       <div
         aria-controls="myAccordionId-content"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="clickable-area"
         role="button"
         tabindex="0"
@@ -719,7 +719,7 @@ exports[`Accordion Renders without crashing 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         aria-expanded="false"
-        aria-label="Expand content"
+        aria-label="Close content"
         class="button button-neutral button-medium round-shape icon-left"
       >
         <span

--- a/src/components/Accordion/accordion.module.scss
+++ b/src/components/Accordion/accordion.module.scss
@@ -63,12 +63,69 @@
     align-items: center;
     background: var(--accordion-summary-background-color);
     color: var(--accordion-summary-text-color);
-    cursor: pointer;
     display: flex;
     gap: $space-s;
     justify-content: space-between;
+    position: relative;
     width: 100%;
     transition: background-color $motion-duration-fast $motion-easing-easeout;
+
+    .clickable-area {
+      bottom: 0;
+      border-radius: $border-radius-xl;
+      cursor: pointer;
+      left: 0;
+      pointer-events: all;
+      position: absolute;
+      right: 0;
+      top: 0;
+      z-index: 0;
+
+      &:focus,
+      &:focus-visible {
+        outline: none;
+      }
+    }
+
+    // By default we ensure the header content does not obscure the clickable area.
+    .accordion-header-container {
+      pointer-events: none;
+      z-index: 1;
+
+      // If there's custom content in the header, its interactive children should be clickable or selectable.
+      a[href],
+      area,
+      audio,
+      blockquote,
+      button:not([disabled]),
+      cite,
+      details,
+      dd,
+      dt,
+      dl,
+      em,
+      embed,
+      figcaption,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      iframe,
+      input:not([disabled]),
+      label,
+      object,
+      p,
+      select:not([disabled]),
+      span,
+      strong,
+      [tabindex]:not([tabindex='-1']),
+      textarea:not([disabled]),
+      video {
+        pointer-events: auto;
+      }
+    }
 
     &.large {
       padding: $space-m $space-l;
@@ -113,18 +170,6 @@
       }
     }
 
-    &:focus,
-    &:focus-visible {
-      outline: none;
-    }
-
-    &-expanded {
-      &:focus,
-      &:focus-visible {
-        outline: none;
-      }
-    }
-
     &:hover {
       background: var(--accordion-summary-background-hover-color);
       color: var(--accordion-summary-text-hover-color);
@@ -133,6 +178,7 @@
 
   .accordion-icon-button {
     transition: transform $motion-duration-fast;
+    z-index: 1;
 
     &.expanded-icon-button {
       transform: rotate(180deg);
@@ -181,20 +227,19 @@
 :global(.focus-visible) {
   .accordion-container {
     .accordion-summary {
-      &.focus-visible,
-      &:focus-visible {
-        border: 2px solid var(--focus-visible-shadow-color);
-        border-radius: $border-radius-xl;
-
-        &.large {
-          padding: calc(#{$space-m} - 2px) calc(#{$space-l} - 2px);
+      .clickable-area {
+        &.focus-visible,
+        &:focus-visible {
+          box-shadow: inset var(--focus-visible-box-shadow);
         }
+      }
 
-        &.medium {
-          padding: calc(#{$space-s} - 2px) calc(#{$space-m} - 2px);
-        }
+      &.accordion-summary-expanded {
+        border-radius: 0;
+        border-top-left-radius: $border-radius-xl;
+        border-top-right-radius: $border-radius-xl;
 
-        &.accordion-summary-expanded {
+        .clickable-area {
           border-radius: 0;
           border-top-left-radius: $border-radius-xl;
           border-top-right-radius: $border-radius-xl;

--- a/src/components/Locale/Default.tsx
+++ b/src/components/Locale/Default.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/en_US';
 import Breadcrumb from '../Breadcrumb/Locale/en_US';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/en_US';
 import Dialog from '../Dialog/BaseDialog/Locale/en_US';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Select',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/ar_SA.tsx
+++ b/src/components/Locale/ar_SA.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/ar_SA';
 import Breadcrumb from '../Breadcrumb/Locale/ar_SA';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ar_SA';
 import Dialog from '../Dialog/BaseDialog/Locale/ar_SA';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'اختر',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/bg_BG.tsx
+++ b/src/components/Locale/bg_BG.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/bg_BG';
 import Breadcrumb from '../Breadcrumb/Locale/bg_BG';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/bg_BG';
 import Dialog from '../Dialog/BaseDialog/Locale/bg_BG';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Изберете',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/cs_CZ.tsx
+++ b/src/components/Locale/cs_CZ.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/cs_CZ';
 import Breadcrumb from '../Breadcrumb/Locale/cs_CZ';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/cs_CZ';
 import Dialog from '../Dialog/BaseDialog/Locale/cs_CZ';
@@ -17,6 +18,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Prosím vyber',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/da_DK.tsx
+++ b/src/components/Locale/da_DK.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/da_DK';
 import Breadcrumb from '../Breadcrumb/Locale/da_DK';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/da_DK';
 import Dialog from '../Dialog/BaseDialog/Locale/da_DK';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/da_DK';
 
 const localeValues: Locale = {
   locale: 'da',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/de_DE.tsx
+++ b/src/components/Locale/de_DE.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/de_DE';
 import Breadcrumb from '../Breadcrumb/Locale/de_DE';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/de_DE';
 import Dialog from '../Dialog/BaseDialog/Locale/de_DE';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Bitte auswählen',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/el_GR.tsx
+++ b/src/components/Locale/el_GR.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/el_GR';
 import Breadcrumb from '../Breadcrumb/Locale/el_GR';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/el_GR';
 import Dialog from '../Dialog/BaseDialog/Locale/el_GR';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/el_GR';
 
 const localeValues: Locale = {
   locale: 'el',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/en_GB.tsx
+++ b/src/components/Locale/en_GB.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/en_GB';
 import Breadcrumb from '../Breadcrumb/Locale/en_GB';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/en_GB';
 import Dialog from '../Dialog/BaseDialog/Locale/en_GB';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Select',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/es_DO.tsx
+++ b/src/components/Locale/es_DO.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/es_DO';
 import Breadcrumb from '../Breadcrumb/Locale/es_DO';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_DO';
 import Dialog from '../Dialog/BaseDialog/Locale/es_DO';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Seleccione',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/es_ES.tsx
+++ b/src/components/Locale/es_ES.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/es_ES';
 import Breadcrumb from '../Breadcrumb/Locale/es_ES';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_ES';
 import Dialog from '../Dialog/BaseDialog/Locale/es_ES';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Seleccione',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/es_MX.tsx
+++ b/src/components/Locale/es_MX.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/es_MX';
 import Breadcrumb from '../Breadcrumb/Locale/es_MX';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/es_MX';
 import Dialog from '../Dialog/BaseDialog/Locale/es_MX';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Seleccione',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/fi_FI.tsx
+++ b/src/components/Locale/fi_FI.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/fi_FI';
 import Breadcrumb from '../Breadcrumb/Locale/fi_FI';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fi_FI';
 import Dialog from '../Dialog/BaseDialog/Locale/fi_FI';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/fi_FI';
 
 const localeValues: Locale = {
   locale: 'fi',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/fr_BE.tsx
+++ b/src/components/Locale/fr_BE.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/fr_BE';
 import Breadcrumb from '../Breadcrumb/Locale/fr_BE';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_BE';
 import Dialog from '../Dialog/BaseDialog/Locale/fr_BE';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/fr_BE';
 
 const localeValues: Locale = {
   locale: 'fr',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/fr_CA.tsx
+++ b/src/components/Locale/fr_CA.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/fr_CA';
 import Breadcrumb from '../Breadcrumb/Locale/fr_CA';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_CA';
 import Dialog from '../Dialog/BaseDialog/Locale/fr_CA';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/fr_CA';
 
 const localeValues: Locale = {
   locale: 'fr',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/fr_FR.tsx
+++ b/src/components/Locale/fr_FR.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/fr_FR';
 import Breadcrumb from '../Breadcrumb/Locale/fr_FR';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/fr_FR';
 import Dialog from '../Dialog/BaseDialog/Locale/fr_FR';
@@ -18,6 +19,7 @@ const typeTemplate =
 
 const localeValues: Locale = {
   locale: 'fr',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/he_IL.tsx
+++ b/src/components/Locale/he_IL.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/he_IL';
 import Breadcrumb from '../Breadcrumb/Locale/he_IL';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/he_IL';
 import Dialog from '../Dialog/BaseDialog/Locale/he_IL';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'אנא בחר',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/hi_IN.tsx
+++ b/src/components/Locale/hi_IN.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/hi_IN';
 import Breadcrumb from '../Breadcrumb/Locale/hi_IN';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/hi_IN';
 import Dialog from '../Dialog/BaseDialog/Locale/hi_IN';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'चुनना',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/hr_HR.tsx
+++ b/src/components/Locale/hr_HR.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/hr_HR';
 import Breadcrumb from '../Breadcrumb/Locale/hr_HR';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/hr_HR';
 import Dialog from '../Dialog/BaseDialog/Locale/hr_HR';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Molimo označite',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/ht_HT.tsx
+++ b/src/components/Locale/ht_HT.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/ht_HT';
 import Breadcrumb from '../Breadcrumb/Locale/ht_HT';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ht_HT';
 import Dialog from '../Dialog/BaseDialog/Locale/ht_HT';
@@ -18,6 +19,7 @@ const typeTemplate =
 
 const localeValues: Locale = {
   locale: 'fr',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/hu_HU.tsx
+++ b/src/components/Locale/hu_HU.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/hu_HU';
 import Breadcrumb from '../Breadcrumb/Locale/hu_HU';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/hu_HU';
 import Dialog from '../Dialog/BaseDialog/Locale/hu_HU';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/hu_HU';
 
 const localeValues: Locale = {
   locale: 'hu',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/it_IT.tsx
+++ b/src/components/Locale/it_IT.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/it_IT';
 import Breadcrumb from '../Breadcrumb/Locale/it_IT';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/it_IT';
 import Dialog from '../Dialog/BaseDialog/Locale/it_IT';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/it_IT';
 
 const localeValues: Locale = {
   locale: 'it',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/ja_JP.tsx
+++ b/src/components/Locale/ja_JP.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/ja_JP';
 import Breadcrumb from '../Breadcrumb/Locale/ja_JP';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ja_JP';
 import Dialog from '../Dialog/BaseDialog/Locale/ja_JP';
@@ -17,6 +18,7 @@ const typeTemplate = '${label}は有効な${type}ではありません';
 
 const localeValues: Locale = {
   locale: 'ja',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/ko_KR.tsx
+++ b/src/components/Locale/ko_KR.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/ko_KR';
 import Breadcrumb from '../Breadcrumb/Locale/ko_KR';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ko_KR';
 import Dialog from '../Dialog/BaseDialog/Locale/ko_KR';
@@ -17,6 +18,7 @@ const typeTemplate = '${label} 유효하지 않은 ${type}';
 
 const localeValues: Locale = {
   locale: 'ko',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/ms_MY.tsx
+++ b/src/components/Locale/ms_MY.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/ms_MY';
 import Breadcrumb from '../Breadcrumb/Locale/ms_MY';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ms_MY';
 import Dialog from '../Dialog/BaseDialog/Locale/ms_MY';
@@ -17,6 +18,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Sila pilih',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/nb_NO.tsx
+++ b/src/components/Locale/nb_NO.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/nb_NO';
 import Breadcrumb from '../Breadcrumb/Locale/nb_NO';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nb_NO';
 import Dialog from '../Dialog/BaseDialog/Locale/nb_NO';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Vennligst velg',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/nl_BE.tsx
+++ b/src/components/Locale/nl_BE.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/nl_BE';
 import Breadcrumb from '../Breadcrumb/Locale/nl_BE';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_BE';
 import Dialog from '../Dialog/BaseDialog/Locale/nl_BE';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Maak een selectie',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/nl_NL.tsx
+++ b/src/components/Locale/nl_NL.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/nl_NL';
 import Breadcrumb from '../Breadcrumb/Locale/nl_NL';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/nl_NL';
 import Dialog from '../Dialog/BaseDialog/Locale/nl_NL';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Maak een selectie',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/pl_PL.tsx
+++ b/src/components/Locale/pl_PL.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/pl_PL';
 import Breadcrumb from '../Breadcrumb/Locale/pl_PL';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pl_PL';
 import Dialog from '../Dialog/BaseDialog/Locale/pl_PL';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Wybierz',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/pt_BR.tsx
+++ b/src/components/Locale/pt_BR.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/pt_BR';
 import Breadcrumb from '../Breadcrumb/Locale/pt_BR';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_BR';
 import Dialog from '../Dialog/BaseDialog/Locale/pt_BR';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Por favor escolha',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/pt_PT.tsx
+++ b/src/components/Locale/pt_PT.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/pt_PT';
 import Breadcrumb from '../Breadcrumb/Locale/pt_PT';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/pt_PT';
 import Dialog from '../Dialog/BaseDialog/Locale/pt_PT';
@@ -14,6 +15,7 @@ import Upload from '../Upload/Locale/pt_PT';
 
 const localeValues: Locale = {
   locale: 'pt',
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/ro_RO.tsx
+++ b/src/components/Locale/ro_RO.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/ro_RO';
 import Breadcrumb from '../Breadcrumb/Locale/ro_RO';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ro_RO';
 import Dialog from '../Dialog/BaseDialog/Locale/ro_RO';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Selectați',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/ru_RU.tsx
+++ b/src/components/Locale/ru_RU.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/ru_RU';
 import Breadcrumb from '../Breadcrumb/Locale/ru_RU';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/ru_RU';
 import Dialog from '../Dialog/BaseDialog/Locale/ru_RU';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Пожалуйста выберите',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/sk_SK.tsx
+++ b/src/components/Locale/sk_SK.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/sk_SK';
 import Breadcrumb from '../Breadcrumb/Locale/sk_SK';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/sk_SK';
 import Dialog from '../Dialog/BaseDialog/Locale/sk_SK';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Vyberte',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/sr_RS.tsx
+++ b/src/components/Locale/sr_RS.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/sr_RS';
 import Breadcrumb from '../Breadcrumb/Locale/sr_RS';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/sr_RS';
 import Dialog from '../Dialog/BaseDialog/Locale/sr_RS';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Izaberi',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/sv_SE.tsx
+++ b/src/components/Locale/sv_SE.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/sv_SE';
 import Breadcrumb from '../Breadcrumb/Locale/sv_SE';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/sv_SE';
 import Dialog from '../Dialog/BaseDialog/Locale/sv_SE';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Vänligen välj',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/te_IN.tsx
+++ b/src/components/Locale/te_IN.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/te_IN';
 import Breadcrumb from '../Breadcrumb/Locale/te_IN';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/te_IN';
 import Dialog from '../Dialog/BaseDialog/Locale/te_IN';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'ఎంచుకోండి',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/th_TH.tsx
+++ b/src/components/Locale/th_TH.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/th_TH';
 import Breadcrumb from '../Breadcrumb/Locale/th_TH';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/th_TH';
 import Dialog from '../Dialog/BaseDialog/Locale/th_TH';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'กรุณาเลือก',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/tr_TR.tsx
+++ b/src/components/Locale/tr_TR.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/tr_TR';
 import Breadcrumb from '../Breadcrumb/Locale/tr_TR';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/tr_TR';
 import Dialog from '../Dialog/BaseDialog/Locale/tr_TR';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Lütfen seçiniz',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/uk_UA.tsx
+++ b/src/components/Locale/uk_UA.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/uk_UA';
 import Breadcrumb from '../Breadcrumb/Locale/uk_UA';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/uk_UA';
 import Dialog from '../Dialog/BaseDialog/Locale/uk_UA';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Будь ласка, оберіть',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/vi_VN.tsx
+++ b/src/components/Locale/vi_VN.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/vi_VN';
 import Breadcrumb from '../Breadcrumb/Locale/vi_VN';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/vi_VN';
 import Dialog from '../Dialog/BaseDialog/Locale/vi_VN';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: 'Chọn',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/zh_CN.tsx
+++ b/src/components/Locale/zh_CN.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/zh_CN';
 import Breadcrumb from '../Breadcrumb/Locale/zh_CN';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_CN';
 import Dialog from '../Dialog/BaseDialog/Locale/zh_CN';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: '请选择',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/Locale/zh_TW.tsx
+++ b/src/components/Locale/zh_TW.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import type { Locale } from '../LocaleProvider';
+import Accordion from '../Accordion/Locale/zh_TW';
 import Breadcrumb from '../Breadcrumb/Locale/zh_TW';
 import DatePicker from '../DateTimePicker/DatePicker/Locale/zh_TW';
 import Dialog from '../Dialog/BaseDialog/Locale/zh_TW';
@@ -20,6 +21,7 @@ const localeValues: Locale = {
   global: {
     placeholder: '請選擇',
   },
+  Accordion,
   Breadcrumb,
   DatePicker,
   Dialog,

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import type { AccordionLocale } from '../Accordion/Accordion.types';
 import type { BreadcrumbLocale } from '../Breadcrumb/Breadcrumb.types';
 import type { DialogLocale } from '../Dialog/BaseDialog/BaseDialog.types';
 import type { DrawerLocale } from '../Drawer/Drawer.types';
@@ -18,6 +19,7 @@ import LocaleContext from './Context';
 export interface Locale {
   locale: string;
   global?: Record<string, any>;
+  Accordion?: AccordionLocale;
   Breadcrumb?: BreadcrumbLocale;
   DatePicker?: DatePickerLocale;
   Dialog?: DialogLocale;


### PR DESCRIPTION
## SUMMARY:
- Removes multiple click target concern by moving overall clickable area inside the header, under the content via `zIndex`
- Updates `focus-visible` styles to work with the new layout
- Accounts for custom interactive content via selectors, such that it remains selectable or clickable
- Checks if custom content is a `string`, wraps it in a `span` so it remains selectable
- Removes a duplicate `{...expandButtonProps}` attribute
- Updates unit tests
- Updates stories

Lighthouse report:
![accordionDeepA11yPassLighthouse](https://github.com/EightfoldAI/octuple/assets/99700808/0ecbb642-daa1-408d-8fb0-08d3bd812324)

Axe report:
![accordionDeepA11yPassAxe](https://github.com/EightfoldAI/octuple/assets/99700808/24412c23-bcf9-45ea-ab20-ab22cfacacd1)


## JIRA TASK (Eightfold Employees Only):
ENG-87358

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Accordion` stories behave as expected.