### PR TITLE
Added a hidden section for announcing zoom/rotate values

### DIFF
--- a/src/components/Upload/Cropper/EasyCrop.tsx
+++ b/src/components/Upload/Cropper/EasyCrop.tsx
@@ -54,8 +54,11 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
   const [cropSize, setCropSize] = useState<Size>({ width: 0, height: 0 });
   const [zoomVal, setZoomVal] = useState<number>(INIT_ZOOM);
   const [rotateVal, setRotateVal] = useState<number>(INIT_ROTATE);
-  const [buttonType, setButtonType] = useState<
-    'in' | 'out' | 'left' | 'right' | ''
+  const [zoomButtonDirection, setZoomButtonDirection] = useState<
+    'in' | 'out' | ''
+  >('');
+  const [rotateButtonDirection, setRotateButtonDirection] = useState<
+    'right' | 'left' | ''
   >('');
   const cropPixelsRef: React.MutableRefObject<Area> = useRef<Area>({
     width: 0,
@@ -140,7 +143,8 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
                 path: IconName.mdiMinus,
               }}
               onClick={() => {
-                setButtonType('out');
+                setRotateButtonDirection('');
+                setZoomButtonDirection('out');
                 setZoomVal(zoomVal - ZOOM_STEP);
               }}
               shape={ButtonShape.Round}
@@ -155,9 +159,10 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               max={maxZoom}
               min={minZoom}
               onChange={(value: number | number[]) => {
+                setRotateButtonDirection('');
                 zoomVal < Number(value)
-                  ? setButtonType('in')
-                  : setButtonType('out');
+                  ? setZoomButtonDirection('in')
+                  : setZoomButtonDirection('out');
                 setZoomVal(Number(value));
               }}
               hideMax
@@ -177,7 +182,8 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
                 path: IconName.mdiPlus,
               }}
               onClick={() => {
-                setButtonType('in');
+                setRotateButtonDirection('');
+                setZoomButtonDirection('in');
                 setZoomVal(zoomVal + ZOOM_STEP);
               }}
               shape={ButtonShape.Round}
@@ -192,7 +198,7 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
             aria-live="assertive"
             role="status"
           >
