### PR TITLE
feat: feature flags: Add feature flag config for Octuple

### DIFF
--- a/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -277,18 +277,18 @@ describe('ConfigProvider', () => {
   test('Provides feature flag values if provided as a prop', () => {
     const { result } = renderHook(() => useFeatureFlags(), {
       wrapper: ({ children }) => (
-        <ConfigProvider featureFlags={{ lazyLoadPanelContent: true }}>
+        <ConfigProvider featureFlags={{ panelLazyLoadContent: true }}>
           {children}
         </ConfigProvider>
       ),
     });
-    expect(result.current.lazyLoadPanelContent).toBeTruthy();
+    expect(result.current.panelLazyLoadContent).toBeTruthy();
   });
 
   test('Provides default feature flag values if not provided as a prop', () => {
     const { result } = renderHook(() => useFeatureFlags(), {
       wrapper: ConfigProvider,
     });
-    expect(result.current.lazyLoadPanelContent).toBeFalsy();
+    expect(result.current.panelLazyLoadContent).toBeFalsy();
   });
 });

--- a/src/components/ConfigProvider/ConfigProvider.test.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.test.tsx
@@ -13,6 +13,7 @@ import esES from '../Locale/es_ES';
 import iconSet from '../Icon/selection.json';
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
+import { useFeatureFlags } from './FeatureFlagProvider';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -271,5 +272,23 @@ describe('ConfigProvider', () => {
       wrapper: ConfigProvider,
     });
     expect(result.current.form).toEqual(undefined);
+  });
+
+  test('Provides feature flag values if provided as a prop', () => {
+    const { result } = renderHook(() => useFeatureFlags(), {
+      wrapper: ({ children }) => (
+        <ConfigProvider featureFlags={{ lazyLoadPanelContent: true }}>
+          {children}
+        </ConfigProvider>
+      ),
+    });
+    expect(result.current.lazyLoadPanelContent).toBeTruthy();
+  });
+
+  test('Provides default feature flag values if not provided as a prop', () => {
+    const { result } = renderHook(() => useFeatureFlags(), {
+      wrapper: ConfigProvider,
+    });
+    expect(result.current.lazyLoadPanelContent).toBeFalsy();
   });
 });

