### PR TITLE
fix: carousel and tooltip: preventTouchMoveDefault false for tooltips inside carousels 

### DIFF
--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -11,6 +11,7 @@ import {
 import { Button, ButtonShape, ButtonSize, ButtonVariant } from '../Button';
 import { Card } from '../Card';
 import { IconName } from '../Icon';
+import { Tooltip } from '../Tooltip';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 
 export default {
@@ -310,7 +311,9 @@ Scroller.args = {
             width: '100%',
           }}
         >
-          {item.name}
+          <Tooltip content={item.name} portal>
+            {item.name}
+          </Tooltip>
         </div>
       </Card>
     )),
@@ -335,7 +338,9 @@ Scroller_Single.args = {
             width: '100%',
           }}
         >
-          {item.name}
+          <Tooltip content={item.name} portal>
+            {item.name}
+          </Tooltip>
         </div>
       </Card>
     )),
@@ -361,7 +366,9 @@ Scroller_Custom_Buttons.args = {
             width: '100%',
           }}
         >
-          {item.name}
+          <Tooltip content={item.name} portal>
+            {item.name}
+          </Tooltip>
         </div>
       </Card>
     )),

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -11,7 +11,7 @@ import {
 import { Button, ButtonShape, ButtonSize, ButtonVariant } from '../Button';
 import { Card } from '../Card';
 import { IconName } from '../Icon';
-import { Tooltip } from '../Tooltip';
+import { Tooltip, TooltipSize, TooltipTheme } from '../Tooltip';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 
 export default {
@@ -119,6 +119,11 @@ const sampleList: SampleItem[] = [1, 2, 3, 4, 5, 6, 7, 8].map((i) => ({
   name: `Item ${i}`,
   key: `key-${i}`,
 }));
+
+const TOOLTIP_INFO_TEXT =
+  'Try dragging on me in a mobile view!\n\nWhen inside a Carousel, Tooltips will set preventTouchMoveDefault={false} by default to enable touch scrolling.';
+// const TOOLTIP_INFO_SUBTITLE_TEXT =
+//   ' When inside a Carousel, Tooltips will set preventTouchMoveDefault={false} by default to enable touch scrolling.'
 
 const Scroll_Story: ComponentStory<typeof Carousel> = (args) => (
   <Carousel {...args} />
@@ -257,6 +262,7 @@ export const Slider = Slide_Story.bind({});
 export const Scroller = Scroll_Story.bind({});
 export const Scroller_Single = Scroll_Story.bind({});
 export const Scroller_Custom_Buttons = Scroll_Custom_Buttons_Story.bind({});
+export const Scroller_With_Tooltips = Scroll_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
@@ -266,6 +272,7 @@ export const __namedExportsOrder = [
   'Scroller',
   'Scroller_Single',
   'Scroller_Custom_Buttons',
+  'Scroller_With_Tooltips',
 ];
 
 const carouselArgs: Object = {
@@ -311,9 +318,7 @@ Scroller.args = {
             width: '100%',
           }}
         >
-          <Tooltip content={item.name} portal>
-            {item.name}
-          </Tooltip>
+          {item.name}
         </div>
       </Card>
     )),
@@ -338,9 +343,7 @@ Scroller_Single.args = {
             width: '100%',
           }}
         >
-          <Tooltip content={item.name} portal>
-            {item.name}
-          </Tooltip>
+          {item.name}
         </div>
       </Card>
     )),
@@ -366,9 +369,7 @@ Scroller_Custom_Buttons.args = {
             width: '100%',
           }}
         >
-          <Tooltip content={item.name} portal>
-            {item.name}
-          </Tooltip>
+          {item.name}
         </div>
       </Card>
     )),
