### PR TITLE
fix: improve basic snackbar and infobar layouts

### DIFF
--- a/src/components/InfoBar/InfoBar.stories.tsx
+++ b/src/components/InfoBar/InfoBar.stories.tsx
@@ -58,6 +58,7 @@ export const Neutral = InfoBar_Story.bind({});
 export const Positive = InfoBar_Story.bind({});
 export const Warning = InfoBar_Story.bind({});
 export const Disruptive = InfoBar_Story.bind({});
+export const Basic = InfoBar_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
@@ -67,6 +68,7 @@ export const __namedExportsOrder = [
   'Positive',
   'Warning',
   'Disruptive',
+  'Basic',
 ];
 
 const infoBarArgs: Object = {
@@ -121,4 +123,14 @@ Disruptive.args = {
   ...infoBarArgs,
   icon: IconName.mdiInformation,
   type: InfoBarType.disruptive,
+};
+
+Basic.args = {
+  ...infoBarArgs,
+  icon: IconName.mdiInformation,
+  type: InfoBarType.neutral,
+  closeButtonProps: null,
+  closeIcon: null,
+  closable: false,
+  actionButtonProps: null,
 };

--- a/src/components/InfoBar/infoBar.module.scss
+++ b/src/components/InfoBar/infoBar.module.scss
@@ -184,6 +184,7 @@
       display: flex;
       min-width: 100%;
       padding-top: $space-xs;
+      padding-bottom: $space-xs;
     }
 
     .action-button {

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -83,6 +83,17 @@ const Default_Story: ComponentStory<typeof Snackbar> = (args) => (
   </>
 );
 
+const Basic_Story: ComponentStory<typeof Snackbar> = (args) => (
+  <>
+    <Button
+      text="Serve snack"
+      onClick={() => snack.serve({ ...args })}
+      size={ButtonSize.Small}
+    />
+    <SnackbarContainer />
+  </>
+);
+
 const Closable_Story: ComponentStory<typeof Snackbar> = (args) => (
   <>
     <Button
@@ -106,13 +117,19 @@ const With_Action_Story: ComponentStory<typeof Snackbar> = (args) => (
 );
 
 export const Default = Default_Story.bind({});
+export const Basic = Basic_Story.bind({});
 export const Closable = Closable_Story.bind({});
 export const With_Action = With_Action_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
 // See https://www.npmjs.com/package/babel-plugin-named-exports-order
-export const __namedExportsOrder = ['Default', 'Closable', 'With_Action'];
+export const __namedExportsOrder = [
+  'Default',
+  'Basic',
+  'Closable',
+  'With_Action',
+];
 
 const snackArgs: Object = {
   position: 'top-center',
@@ -135,6 +152,13 @@ const snackArgs: Object = {
 
 Default.args = {
   ...snackArgs,
+  duration: 3000,
+};
+
+Basic.args = {
+  ...snackArgs,
+  content: 'Body 2 is used in this snackbar.',
+  closable: false,
   duration: 3000,
 };
 


### PR DESCRIPTION
## SUMMARY:
In cases where InfoBars and SnackBars were used without action buttons and weren't closeable, the content was not centered in the container. This adds padding to the bottom of the message to maintain layout balance in such cases.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-104202

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change
- [x] This is a style change only

## TEST PLAN:
- pull the PR down locally and view the new "basic" stories which are one liner snackbars and infobars
- confirm that layout is vertically balanced
- confirm that other stories for SnackBar and InfoBar are not impacted and still look good