### PR TITLE
fix: accordion: reverts fit content change in sass

### DIFF
--- a/src/components/Accordion/accordion.module.scss
+++ b/src/components/Accordion/accordion.module.scss
@@ -1,7 +1,6 @@
 .accordion-container {
   font-family: var(--accordion-font-family);
   overflow: hidden;
-  min-width: fit-content;
 
   &.accordion-border {
     border: var(--accordion-border);


### PR DESCRIPTION
## SUMMARY:
reverts sass change to previous by removing `width: fit-content`

## JIRA TASK (Eightfold Employees Only):
ENG-89696

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull the pr branch and run `yarn` and `yarn storybook`. Verify the `Accordion` stories behave as expected.