### PR TITLE
fix: type errors & storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@types/node": "16.11.26",
     "@types/react": "17.0.80",
     "@types/react-color": "3.0.6",
-    "@types/react-dom": "17.0.11",
+    "@types/react-dom": "17.0.25",
     "@types/react-window": "1.8.2",
     "@types/webpack": "5.28.0",
     "@typescript-eslint/eslint-plugin": "5.14.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "prerelease:patch": "standard-version --release-as patch --prerelease",
     "prerelease:major": "standard-version --release-as major --prerelease",
     "prepublishOnly": "clean-package",
-    "postpublish": "clean-package restore"
+    "postpublish": "clean-package restore",
+    "typecheck": "tsc --noEmit --skipLibCheck"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/InfoBar/InfoBar.types.ts
+++ b/src/components/InfoBar/InfoBar.types.ts
@@ -28,7 +28,8 @@ export type InfoBarLocale = {
   lang: Locale;
 };
 
-export interface InfoBarsProps extends OcBaseProps<HTMLDivElement> {
+export interface InfoBarsProps
+  extends Omit<OcBaseProps<HTMLDivElement>, 'content'> {
   /**
    * Custom classes for the action button.
    * May be implemnted without the need for a button.

--- a/src/components/Skill/Skill.types.ts
+++ b/src/components/Skill/Skill.types.ts
@@ -299,7 +299,7 @@ export interface SharedSkillProps extends OcBaseProps<HTMLDivElement> {
   title?: string;
 }
 
-export interface SkillBlockProps extends SharedSkillProps {
+export interface SkillBlockProps extends Omit<SharedSkillProps, 'content'> {
   /**
    * The Skill animates expand and collapse.
    * @default true

--- a/src/components/Stepper/Stepper.types.ts
+++ b/src/components/Stepper/Stepper.types.ts
@@ -77,7 +77,7 @@ export type StepperLocale = {
   lang: Locale;
 };
 
-export interface Step extends OcBaseProps<HTMLDivElement> {
+export interface Step extends Omit<OcBaseProps<HTMLDivElement>, 'content'> {
   /**
    * Whether the Step is complete.
    * Use when the Stepper isn't readonly.

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -39,7 +39,8 @@ export enum TooltipTouchInteraction {
   TapAndHold = 'TapAndHold',
 }
 
-export interface TooltipProps extends Omit<OcBaseProps<HTMLDivElement>, 'ref'> {
+export interface TooltipProps
+  extends Omit<OcBaseProps<HTMLDivElement>, 'ref' | 'content'> {
   /**
    * Should animate the Tooltip transitions.
    * @default true

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,12 +4729,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@17.0.11":
-  version "17.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
-  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+"@types/react-dom@17.0.25":
+  version "17.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
+  integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==
   dependencies:
-    "@types/react" "*"
+    "@types/react" "^17"
 
 "@types/react-dom@>=16.9.0":
   version "17.0.14"
@@ -4773,7 +4773,7 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@17.0.80":
+"@types/react@17.0.80", "@types/react@^17":
   version "17.0.80"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.80.tgz#a5dfc351d6a41257eb592d73d3a85d3b7dbcbb41"
   integrity sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==


### PR DESCRIPTION
## SUMMARY:
Fixes some type errors that were blocking storybook from running in development as a result of upgrading `@types/react` in #803.

Causes:
- A new `content` prop was added to all HTML elements in @types/react. This is defined to be a `string` upstream (I believe for the `<meta>` tag specifically), and overriding it with `React.ReactNode` failed after upgrading.
- @types/react-dom was not previously upgraded which broke typechecking on the Portal component.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Running `yarn storybook` in dev should work successfully.