### PR TITLE
fix: reset accordion z-index

### DIFF
--- a/src/components/Accordion/accordion.module.scss
+++ b/src/components/Accordion/accordion.module.scss
@@ -68,6 +68,7 @@
     position: relative;
     width: 100%;
     transition: background-color $motion-duration-fast $motion-easing-easeout;
+    z-index: 0;
 
     .clickable-area {
       bottom: 0;

--- a/src/components/Accordion/accordion.module.scss
+++ b/src/components/Accordion/accordion.module.scss
@@ -78,6 +78,7 @@
       position: absolute;
       right: 0;
       top: 0;
+      z-index: 0;
 
       &:focus,
       &:focus-visible {
@@ -88,6 +89,7 @@
     // By default we ensure the header content does not obscure the clickable area.
     .accordion-header-container {
       pointer-events: none;
+      z-index: 1;
 
       // If there's custom content in the header, its interactive children should be clickable or selectable.
       a[href],
@@ -175,6 +177,7 @@
 
   .accordion-icon-button {
     transition: transform $motion-duration-fast;
+    z-index: 1;
 
     &.expanded-icon-button {
       transform: rotate(180deg);

--- a/src/components/Accordion/accordion.module.scss
+++ b/src/components/Accordion/accordion.module.scss
@@ -78,7 +78,6 @@
       position: absolute;
       right: 0;
       top: 0;
-      z-index: 0;
 
       &:focus,
       &:focus-visible {
@@ -89,7 +88,6 @@
     // By default we ensure the header content does not obscure the clickable area.
     .accordion-header-container {
       pointer-events: none;
-      z-index: 1;
 
       // If there's custom content in the header, its interactive children should be clickable or selectable.
       a[href],
@@ -177,7 +175,6 @@
 
   .accordion-icon-button {
     transition: transform $motion-duration-fast;
-    z-index: 1;
 
     &.expanded-icon-button {
       transform: rotate(180deg);


### PR DESCRIPTION
## SUMMARY:
This change establishes a zindex root for the accordion summary container div. This prevents its children from impacting surrounding elements that would otherwise have a higher z-index by DOM order.

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-94042

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
- pull this locally and bring up storybook
- confirm that the accordion presentation is the same without the z-index values as it is with them
OR
 - view the steps on the JIRA ticket https://eightfoldai.atlassian.net/browse/ENG-94042
 - check those repo steps for sandbox for octuple upgrade PR: https://github.com/EightfoldAI/vscode/pull/61221
 - manually apply the one line css change in devtools and observe that it fixes the z-index layout issues