@@ -380,5 +381,55 @@ Scroller_Custom_Buttons.args = {
   id: 'myCarouselScrollId',
   single: true,
   style: { background: 'transparent' },
+  type: 'scroll',
+};
+
+Scroller_With_Tooltips.args = {
+  ...carouselArgs,
+  carouselScrollMenuProps: {
+    children: sampleList.map((item: SampleItem) => (
+      <Card bordered height={344} key={item.key} tabIndex={0} width={280}>
+        <div
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 24,
+            height: '100%',
+            justifyContent: 'center',
+            width: '100%',
+          }}
+        >
+          {item.name}
+          <Tooltip
+            content={TOOLTIP_INFO_TEXT}
+            portal
+            size={TooltipSize.Medium}
+            theme={TooltipTheme.dark}
+            tooltipStyle={{ fontSize: 14 }}
+            wrapperStyle={{ width: 'fit-content' }}
+          >
+            <div
+              style={{
+                display: '-webkit-box',
+                overflow: 'hidden',
+                textAlign: 'center',
+                textOverflow: 'ellipsis',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 4,
+                whiteSpace: 'pre-line',
+                width: '100%',
+              }}
+            >
+              {TOOLTIP_INFO_TEXT}
+            </div>
+          </Tooltip>
+        </div>
+      </Card>
+    )),
+    containerPadding: 8,
+    gap: 24,
+  },
+  id: 'myCarouselScrollId',
   type: 'scroll',
 };

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -285,22 +285,15 @@ const CarouselCardWithTooltip = ({
           justifyContent: 'center',
         }}
       >
-        {isTextTruncated ? (
-          <Tooltip
-            content={children}
-            portal
-            size={TooltipSize.Medium}
-            theme={TooltipTheme.dark}
-            tooltipStyle={{ fontSize: 14 }}
-            wrapperStyle={{ width: 'fit-content' }}
-          >
-            <TruncateText>{children}</TruncateText>
-          </Tooltip>
-        ) : (
-          <TruncateText style={{ wordBreak: 'initial' }}>
-            {children}
-          </TruncateText>
-        )}
+        <Tooltip
+          content={children}
+          disabled={!isTextTruncated}
+          portal
+          size={TooltipSize.Medium}
+          theme={TooltipTheme.dark}
+        >
+          <TruncateText>{children}</TruncateText>
+        </Tooltip>
       </div>
       <span>Line Clamp: {lineClamp}</span>
     </Card>

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -13,6 +13,7 @@ import { Card } from '../Card';
 import { IconName } from '../Icon';
 import { Tooltip, TooltipSize, TooltipTheme } from '../Tooltip';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
+import { useTruncate } from '../../hooks/useTruncate';
 
 export default {
   title: 'Carousel',
@@ -119,11 +120,6 @@ const sampleList: SampleItem[] = [1, 2, 3, 4, 5, 6, 7, 8].map((i) => ({
   name: `Item ${i}`,
   key: `key-${i}`,
 }));
-
-const TOOLTIP_INFO_TEXT =
-  'Try dragging on me in a mobile view!\n\nWhen inside a Carousel, Tooltips will set preventTouchMoveDefault={false} by default to enable touch scrolling.';
-// const TOOLTIP_INFO_SUBTITLE_TEXT =
-//   ' When inside a Carousel, Tooltips will set preventTouchMoveDefault={false} by default to enable touch scrolling.'
 
 const Scroll_Story: ComponentStory<typeof Carousel> = (args) => (
   <Carousel {...args} />
@@ -258,6 +254,59 @@ const Scroll_Custom_Buttons_Story: ComponentStory<typeof Carousel> = (args) => {
   );
 };
 
+const CarouselCardWithTooltip = ({
+  children,
+  lineClamp,
+}: {
+  children?: React.ReactNode;
+  lineClamp?: number;
+}) => {
+  const { TruncateText, isTextTruncated } = useTruncate({ lineClamp });
+  return (
+    <Card
+      bordered
+      height={344}
+      tabIndex={0}
+      width={280}
+      style={{
+        alignItems: 'center',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        width: '100%',
+      }}
+    >
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+          flexGrow: 1,
+          justifyContent: 'center',
+        }}
+      >
+        {isTextTruncated ? (
+          <Tooltip
+            content={children}
+            portal
+            size={TooltipSize.Medium}
+            theme={TooltipTheme.dark}
+            tooltipStyle={{ fontSize: 14 }}
+            wrapperStyle={{ width: 'fit-content' }}
+          >
+            <TruncateText>{children}</TruncateText>
+          </Tooltip>
+        ) : (
+          <TruncateText style={{ wordBreak: 'initial' }}>
+            {children}
+          </TruncateText>
+        )}
+      </div>
+      <span>Line Clamp: {lineClamp}</span>
+    </Card>
+  );
+};
+
 export const Slider = Slide_Story.bind({});
 export const Scroller = Scroll_Story.bind({});
 export const Scroller_Single = Scroll_Story.bind({});