-            {buttonType === 'in'
+            {zoomButtonDirection === 'in'
               ? `${zoomInButtonAriaLabelText} ${parseFloat(zoomVal.toFixed(2))}`
               : `${zoomOutButtonAriaLabelText} ${parseFloat(
                   zoomVal.toFixed(2)
@@ -213,7 +219,8 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
                 path: IconName.mdiRotateLeft,
               }}
               onClick={() => {
-                setButtonType('left');
+                setZoomButtonDirection('');
+                setRotateButtonDirection('left');
                 setRotateVal(rotateVal - ROTATE_STEP);
               }}
               shape={ButtonShape.Round}
@@ -228,9 +235,10 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               max={MAX_ROTATE}
               min={MIN_ROTATE}
               onChange={(value: number | number[]) => {
+                setZoomButtonDirection('');
                 rotateVal < Number(value)
-                  ? setButtonType('right')
-                  : setButtonType('left');
+                  ? setRotateButtonDirection('right')
+                  : setRotateButtonDirection('left');
                 setRotateVal(Number(value));
               }}
               hideMax
@@ -250,7 +258,7 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
                 path: IconName.mdiRotateRight,
               }}
               onClick={() => {
-                setButtonType('right');
+                setRotateButtonDirection('right');
                 setRotateVal(rotateVal + ROTATE_STEP);
               }}
               shape={ButtonShape.Round}
@@ -265,7 +273,7 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
             aria-live="assertive"
             role="status"
           >
-            {buttonType === 'right'
+            {rotateButtonDirection === 'right'
               ? `${rotateRightButtonAriaLabelText} ${rotateVal}`
               : `${rotateLeftButtonAriaLabelText} ${rotateVal}`}
           </div>

--- a/src/components/Upload/Cropper/EasyCrop.tsx
+++ b/src/components/Upload/Cropper/EasyCrop.tsx
@@ -54,6 +54,7 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
   const [cropSize, setCropSize] = useState<Size>({ width: 0, height: 0 });
   const [zoomVal, setZoomVal] = useState<number>(INIT_ZOOM);
   const [rotateVal, setRotateVal] = useState<number>(INIT_ROTATE);
+  const [buttonType, setButtonType] = useState<string>('');
   const cropPixelsRef: React.MutableRefObject<Area> = useRef<Area>({
     width: 0,
     height: 0,
@@ -136,7 +137,10 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               iconProps={{
                 path: IconName.mdiMinus,
               }}
-              onClick={() => setZoomVal(zoomVal - ZOOM_STEP)}
+              onClick={() => {
+                setButtonType('out');
+                setZoomVal(zoomVal - ZOOM_STEP);
+              }}
               shape={ButtonShape.Round}
               size={ButtonSize.Small}
               theme={mergedTheme}
@@ -148,7 +152,12 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               containerClassNames={styles.cropperSlider}
               max={maxZoom}
               min={minZoom}
-              onChange={(value: number | number[]) => setZoomVal(Number(value))}
+              onChange={(value: number | number[]) => {
+                zoomVal < Number(value)
+                  ? setButtonType('in')
+                  : setButtonType('out');
+                setZoomVal(Number(value));
+              }}
               hideMax
               hideMin
               step={ZOOM_STEP}
@@ -165,7 +174,10 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               iconProps={{
                 path: IconName.mdiPlus,
               }}
-              onClick={() => setZoomVal(zoomVal + ZOOM_STEP)}
+              onClick={() => {
+                setButtonType('in');
+                setZoomVal(zoomVal + ZOOM_STEP);
+              }}
               shape={ButtonShape.Round}
               size={ButtonSize.Small}
               theme={mergedTheme}
@@ -173,6 +185,17 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               variant={ButtonVariant.SystemUI}
             />
           </Stack>
+          <div
+            className={styles.visuallyhidden}
+            aria-live="assertive"
+            role="status"
+          >
+            {buttonType === 'in'
+              ? `${zoomInButtonAriaLabelText} ${parseFloat(zoomVal.toFixed(2))}`
+              : `${zoomOutButtonAriaLabelText} ${parseFloat(
+                  zoomVal.toFixed(2)
+                )}`}
+          </div>
         </section>
       )}
       {rotate && (
@@ -187,7 +210,10 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               iconProps={{
                 path: IconName.mdiRotateLeft,
               }}
-              onClick={() => setRotateVal(rotateVal - ROTATE_STEP)}
+              onClick={() => {
+                setButtonType('left');
+                setRotateVal(rotateVal - ROTATE_STEP);
+              }}
               shape={ButtonShape.Round}
               size={ButtonSize.Small}
               theme={mergedTheme}
@@ -199,9 +225,12 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               containerClassNames={styles.cropperSlider}
               max={MAX_ROTATE}
               min={MIN_ROTATE}
-              onChange={(value: number | number[]) =>
-                setRotateVal(Number(value))
-              }
+              onChange={(value: number | number[]) => {
+                rotateVal < Number(value)
+                  ? setButtonType('right')
+                  : setButtonType('left');
+                setRotateVal(Number(value));
+              }}
               hideMax
               hideMin
               step={ROTATE_STEP}
@@ -218,7 +247,10 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               iconProps={{
                 path: IconName.mdiRotateRight,
               }}
-              onClick={() => setRotateVal(rotateVal + ROTATE_STEP)}
+              onClick={() => {
+                setButtonType('right');
+                setRotateVal(rotateVal + ROTATE_STEP);
+              }}
               shape={ButtonShape.Round}
               size={ButtonSize.Small}
               theme={mergedTheme}
@@ -226,6 +258,15 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               variant={ButtonVariant.SystemUI}
             />
           </Stack>
+          <div
+            className={styles.visuallyhidden}
+            aria-live="assertive"
+            role="status"
+          >
+            {buttonType === 'right'
+              ? `${rotateRightButtonAriaLabelText} ${rotateVal}`
+              : `${rotateLeftButtonAriaLabelText} ${rotateVal}`}
+          </div>
         </section>
       )}
     </>

--- a/src/components/Upload/Cropper/EasyCrop.tsx
+++ b/src/components/Upload/Cropper/EasyCrop.tsx
@@ -54,7 +54,9 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
   const [cropSize, setCropSize] = useState<Size>({ width: 0, height: 0 });
   const [zoomVal, setZoomVal] = useState<number>(INIT_ZOOM);
   const [rotateVal, setRotateVal] = useState<number>(INIT_ROTATE);
-  const [buttonType, setButtonType] = useState<string>('');
+  const [buttonType, setButtonType] = useState<
+    'in' | 'out' | 'left' | 'right' | ''
+  >('');
   const cropPixelsRef: React.MutableRefObject<Area> = useRef<Area>({
     width: 0,
     height: 0,

--- a/src/components/Upload/Cropper/cropper.module.scss
+++ b/src/components/Upload/Cropper/cropper.module.scss
@@ -25,6 +25,14 @@
     }
   }
 
+  .visuallyhidden {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
   .cropper-zoom-control {
     margin-top: $space-ml;
   }


### PR DESCRIPTION
## SUMMARY:
Added a hidden section for announcing zoom/rotate values

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
Jira task - https://eightfoldai.atlassian.net/browse/ENG-95132

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

- pull branch down locally and start storybook (yarn storybook)
- with screen reader on,  zoom and rotate the image and observe the zoomed/rotated values being announced. 
