### PR TITLE
chore: tooltip: revert width css change

### DIFF
--- a/src/components/Progress/Progress.stories.tsx
+++ b/src/components/Progress/Progress.stories.tsx
@@ -234,7 +234,6 @@ const Success_Segment_Story: ComponentStory<typeof Progress> = (args) => {
           success={{ percent: 30 }}
           showSuccessLabel
           showValueLabel
-          width={200}
         />
       </Tooltip>
       <div style={{ width: 120 }}>

--- a/src/components/Tooltip/tooltip.module.scss
+++ b/src/components/Tooltip/tooltip.module.scss
@@ -2,7 +2,6 @@ $tooltip-arrow-shadow: 0px 1px 2px rgba(15, 20, 31, 0.12);
 
 .referenceWrapper {
   display: inline-block;
-  width: fit-content;
 
   // Ensure portaled tooltip triggers are above when triggerAbove.
   &.trigger-above[aria-expanded='true'] {


### PR DESCRIPTION
## SUMMARY:
Reverts one line of css and a patch to a `Progress` story, upon further review there were a couple other scenarios this change regressed, so might need to wait for v3.0.0

## JIRA TASK (Eightfold Employees Only):
N/A

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:
N/A

## TEST PLAN:
Pull the PR brach and run `yarn` and `yarn storybook`. Verify the following stories behave as expected: `Progress` `Success Segment` and `Table` `Ellipsis with Tooltip`.