### PR TITLE
fix: tab: fixes stat tabs word wrap and spacing when border is false

### DIFF
--- a/src/components/Tabs/tabs.module.scss
+++ b/src/components/Tabs/tabs.module.scss
@@ -278,7 +278,24 @@
     }
 
     &:not(.bordered) {
-      padding: 0;
+      padding: $space-ml 0;
+
+      .tab:not(.tab-rtl) {
+        &:first-of-type {
+          margin-left: 0;
+        }
+        &:last-of-type {
+          margin-right: 0;
+        }
+      }
+      .tab-rtl {
+        &:first-of-type {
+          margin-right: 0;
+        }
+        &:last-of-type {
+          margin-left: 0;
+        }
+      }
 
       &.divider {
         padding: 0;
@@ -355,13 +372,13 @@
         font-size: $text-font-size-3;
         line-height: $text-line-height-3;
         white-space: normal;
-        word-break: break-all;
 
         &.line-clamp {
           display: -webkit-box;
           -webkit-box-orient: vertical;
           overflow-y: hidden;
           text-overflow: ellipsis;
+          word-break: break-all;
         }
       }
 
@@ -743,7 +760,24 @@
       }
 
       &:not(.bordered) {
-        padding: 0;
+        padding: $space-s 0;
+
+        .tab:not(.tab-rtl) {
+          &:first-of-type {
+            margin-left: 0;
+          }
+          &:last-of-type {
+            margin-right: 0;
+          }
+        }
+        .tab-rtl {
+          &:first-of-type {
+            margin-right: 0;
+          }
+          &:last-of-type {
+            margin-left: 0;
+          }
+        }
 
         &.divider {
           padding: 0;
@@ -835,7 +869,24 @@
       }
 
       &:not(.bordered) {
-        padding: 0;
+        padding: $space-xs 0;
+
+        .tab:not(.tab-rtl) {
+          &:first-of-type {
+            margin-left: 0;
+          }
+          &:last-of-type {
+            margin-right: 0;
+          }
+        }
+        .tab-rtl {
+          &:first-of-type {
+            margin-right: 0;
+          }
+          &:last-of-type {
+            margin-left: 0;
+          }
+        }
 
         &.divider {
           padding: 0;


### PR DESCRIPTION
## SUMMARY:
Updates Stat Tabs layout fixing line clamp word break bug and insets. Addresses TODOs noted [here](https://github.com/EightfoldAI/vscode/blob/master/www/react/src/apps/careerHub/profile/components/ProfileSuccessionsDetailsWidget/SkillAssessmentViewer.module.scss#L3-L28).

- Removes horizontal `padding` when `bordered` is `false`, but preserves vertical `padding` to preserve existing layouts
- Removes internal `margin-left` and `margin-right` from first and last `Stat` when `bordered` is `false`
- Moves `word-break: break-all;` to only apply when `lineClamp` is active

Before:
![opportunity](https://github.com/EightfoldAI/octuple/assets/99700808/c0c0aa2b-127e-4da5-aee6-f5a8053549b2)

After:
![afterFixup](https://github.com/EightfoldAI/octuple/assets/99700808/32c06c42-87be-4da6-be31-8c4214de6b26)



## JIRA TASK (Eightfold Employees Only):
ENG-87058

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `Stat Tabs` stories behave as expected.