### PR TITLE
fix: inlinesvg: adds cross fetch dep to avoid fetch api reference errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/shallowequal": "1.1.1",
     "async-validator": "4.1.0",
     "bodymovin": "4.13.0",
+    "cross-fetch": "4.0.0",
     "date-fns": "2.28.0",
     "dayjs": "1.11.3",
     "dom-align": "1.12.3",

--- a/src/components/InlineSvg/InlineSvg.test.tsx
+++ b/src/components/InlineSvg/InlineSvg.test.tsx
@@ -1,14 +1,26 @@
 import '@testing-library/jest-dom/extend-expect';
-
+import fetch from 'cross-fetch';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { InlineSvg } from './InlineSvg';
 
+jest.mock('cross-fetch', () => {
+  return jest.fn(() =>
+    Promise.resolve({
+      text: () => '<svg>Mock SVG</svg>',
+    })
+  );
+});
+
 describe('InlineSvg', () => {
   const url = 'https://static.vscdn.net/images/learning-opp.svg';
   const width = '300px';
   const height = '200px';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   test('renders a skeleton while loading the SVG image if enabled', async () => {
     const { container } = render(
@@ -41,27 +53,21 @@ describe('InlineSvg', () => {
   });
 
   test('Should call fetchSvg only once', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve({ text: () => '<svg>Mock SVG</svg>' })
-    ) as jest.Mock;
     const { rerender } = render(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Should call fetchSvg twice', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve({ text: () => '<svg>Mock SVG</svg>' })
-    ) as jest.Mock;
     const { rerender } = render(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url-diff" />);
     rerender(<InlineSvg url="mock-url-diff" />);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/InlineSvg/InlineSvg.tsx
+++ b/src/components/InlineSvg/InlineSvg.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState, useRef, FC, Ref } from 'react';
+import fetch from 'cross-fetch';
 import { InlineSvgProps } from './InlineSvg.types';
 import { Icon, IconName } from '../Icon';
 import { Skeleton, SkeletonVariant } from '../Skeleton';
@@ -46,6 +47,15 @@ export const InlineSvg: FC<InlineSvgProps> = React.forwardRef(
         }
         try {
           const response: Response = await fetch(_url);
+
+          // If the response is not ok (404, 500 ...), set the error state and return
+          if (!response.ok) {
+            console.error(response.status);
+            setHasError(true);
+            setIsLoading(false);
+            return;
+          }
+
           const text: string = await response.text();
 
           const parser: DOMParser = new DOMParser();
@@ -59,6 +69,7 @@ export const InlineSvg: FC<InlineSvgProps> = React.forwardRef(
           svgRef.current.innerHTML = text;
           setIsLoading(false);
         } catch (error) {
+          // Set the error state upon network error rejection of the try block
           console.error(error);
           setHasError(true);
           setIsLoading(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7459,6 +7459,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-fetch@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -12783,6 +12790,13 @@ node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
## SUMMARY:
The fetch API is supported by browsers, but when running Jest using older Node versions, it throws null reference errors as the API is not supported. The [cross-fetch](https://www.npmjs.com/package/cross-fetch) dep fixes this.

## JIRA TASK (Eightfold Employees Only):
ENG-91718

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Pull the PR branch and run `yarn` and `yarn storybook`. Verify the `InlineSvg` stories behave as expected.