### PR TITLE
chore: readme: updates size badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 [![npm version](https://badge.fury.io/js/@eightfold.ai%2Foctuple.svg)](https://badge.fury.io/js/@eightfold.ai%2Foctuple) ![node](https://img.shields.io/badge/node-16.14.2-brightgreen.svg) [![codecov](https://codecov.io/gh/EightfoldAI/octuple/branch/main/graph/badge.svg?token=XSAVLS0SVP)](https://codecov.io/gh/EightfoldAI/octuple) ![Build](https://github.com/EightfoldAI/octuple/actions/workflows/build.yml/badge.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-![bundlesize-js-image](https://img.badgesize.io/https:/unpkg.com/browse/@eightfold.ai/octuple/lib/octuple.js?label=octuple.js&compression=gzip)
-![bundlesize-css-image](https://img.badgesize.io/https:/unpkg.com/browse/@eightfold.ai/octuple/lib/octuple.css?label=octuple.css&compression=gzip)
+![npm package minimized gzipped size](https://img.shields.io/badge/octuple.js-337.4k-blueviolet?link=https://bundlephobia.com/package/@eightfold.ai/octuple)
+![bundlesize-css-image](<https://img.shields.io/badge/@eightfold.ai/octuple/lib/octuple.css-163.5k_(gzipped)-blue?link=https://facia.dev/tools/compress-decompress/gzip-compress/>)
+![bundlesize-locale-image](<https://img.shields.io/badge/@eightfold.ai/octuple/lib/locale.js-67.2k_(gzipped)-blue?link=https://facia.dev/tools/compress-decompress/gzip-compress/>)
 
 </div>
 


### PR DESCRIPTION
## SUMMARY:
img.badgesize.io is down indefinitely due to it's domain being expired. Not sure if it'll ever be live again.

Move to use static badges for now with urls.

## GITHUB ISSUE (Open Source Contributors)
https://github.com/ngryman/badge-size/issues/113

## JIRA TASK (Eightfold Employees Only):
N/A

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:
N/A

## TEST PLAN:
Open the badge urls using a browser.