@@ -387,45 +436,12 @@ Scroller_Custom_Buttons.args = {
 Scroller_With_Tooltips.args = {
   ...carouselArgs,
   carouselScrollMenuProps: {
-    children: sampleList.map((item: SampleItem) => (
-      <Card bordered height={344} key={item.key} tabIndex={0} width={280}>
-        <div
-          style={{
-            alignItems: 'center',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 24,
-            height: '100%',
-            justifyContent: 'center',
-            width: '100%',
-          }}
-        >
-          {item.name}
-          <Tooltip
-            content={TOOLTIP_INFO_TEXT}
-            portal
-            size={TooltipSize.Medium}
-            theme={TooltipTheme.dark}
-            tooltipStyle={{ fontSize: 14 }}
-            wrapperStyle={{ width: 'fit-content' }}
-          >
-            <div
-              style={{
-                display: '-webkit-box',
-                overflow: 'hidden',
-                textAlign: 'center',
-                textOverflow: 'ellipsis',
-                WebkitBoxOrient: 'vertical',
-                WebkitLineClamp: 4,
-                whiteSpace: 'pre-line',
-                width: '100%',
-              }}
-            >
-              {TOOLTIP_INFO_TEXT}
-            </div>
-          </Tooltip>
-        </div>
-      </Card>
+    children: sampleList.map((item: SampleItem, index: number) => (
+      <CarouselCardWithTooltip key={item.key} lineClamp={index + 1}>
+        Try dragging on me in a mobile view! When inside a Carousel, Tooltips
+        will set preventTouchMoveDefault to {'false'} by default to enable touch
+        scrolling.
+      </CarouselCardWithTooltip>
     )),
     containerPadding: 8,
     gap: 24,

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -13,6 +13,7 @@ import React, {
 } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName, Size } from '../ConfigProvider';
+import { ParentComponentsContextProvider } from '../ConfigProvider/ParentComponentsContext';
 import ThemeContext, {
   ThemeContextProvider,
 } from '../ConfigProvider/ThemeContext';
@@ -829,87 +830,92 @@ export const Carousel: FC<CarouselProps> = React.forwardRef(
               containerId={themeContainerId}
               theme={mergedTheme}
             >
-              <div
-                className={carouselClassNames}
-                data-test-id={dataTestId}
-                onMouseEnter={
-                  type === 'slide' ? handlePause : () => setMouseEnter(true)
-                }
-                onMouseLeave={
-                  type === 'slide' ? handleCycle : () => setMouseEnter(false)
-                }
-                {...rest}
-                ref={forkedRef}
-              >
-                <CarouselContext.Provider
-                  value={{
-                    setAnimating,
-                    setCustomInterval,
-                  }}
+              <ParentComponentsContextProvider componentName="Carousel">
+                <div
+                  className={carouselClassNames}
+                  data-test-id={dataTestId}
+                  onMouseEnter={
+                    type === 'slide' ? handlePause : () => setMouseEnter(true)
+                  }
+                  onMouseLeave={
+                    type === 'slide' ? handleCycle : () => setMouseEnter(false)
+                  }
+                  {...rest}
+                  ref={forkedRef}
                 >
-                  {pagination && (
-                    <Pagination
-                      classNames={styles.carouselPagination}
-                      configContextProps={configContextProps}
-                      currentPage={active + 1}
-                      dots
-                      gradient={gradient}
-                      layout={[
-                        PaginationLayoutOptions.Previous,
-                        PaginationLayoutOptions.Pager,
-                        PaginationLayoutOptions.Next,
-                      ]}
-                      loop={loop}
-                      onCurrentChange={(currentPage: number) =>
-                        handleIndicatorClick(currentPage - 1)
-                      }
-                      restrictPageSizesPropToSizesLayout
-                      pageSize={1}
-                      theme={mergedTheme}
-                      themeContainerId={themeContainerId}
-                      total={itemsNumber}
-                    />
-                  )}
-                  <div className={styles.carouselInner} ref={carouselInnerRef}>
-                    {type === 'slide' &&
-                      Children?.map(children, (child, index) => {
-                        if (React.isValidElement(child)) {
-                          return React.cloneElement(
-                            child as React.ReactElement<any>,
-                            {
-                              active: active === index ? true : false,
-                              direction: direction,
-                              key: index,
-                            }
-                          );
+                  <CarouselContext.Provider
+                    value={{
+                      setAnimating,
+                      setCustomInterval,
+                    }}
+                  >
+                    {pagination && (
+                      <Pagination
+                        classNames={styles.carouselPagination}
+                        configContextProps={configContextProps}
+                        currentPage={active + 1}
+                        dots
+                        gradient={gradient}
+                        layout={[
+                          PaginationLayoutOptions.Previous,
+                          PaginationLayoutOptions.Pager,
+                          PaginationLayoutOptions.Next,
+                        ]}
+                        loop={loop}
+                        onCurrentChange={(currentPage: number) =>
+                          handleIndicatorClick(currentPage - 1)
                         }
-                        return null;
-                      })}
-                    {type === 'scroll' && (
-                      <ResizeObserver onResize={updateScrollMode}>
-                        <ScrollMenu
-                          controls={controls}
-                          nextButton={() => autoScrollButton('next')}
-                          onWheel={handleOnWheel}
-                          overlayControls={overlayControls}
-                          previousButton={() => autoScrollButton('previous')}
-                          rtl={htmlDir === 'rtl'}
-                          {...carouselScrollMenuProps}
-                          ref={scrollMenuRef}
-                        >
-                          {carouselScrollMenuProps?.children}
-                        </ScrollMenu>
-                      </ResizeObserver>
+                        restrictPageSizesPropToSizesLayout
+                        pageSize={1}
+                        theme={mergedTheme}
+                        themeContainerId={themeContainerId}
+                        total={itemsNumber}
+                      />
                     )}
-                  </div>
-                  {controls && type === 'slide' && (
-                    <>
-                      {previousButton()}
-                      {nextButton()}
-                    </>
-                  )}
-                </CarouselContext.Provider>
-              </div>
+                    <div
+                      className={styles.carouselInner}
+                      ref={carouselInnerRef}
+                    >
+                      {type === 'slide' &&
+                        Children?.map(children, (child, index) => {
+                          if (React.isValidElement(child)) {
+                            return React.cloneElement(
+                              child as React.ReactElement<any>,
+                              {
+                                active: active === index ? true : false,
+                                direction: direction,
+                                key: index,
+                              }
+                            );
+                          }
+                          return null;
+                        })}
+                      {type === 'scroll' && (
+                        <ResizeObserver onResize={updateScrollMode}>
+                          <ScrollMenu
+                            controls={controls}
+                            nextButton={() => autoScrollButton('next')}
+                            onWheel={handleOnWheel}
+                            overlayControls={overlayControls}
+                            previousButton={() => autoScrollButton('previous')}
+                            rtl={htmlDir === 'rtl'}
+                            {...carouselScrollMenuProps}
+                            ref={scrollMenuRef}
+                          >
+                            {carouselScrollMenuProps?.children}
+                          </ScrollMenu>
+                        </ResizeObserver>
+                      )}
+                    </div>
+                    {controls && type === 'slide' && (
+                      <>
+                        {previousButton()}
+                        {nextButton()}
+                      </>
+                    )}
+                  </CarouselContext.Provider>
+                </div>
+              </ParentComponentsContextProvider>
             </ThemeContextProvider>
           );
         }}

--- a/src/components/Carousel/Tests/Slide.test.tsx
+++ b/src/components/Carousel/Tests/Slide.test.tsx
@@ -199,4 +199,22 @@ describe('Slide', () => {
     expect(buttonNext).toHaveClass('button-small');
     expect(buttonPrev).toHaveClass('button-small');
   });
+
+  test('Carousel renders only React elements', () => {
+    const { container } = render(
+      <Carousel controls={false} pagination={false}>
+        <Slide classNames="slide-1">Slide-1</Slide>
+        <Slide classNames="slide-2">Slide-2</Slide>
+        <Slide classNames="slide-3">Slide-3</Slide>
+        {/* The below elements will not be rendered */}
+        {'Invalid Element'}
+        {42}
+        {true}
+        {false}
+      </Carousel>
+    );
+    const carousel = container.querySelector('.carousel');
+    const carouselInner = carousel.children[0];
+    expect(carouselInner.children.length).toBe(3);
+  });
 });

--- a/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -3,6 +3,7 @@ import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import { ConfigProvider, useConfig } from './ConfigProvider';
+import { useParentComponents } from './ParentComponentsContext';
 import DisabledContext from './DisabledContext';
 import GradientContext from './GradientContext';
 import { IConfigContext } from './ConfigProvider.types';
@@ -71,6 +72,26 @@ describe('ConfigProvider', () => {
       ),
     });
     expect(result.current.fontOptions.customFont).toEqual(fontOptions);
+  });
+
+  test('Provides the parent component names if provided as a prop', () => {
+    const { result } = renderHook(() => useParentComponents(), {
+      wrapper: ({ children }) => (
+        <ConfigProvider componentName="Parent1">
+          <ConfigProvider componentName="Parent2">{children}</ConfigProvider>
+        </ConfigProvider>
+      ),
+    });
+    expect(result.current.length).toEqual(2);
+    expect(result.current[0]).toEqual('Parent1');
+    expect(result.current[1]).toEqual('Parent2');
+  });
+
+  test('Provides no parent component names if not provided as a prop', () => {
+    const { result } = renderHook(() => useParentComponents(), {
+      wrapper: ConfigProvider,
+    });
+    expect(result.current.length).toEqual(0);
   });
 
   test('Provides disabled config if provided as prop', () => {

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -18,6 +18,7 @@ import {
   ThemeOptions,
 } from './Theming';
 import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
+import { ParentComponentsContextProvider } from './ParentComponentsContext';
 import { DisabledContextProvider } from './DisabledContext';
 import { GradientContextProvider } from './GradientContext';
 import { ShapeContextProvider } from './ShapeContext';
@@ -40,6 +41,7 @@ const DEFAULT_FOCUS_VISIBLE_ELEMENT: HTMLElement = canUseDocElement()
 
 const ConfigProvider: FC<ConfigProviderProps> = ({
   children,
+  componentName,
   disabled = false,
   focusVisibleOptions = {
     focusVisible: DEFAULT_FOCUS_VISIBLE,
@@ -147,6 +149,14 @@ const ConfigProvider: FC<ConfigProviderProps> = ({
       <DisabledContextProvider disabled={disabled}>
         {childNode}
       </DisabledContextProvider>
+    );
+  }
+
+  if (componentName !== undefined) {
+    childNode = (
+      <ParentComponentsContextProvider componentName={componentName}>
+        {childNode}
+      </ParentComponentsContextProvider>
     );
   }
 

--- a/src/components/ConfigProvider/ConfigProvider.types.ts
+++ b/src/components/ConfigProvider/ConfigProvider.types.ts
@@ -69,6 +69,10 @@ export interface ConfigProviderProps {
    */
   children?: React.ReactNode;
   /**
+   * The name of the component for use in child components to determine if they are a child of this component.
+   */
+  componentName?: string;
+  /**
    * Used by the disabled context provider to disable components.
    */
   disabled?: boolean;

--- a/src/components/ConfigProvider/ParentComponentsContext.tsx
+++ b/src/components/ConfigProvider/ParentComponentsContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, FC, useContext, useMemo } from 'react';
+
+export type ParentComponentsContextType = string[];
+
+const ParentComponentsContext = createContext<ParentComponentsContextType>([]);
+
+interface ParentComponentsProviderProps {
+  componentName: string;
+  children: React.ReactNode;
+}
+
+export const ParentComponentsContextProvider: FC<
+  ParentComponentsProviderProps
+> = ({ componentName, children }) => {
+  const parentContext = useContext(ParentComponentsContext);
+
+  const currentContext = useMemo(
+    () => [...(parentContext ?? []), componentName],
+    [parentContext, componentName]
+  );
+
+  return (
+    <ParentComponentsContext.Provider value={currentContext}>
+      {children}
+    </ParentComponentsContext.Provider>
+  );
+};
+
+export const useParentComponents = () => useContext(ParentComponentsContext);
+
+export default ParentComponentsContext;

--- a/src/components/ConfigProvider/ParentComponentsContext.tsx
+++ b/src/components/ConfigProvider/ParentComponentsContext.tsx
@@ -2,13 +2,22 @@ import React, { createContext, FC, useContext, useMemo } from 'react';
 
 export type ParentComponentsContextType = string[];
 
+/**
+ * Context for tracking parent elements in the React component tree.
+ */
 const ParentComponentsContext = createContext<ParentComponentsContextType>([]);
 
-interface ParentComponentsProviderProps {
+export interface ParentComponentsProviderProps {
+  /**
+   * The name of the current component to register to the tracked component tree.
+   */
   componentName: string;
   children: React.ReactNode;
 }
 
+/**
+ * Provider to wrap around components you would like to check for in the component tree by a child component.
+ */
 export const ParentComponentsContextProvider: FC<
   ParentComponentsProviderProps
 > = ({ componentName, children }) => {
@@ -26,6 +35,11 @@ export const ParentComponentsContextProvider: FC<
   );
 };
 
+/**
+ * Hook to retrieve an ordered list of the tracked ancestors of the current component.
+ * Ordered from furthest -> closest ancestor.
+ * @returns The list of parent component names.
+ */
 export const useParentComponents = () => useContext(ParentComponentsContext);
 
 export default ParentComponentsContext;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -32,6 +32,7 @@ import {
   TRIGGER_TO_HANDLER_MAP_ON_LEAVE,
   TooltipTouchInteraction,
 } from './Tooltip.types';
+import { useParentComponents } from '../ConfigProvider/ParentComponentsContext';
 import useGestures, { Gestures } from '../../hooks/useGestures';
 import { useMergedState } from '../../hooks/useMergedState';
 import { useOnClickOutside } from '../../hooks/useOnClickOutside';
@@ -76,7 +77,7 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         portalId,
         portalRoot,
         positionStrategy = 'absolute',
-        preventTouchMoveDefault = true,
+        preventTouchMoveDefault,
         referenceOnClick,
         referenceOnKeydown,
         showTooltip,
@@ -145,9 +146,10 @@ export const Tooltip: FC<TooltipProps> = React.memo(
         ],
       });
 
+      const parentComponents = useParentComponents();
       const gestureType: Gestures = useGestures(
         refs.reference?.current as HTMLElement,
-        preventTouchMoveDefault
+        preventTouchMoveDefault ?? !parentComponents.includes('Carousel')
       );
 
       const toggle: Function =

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -212,7 +212,7 @@ export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
   /**
    * Determines the interaction that triggers
    * the equivalent of hover on touch interfaces.
-   * @default TooltipTouchInteraction.Tap
+   * @default TooltipTouchInteraction.TapAndHold
    */
   touchInteraction?: TooltipTouchInteraction;
   /**

--- a/src/hooks/useTruncate.tsx
+++ b/src/hooks/useTruncate.tsx
@@ -68,7 +68,7 @@ export const useTruncate = (options?: {
         WebkitLineClamp: options?.lineClamp || 1,
         overflowY: 'hidden',
         textOverflow: 'ellipsis',
-        wordBreak: 'break-all',
+        ...(isTextTruncated && { wordBreak: 'break-all' }),
         ...rest?.style,
       }}
     >

--- a/src/octuple.ts
+++ b/src/octuple.ts
@@ -72,6 +72,10 @@ import GradientContext, {
   Gradient,
 } from './components/ConfigProvider/GradientContext';
 
+import ParentComponentsContext, {
+  ParentComponentsContextProvider,
+} from './components/ConfigProvider/ParentComponentsContext';
+
 import ThemeContext, {
   ThemeContextProvider,
 } from './components/ConfigProvider/ThemeContext';
@@ -485,6 +489,8 @@ export {
   PanelHeader,
   PanelPlacement,
   PanelSize,
+  ParentComponentsContext,
+  ParentComponentsContextProvider,
   PersistentBar,
   PersistentBarType,
   Pill,


### PR DESCRIPTION
## SUMMARY:
- Fixes an issue on mobile / touch devices where the tooltip `preventTouchMoveDefault` behavior would prevent carousels from being draggable.
- Fixes the JSDoc annotation for the tooltip `touchInteraction` prop to correctly reflect the default: `TooltipTouchInteraction.TapAndHold`

> NOTE: Once this is released in a new version, https://github.com/EightfoldAI/vscode/pull/58487 and https://github.com/EightfoldAI/vscode/pull/58660 can & should be reverted. 

## GITHUB ISSUE (Open Source Contributors)
N/A

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-86212

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Load the Octuple storybook for Carousel on a mobile device, or on desktop using the mobile view inside of the Chrome Dev Tools (`⌘ ⇧ M`)
In the new "Scroller with Tooltips" story:
- [ ] Tapping on the text inside the card shows a tooltip with the same text.
- [ ] Pressing on the text and dragging left/right moves the carousel cards.