--- a/src/components/ConfigProvider/ConfigProvider.tsx
+++ b/src/components/ConfigProvider/ConfigProvider.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React, {
   createContext,
   FC,
@@ -7,26 +5,30 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import LocaleReceiver from '../LocaleProvider/LocaleReceiver';
-import LocaleProvider from '../LocaleProvider';
-import { registerFont, registerTheme } from './Theming/styleGenerator';
-import { ConfigProviderProps, IConfigContext } from './ConfigProvider.types';
-import {
-  IRegisterFont,
-  IRegisterTheme,
-  FontOptions,
-  ThemeOptions,
-} from './Theming';
+
 import { useFocusVisibleClassName } from '../../hooks/useFocusVisibleClassName';
-import { ParentComponentsContextProvider } from './ParentComponentsContext';
+import { canUseDocElement } from '../../shared/utilities';
+import { OcFormProvider } from '../Form/Internal';
+import { ValidateMessages } from '../Form/Internal/OcForm.types';
+import defaultLocale from '../Locale/Default';
+import LocaleProvider from '../LocaleProvider';
+import LocaleReceiver from '../LocaleProvider/LocaleReceiver';
+import { ConfigProviderProps, IConfigContext } from './ConfigProvider.types';
 import { DisabledContextProvider } from './DisabledContext';
+import { FeatureFlagContextProvider } from './FeatureFlagProvider';
 import { GradientContextProvider } from './GradientContext';
+import { ParentComponentsContextProvider } from './ParentComponentsContext';
 import { ShapeContextProvider } from './ShapeContext';
 import { SizeContextProvider } from './SizeContext';
-import { ValidateMessages } from '../Form/Internal/OcForm.types';
-import { OcFormProvider } from '../Form/Internal';
-import defaultLocale from '../Locale/Default';
-import { canUseDocElement } from '../../shared/utilities';
+import {
+  FontOptions,
+  IRegisterFont,
+  IRegisterTheme,
+  ThemeOptions,
+} from './Theming';
+import { registerFont, registerTheme } from './Theming/styleGenerator';
+
+('use client');
 
 const ConfigContext: React.Context<Partial<IConfigContext>> = createContext<
   Partial<IConfigContext>
@@ -54,6 +56,7 @@ const ConfigProvider: FC<ConfigProviderProps> = ({
   locale,
   shape,
   size,
+  featureFlags,
   themeOptions: defaultThemeOptions,
 }) => {
   const [fontOptions, setFontOptions] =
@@ -159,6 +162,12 @@ const ConfigProvider: FC<ConfigProviderProps> = ({
       </ParentComponentsContextProvider>
     );
   }
+
+  childNode = (
+    <FeatureFlagContextProvider featureFlags={featureFlags}>
+      {childNode}
+    </FeatureFlagContextProvider>
+  );
 
   return (
     <LocaleReceiver>

--- a/src/components/ConfigProvider/ConfigProvider.types.ts
+++ b/src/components/ConfigProvider/ConfigProvider.types.ts
@@ -1,17 +1,19 @@
 import React from 'react';
-import {
-  IRegisterFont,
-  IRegisterTheme,
-  FontOptions,
-  ThemeOptions,
-} from './Theming';
-import type { Locale } from '../LocaleProvider';
+
+import { RequiredMark } from '../Form/Form.types';
+import { ValidateMessages } from '../Form/Internal/OcForm.types';
 import { FocusVisibleOptions } from './A11y';
+import { FeatureFlags } from './FeatureFlagProvider';
 import { Shape } from './ShapeContext';
 import { Size } from './SizeContext';
-import { ValidateMessages } from '../Form/Internal/OcForm.types';
-import { RequiredMark } from '../Form/Form.types';
+import {
+  FontOptions,
+  IRegisterFont,
+  IRegisterTheme,
+  ThemeOptions,
+} from './Theming';
 
+import type { Locale } from '../LocaleProvider';
 export type DirectionType = 'ltr' | 'rtl' | undefined;
 
 export interface ConfigContextProps {
@@ -76,6 +78,10 @@ export interface ConfigProviderProps {
    * Used by the disabled context provider to disable components.
    */
   disabled?: boolean;
+  /**
+   * Options for Octuple features that can be conditionally enabled.
+   */
+  featureFlags?: FeatureFlags;
   /**
    * Options for font
    * @default { fontFamily: 'Source Sans Pro', fontSize: '16px', fontStack: '-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif' }

--- a/src/components/ConfigProvider/FeatureFlagProvider.tsx
+++ b/src/components/ConfigProvider/FeatureFlagProvider.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, FC, useContext, useMemo } from 'react';
 
 export interface FeatureFlags {
-  lazyLoadPanelContent?: boolean;
+  panelLazyLoadContent?: boolean;
 }
 
 export interface FeatureFlagContextProps {
@@ -14,7 +14,7 @@ export interface FeatureFlagContextProps {
 const FeatureFlagContext = createContext<FeatureFlags>(undefined);
 
 const defaultFeatureFlagValues: FeatureFlags = {
-  lazyLoadPanelContent: false,
+  panelLazyLoadContent: false,
 };
 
 export const FeatureFlagContextProvider: FC<FeatureFlagContextProps> = ({

--- a/src/components/ConfigProvider/FeatureFlagProvider.tsx
+++ b/src/components/ConfigProvider/FeatureFlagProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React, { createContext, FC, useContext, useMemo } from 'react';
+
+export interface FeatureFlags {
+  lazyLoadPanelContent?: boolean;
+}
+
+export interface FeatureFlagContextProps {
+  featureFlags?: FeatureFlags;
+  children?: React.ReactNode;
+}
+
+const FeatureFlagContext = createContext<FeatureFlags>(undefined);
+
+const defaultFeatureFlagValues: FeatureFlags = {
+  lazyLoadPanelContent: false,
+};
+
+export const FeatureFlagContextProvider: FC<FeatureFlagContextProps> = ({
+  children,
+  featureFlags,
+}) => {
+  const ancestorFeatureFlags = useContext(FeatureFlagContext);
+
+  const currentContext = useMemo(
+    () => ({
+      ...(defaultFeatureFlagValues || {}),
+      ...(ancestorFeatureFlags || {}),
+      ...(featureFlags || {}),
+    }),
+    [featureFlags, ancestorFeatureFlags]
+  );
+
+  return (
+    <FeatureFlagContext.Provider value={currentContext}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+};
+
+/**
+ * Hook to retreive a set of currently configured features flags
+ * @returns The currently set feature flags.
+ */
+export const useFeatureFlags = () =>
+  useContext(FeatureFlagContext) || { ...defaultFeatureFlagValues };
+
+export default FeatureFlagContext;

--- a/src/components/ConfigProvider/FeatureFlagProvider.tsx
+++ b/src/components/ConfigProvider/FeatureFlagProvider.tsx
@@ -14,6 +14,11 @@ export interface FeatureFlagContextProps {
 const FeatureFlagContext = createContext<FeatureFlags>(undefined);
 
 const defaultFeatureFlagValues: FeatureFlags = {
+  /**
+   * This feature flag configures panels to only render their content if they are currently visible. This feature deprecates the
+   * `renderContentAlways` option and completely overrides its value when it is enabled.
+   * it overrides the behvavior of `renderContentAlways`
+   */
   panelLazyLoadContent: false,
 };
 
@@ -25,9 +30,9 @@ export const FeatureFlagContextProvider: FC<FeatureFlagContextProps> = ({
 
   const currentContext = useMemo(
     () => ({
-      ...(defaultFeatureFlagValues || {}),
-      ...(ancestorFeatureFlags || {}),
-      ...(featureFlags || {}),
+      ...defaultFeatureFlagValues,
+      ...ancestorFeatureFlags,
+      ...featureFlags,
     }),
     [featureFlags, ancestorFeatureFlags]
   );

--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -120,7 +120,7 @@ export default {
       options: ['top', 'right', 'bottom', 'left'],
       control: { type: 'radio' },
     },
-    lazyLoadPanelContent: {
+    panelLazyLoadContent: {
       control: { type: 'boolean' },
       defaultValue: false,
     },
@@ -129,7 +129,7 @@ export default {
     (Story, context) => (
       <ConfigProvider
         featureFlags={{
-          lazyLoadPanelContent: context.args.lazyLoadPanelContent,
+          panelLazyLoadContent: context.args.panelLazyLoadContent,
         }}
       >
         <Story />

--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -1,10 +1,13 @@
-import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React, { useState } from 'react';
+
+import { Button, ButtonVariant } from '../Button';
+import { ConfigProvider } from '../ConfigProvider';
+import { FeatureFlagContextProvider } from '../ConfigProvider/FeatureFlagProvider';
+import { IconName } from '../Icon';
 import { Panel, PanelSize } from './';
 import { PanelHeader } from './PanelHeader';
-import { Button, ButtonVariant } from '../Button';
-import { IconName } from '../Icon';
 
 export default {
   title: 'Panel',
@@ -117,8 +120,33 @@ export default {
       options: ['top', 'right', 'bottom', 'left'],
       control: { type: 'radio' },
     },
+    lazyLoadPanelContent: {
+      control: { type: 'boolean' },
+      defaultValue: false,
+    },
   },
+  decorators: [
+    (Story, context) => (
+      <ConfigProvider
+        featureFlags={{
+          lazyLoadPanelContent: context.args.lazyLoadPanelContent,
+        }}
+      >
+        <Story />
+      </ConfigProvider>
+    ),
+  ],
 } as ComponentMeta<typeof Panel>;
+
+const FeatureFlag_Story: ComponentStory<typeof FeatureFlagContextProvider> = (
+  args
+) => {
+  return (
+    <ConfigProvider featureFlags={args.featureFlags}>
+      {args.children}
+    </ConfigProvider>
+  );
+};
 
 const Panel_Story: ComponentStory<typeof Panel> = (args) => {
   const [visible, setVisible] = useState<boolean>(false);
@@ -405,6 +433,7 @@ const panelArgs: Object = {
   footerClassNames: 'my-panel-footer-class',
   autoFocus: true,
   focusTrap: true,
+  featureFlags: undefined,
 };
 
 Small.args = {

--- a/src/components/Panel/Panel.test.tsx
+++ b/src/components/Panel/Panel.test.tsx
@@ -6,6 +6,8 @@ import { Panel } from './';
 import { Button, ButtonVariant } from '../Button';
 import { IconName } from '../Icon';
 import { render } from '@testing-library/react';
+import { ConfigProvider } from '../ConfigProvider';
+import { FeatureFlagContextProvider } from '../ConfigProvider/FeatureFlagProvider';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -162,5 +164,53 @@ describe('Panel', () => {
       </Panel>
     );
     expect(queryByText('Content is not always rendered')).toBeNull();
+  });
+
+  test('Should not lazy load content when lazyLoadPanelContent is false', () => {
+    const { queryByText } = render(
+      <FeatureFlagContextProvider
+        featureFlags={{ lazyLoadPanelContent: false }}
+      >
+        <Panel>
+          <div>Content is not always rendered</div>
+        </Panel>
+      </FeatureFlagContextProvider>
+    );
+    expect(queryByText('Content is not always rendered')).toBeTruthy();
+  });
+
+  test('Should not render content when lazyLoadPanelContent is true and panel is hidden', () => {
+    const { queryByText } = render(
+      <FeatureFlagContextProvider featureFlags={{ lazyLoadPanelContent: true }}>
+        <Panel visible={false}>
+          <div>Content is not always rendered</div>
+        </Panel>
+      </FeatureFlagContextProvider>
+    );
+    expect(queryByText('Content is not always rendered')).toBeNull();
+  });
+
+  test('Should render content when lazyLoadPanelContent is true and panel is visible', () => {
+    const { queryByText } = render(
+      <FeatureFlagContextProvider featureFlags={{ lazyLoadPanelContent: true }}>
+        <Panel visible>
+          <div>Content is not always rendered</div>
+        </Panel>
+      </FeatureFlagContextProvider>
+    );
+    expect(queryByText('Content is not always rendered')).toBeTruthy();
+  });
+
+  test('Should respect render content always when lazyLoadPanelContent is false', () => {
+    const { queryByText } = render(
+      <FeatureFlagContextProvider
+        featureFlags={{ lazyLoadPanelContent: false }}
+      >
+        <Panel renderContentAlways>
+          <div>Content is not always rendered</div>
+        </Panel>
+      </FeatureFlagContextProvider>
+    );
+    expect(queryByText('Content is not always rendered')).toBeTruthy();
   });
 });

--- a/src/components/Panel/Panel.test.tsx
+++ b/src/components/Panel/Panel.test.tsx
@@ -166,10 +166,10 @@ describe('Panel', () => {
     expect(queryByText('Content is not always rendered')).toBeNull();
   });
 
-  test('Should not lazy load content when lazyLoadPanelContent is false', () => {
+  test('Should not lazy load content when panelLazyLoadContent is false', () => {
     const { queryByText } = render(
       <FeatureFlagContextProvider
-        featureFlags={{ lazyLoadPanelContent: false }}
+        featureFlags={{ panelLazyLoadContent: false }}
       >
         <Panel>
           <div>Content is not always rendered</div>
@@ -179,9 +179,9 @@ describe('Panel', () => {
     expect(queryByText('Content is not always rendered')).toBeTruthy();
   });
 
-  test('Should not render content when lazyLoadPanelContent is true and panel is hidden', () => {
+  test('Should not render content when panelLazyLoadContent is true and panel is hidden', () => {
     const { queryByText } = render(
-      <FeatureFlagContextProvider featureFlags={{ lazyLoadPanelContent: true }}>
+      <FeatureFlagContextProvider featureFlags={{ panelLazyLoadContent: true }}>
         <Panel visible={false}>
           <div>Content is not always rendered</div>
         </Panel>
@@ -190,9 +190,9 @@ describe('Panel', () => {
     expect(queryByText('Content is not always rendered')).toBeNull();
   });
 
-  test('Should render content when lazyLoadPanelContent is true and panel is visible', () => {
+  test('Should render content when panelLazyLoadContent is true and panel is visible', () => {
     const { queryByText } = render(
-      <FeatureFlagContextProvider featureFlags={{ lazyLoadPanelContent: true }}>
+      <FeatureFlagContextProvider featureFlags={{ panelLazyLoadContent: true }}>
         <Panel visible>
           <div>Content is not always rendered</div>
         </Panel>
@@ -201,10 +201,10 @@ describe('Panel', () => {
     expect(queryByText('Content is not always rendered')).toBeTruthy();
   });
 
-  test('Should respect render content always when lazyLoadPanelContent is false', () => {
+  test('Should respect render content always when panelLazyLoadContent is false', () => {
     const { queryByText } = render(
       <FeatureFlagContextProvider
-        featureFlags={{ lazyLoadPanelContent: false }}
+        featureFlags={{ panelLazyLoadContent: false }}
       >
         <Panel renderContentAlways>
           <div>Content is not always rendered</div>

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -121,8 +121,8 @@ export const Panel = React.forwardRef<PanelRef, PanelProps>(
       mergedLocale = panelLocale || props.locale;
     }
 
-    const { lazyLoadPanelContent } = useFeatureFlags();
-    const renderContent = lazyLoadPanelContent ? visible : renderContentAlways;
+    const { panelLazyLoadContent } = useFeatureFlags();
+    const renderContent = panelLazyLoadContent ? visible : renderContentAlways;
 
     const [closeButtonAriaLabelText, setCloseButtonAriaLabelText] =
       useState<string>(defaultCloseButtonAriaLabelText);

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -17,6 +17,7 @@ import { Button, ButtonShape, ButtonVariant } from '../Button';
 import { IconName } from '../Icon';
 import { Portal } from '../Portal';
 import { FocusTrap } from '../../shared/FocusTrap';
+import { useFeatureFlags } from '../ConfigProvider/FeatureFlagProvider';
 import { NoFormStyle } from '../Form/Context';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
 import { useScrollLock } from '../../hooks/useScrollLock';
@@ -28,7 +29,6 @@ import enUS from './Locale/en_US';
 
 import styles from './panel.module.scss';
 import themedComponentStyles from './panel.theme.module.scss';
-import { useFeatureFlags } from '../ConfigProvider/FeatureFlagProvider';
 
 const PanelContext = React.createContext<PanelRef | null>(null);
 

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -28,6 +28,7 @@ import enUS from './Locale/en_US';
 
 import styles from './panel.module.scss';
 import themedComponentStyles from './panel.theme.module.scss';
+import { useFeatureFlags } from '../ConfigProvider/FeatureFlagProvider';
 
 const PanelContext = React.createContext<PanelRef | null>(null);
 
@@ -119,6 +120,9 @@ export const Panel = React.forwardRef<PanelRef, PanelProps>(
     } else {
       mergedLocale = panelLocale || props.locale;
     }
+
+    const { lazyLoadPanelContent } = useFeatureFlags();
+    const renderContent = lazyLoadPanelContent ? visible : renderContentAlways;
 
     const [closeButtonAriaLabelText, setCloseButtonAriaLabelText] =
       useState<string>(defaultCloseButtonAriaLabelText);
@@ -360,7 +364,7 @@ export const Panel = React.forwardRef<PanelRef, PanelProps>(
                         onClick={stopPropagation}
                         style={getPanelStyle()}
                       >
-                        {renderContentAlways && (
+                        {renderContent && (
                           <>
                             {getHeader()}
                             {getBody()}

--- a/src/components/Panel/Panel.types.ts
+++ b/src/components/Panel/Panel.types.ts
@@ -201,6 +201,7 @@ export interface PanelProps extends Omit<OcBaseProps<HTMLElement>, 'title'> {
   push?: boolean;
   /**
    * Whether to render Panel content when Panel `visible` is `false`.
+   * @deprecated Use the feature flag panelLazyLoadContent instead.
    * @default true
    */
   renderContentAlways?: boolean;


### PR DESCRIPTION
Add a feature flag config for octuple which can provide a mechanism to provide default behavior for Octuple components.

## SUMMARY:
This adds a feature flag config, and creates one flag that can control the way that Panels are rendered

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [X] I have added unittests for this change

## TEST PLAN:
Open the panel in storybook, and toggle the `lazyLoadPanelContent` flag in the settings. You should be able to see that the panel contents are rendered or not rendered even when the panel is not visible
