### PR TITLE
fix: select: address selected items getting unselected when expanded.

### DIFF
--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -59,125 +59,6 @@ export default {
   },
 } as ComponentMeta<typeof Form>;
 
-const Form_Select_Multiple_Story: ComponentStory<typeof Form> = (args) => {
-  const [form] = Form.useForm();
-  const [selected, setSelected] = useState<string>();
-  const layout = {
-    labelCol: { span: 1 },
-    wrapperCol: { span: 11 },
-  };
-  const actionsLayout = {
-    wrapperCol: { offset: 1, span: 11 },
-  };
-  const defaultOptions: SelectOption[] = [
-    {
-      text: 'Foo',
-      value: 'foo',
-    },
-    {
-      text: 'Bar',
-      value: 'bar',
-    },
-    {
-      text: 'Other',
-      value: 'other',
-    },
-  ];
-
-  const onSelectChange = (options: SelectOption[]) => {
-    if (!options) {
-      return onReset();
-    }
-    switch (options[0]) {
-      case 'foo' as unknown as SelectOption:
-        form.setFieldListValues({
-          note: 'Hello, Foo!',
-          selectValue: 'foo',
-        });
-        setSelected('foo');
-        return;
-      case 'bar' as unknown as SelectOption:
-        form.setFieldListValues({
-          note: 'Hello, Bar!',
-          selectValue: 'bar',
-        });
-        setSelected('bar');
-        return;
-      case 'other' as unknown as SelectOption:
-        form.setFieldListValues({
-          note: 'Hello, Other!',
-          selectValue: 'other',
-        });
-        setSelected('other');
-        return;
-    }
-  };
-
-  const onFinish = (values: any) => {
-    console.log(values);
-  };
-
-  const onReset = () => {
-    form.resetFields();
-    setSelected('');
-  };
-
-  return (
-    <ConfigProvider
-      themeOptions={{ name: 'blue' }}
-      locale={enUS}
-      children={
-        <Stack fullWidth>
-          <Form
-            {...args}
-            {...layout}
-            form={form}
-            name={'control-hooks'}
-            onFinish={onFinish}
-            style={{
-              width: '100%',
-            }}
-          >
-            <Form.Item
-              name={'selectValue'}
-              label={'Select'}
-              rules={[{ required: true }]}
-            >
-              <Select
-                clearable
-                multiple
-                onClear={onReset}
-                onOptionsChange={onSelectChange}
-                options={defaultOptions}
-                placeholder={'Select an option to change the input text.'}
-                textInputProps={{
-                  inputWidth: TextInputWidth.fill,
-                }}
-                filterable
-              />
-            </Form.Item>
-            <Form.Item {...actionsLayout}>
-              <Stack direction={'horizontal'} flexGap={'m'} fullWidth>
-                <Button
-                  htmlType={'submit'}
-                  text={'Submit'}
-                  variant={ButtonVariant.Primary}
-                />
-                <Button
-                  htmlType={'button'}
-                  onClick={onReset}
-                  text={'Reset'}
-                  variant={ButtonVariant.Secondary}
-                />
-              </Stack>
-            </Form.Item>
-          </Form>
-        </Stack>
-      }
-    />
-  );
-};
-
 const Basic_Story: ComponentStory<typeof Form> = (args) => {
   const onFinish = (values: any) => {
     console.log('Success:', values);
@@ -2245,6 +2126,123 @@ const Dynamic_Rules_Story: ComponentStory<typeof Form> = (args) => {
             />
           </Form.Item>
         </Form>
+      }
+    />
+  );
+};
+
+const Form_Select_Multiple_Story: ComponentStory<typeof Form> = (args) => {
+  const [form] = Form.useForm();
+  const [selected, setSelected] = useState<string>();
+  const layout = {
+    labelCol: { span: 1 },
+    wrapperCol: { span: 11 },
+  };
+  const actionsLayout = {
+    wrapperCol: { offset: 1, span: 11 },
+  };
+  const defaultOptions: SelectOption[] = [
+    {
+      text: 'Foo',
+      value: 'foo',
+    },
+    {
+      text: 'Bar',
+      value: 'bar',
+    },
+    {
+      text: 'Other',
+      value: 'other',
+    },
+  ];
+
+  const onSelectChange = (options: SelectOption[]) => {
+    if (!options) {
+      return onReset();
+    }
+    switch (options[0]) {
+      case 'foo' as unknown as SelectOption:
+        form.setFieldListValues({
+          note: 'Hello, Foo!',
+          selectValue: 'foo',
+        });
+        setSelected('foo');
+        return;
+      case 'bar' as unknown as SelectOption:
+        form.setFieldListValues({
+          note: 'Hello, Bar!',
+          selectValue: 'bar',
+        });
+        setSelected('bar');
+        return;
+      case 'other' as unknown as SelectOption:
+        form.setFieldListValues({
+          note: 'Hello, Other!',
+          selectValue: 'other',
+        });
+        setSelected('other');
+        return;
+    }
+  };
+
+  const onFinish = () => {};
+
+  const onReset = () => {
+    form.resetFields();
+    setSelected('');
+  };
+
+  return (
+    <ConfigProvider
+      themeOptions={{ name: 'blue' }}
+      locale={enUS}
+      children={
+        <Stack fullWidth>
+          <Form
+            {...args}
+            {...layout}
+            form={form}
+            name={'control-hooks'}
+            onFinish={onFinish}
+            style={{
+              width: '100%',
+            }}
+          >
+            <Form.Item
+              name={'selectValue'}
+              label={'Select'}
+              rules={[{ required: true }]}
+            >
+              <Select
+                clearable
+                multiple
+                onClear={onReset}
+                onOptionsChange={onSelectChange}
+                options={defaultOptions}
+                placeholder={'Select an option to change the input text.'}
+                textInputProps={{
+                  inputWidth: TextInputWidth.fill,
+                }}
+                filterable
+              />
+            </Form.Item>
+            <Form.Item {...actionsLayout}>
+              <Stack direction={'horizontal'} flexGap={'m'} fullWidth>
+                <Button
+                  htmlType={'submit'}
+                  text={'Submit'}
+                  variant={ButtonVariant.Primary}
+                />
+                <Button
+                  htmlType={'button'}
+                  onClick={onReset}
+                  text={'Reset'}
+                  variant={ButtonVariant.Secondary}
+                />
+              </Stack>
+            </Form.Item>
+          </Form>
+        </Stack>
       }
     />
   );

--- a/src/components/Form/Form.stories.tsx
+++ b/src/components/Form/Form.stories.tsx
@@ -59,6 +59,125 @@ export default {
   },
 } as ComponentMeta<typeof Form>;
 
+const Form_Select_Multiple_Story: ComponentStory<typeof Form> = (args) => {
+  const [form] = Form.useForm();
+  const [selected, setSelected] = useState<string>();
+  const layout = {
+    labelCol: { span: 1 },
+    wrapperCol: { span: 11 },
+  };
+  const actionsLayout = {
+    wrapperCol: { offset: 1, span: 11 },
+  };
+  const defaultOptions: SelectOption[] = [
+    {
+      text: 'Foo',
+      value: 'foo',
+    },
+    {
+      text: 'Bar',
+      value: 'bar',
+    },
+    {
+      text: 'Other',
+      value: 'other',
+    },
+  ];
+
+  const onSelectChange = (options: SelectOption[]) => {
+    if (!options) {
+      return onReset();
+    }
+    switch (options[0]) {
+      case 'foo' as unknown as SelectOption:
+        form.setFieldListValues({
+          note: 'Hello, Foo!',
+          selectValue: 'foo',
+        });
+        setSelected('foo');
+        return;
+      case 'bar' as unknown as SelectOption:
+        form.setFieldListValues({
+          note: 'Hello, Bar!',
+          selectValue: 'bar',
+        });
+        setSelected('bar');
+        return;
+      case 'other' as unknown as SelectOption:
+        form.setFieldListValues({
+          note: 'Hello, Other!',
+          selectValue: 'other',
+        });
+        setSelected('other');
+        return;
+    }
+  };
+
+  const onFinish = (values: any) => {
+    console.log(values);
+  };
+
+  const onReset = () => {
+    form.resetFields();
+    setSelected('');
+  };
+
+  return (
+    <ConfigProvider
+      themeOptions={{ name: 'blue' }}
+      locale={enUS}
+      children={
+        <Stack fullWidth>
+          <Form
+            {...args}
+            {...layout}
+            form={form}
+            name={'control-hooks'}
+            onFinish={onFinish}
+            style={{
+              width: '100%',
+            }}
+          >
+            <Form.Item
+              name={'selectValue'}
+              label={'Select'}
+              rules={[{ required: true }]}
+            >
+              <Select
+                clearable
+                multiple
+                onClear={onReset}
+                onOptionsChange={onSelectChange}
+                options={defaultOptions}
+                placeholder={'Select an option to change the input text.'}
+                textInputProps={{
+                  inputWidth: TextInputWidth.fill,
+                }}
+                filterable
+              />
+            </Form.Item>
+            <Form.Item {...actionsLayout}>
+              <Stack direction={'horizontal'} flexGap={'m'} fullWidth>
+                <Button
+                  htmlType={'submit'}
+                  text={'Submit'}
+                  variant={ButtonVariant.Primary}
+                />
+                <Button
+                  htmlType={'button'}
+                  onClick={onReset}
+                  text={'Reset'}
+                  variant={ButtonVariant.Secondary}
+                />
+              </Stack>
+            </Form.Item>
+          </Form>
+        </Stack>
+      }
+    />
+  );
+};
+
 const Basic_Story: ComponentStory<typeof Form> = (args) => {
   const onFinish = (values: any) => {
     console.log('Success:', values);
@@ -2165,6 +2284,7 @@ export const Dates_and_Times = Dates_and_Times_Story.bind({});
 export const Manual_Form_Data = Manual_Form_Data_Story.bind({});
 export const Custom_Validation = Custom_Validation_Story.bind({});
 export const Dynamic_Rules = Dynamic_Rules_Story.bind({});
+export const Form_Select_Multiple = Form_Select_Multiple_Story.bind({});
 
 // Storybook 6.5 using Webpack >= 5.76.0 automatically alphabetizes exports,
 // this line ensures they are exported in the desired order.
@@ -2202,6 +2322,7 @@ export const __namedExportsOrder = [
   'Manual_Form_Data',
   'Custom_Validation',
   'Dynamic_Rules',
+  'Form_Select_Multiple',
 ];
 
 const formArgs: Object = {

--- a/src/components/Form/Tests/index.test.js
+++ b/src/components/Form/Tests/index.test.js
@@ -1416,4 +1416,84 @@ describe('Form', () => {
       container.querySelector('.form-item-explain-error')
     ).not.toBeInTheDocument();
   });
+
+  test('should not clear selected item when keboard enter key is pressed on dropdown', async () => {
+    const options = [
+      { text: 'Option 1', value: 'option1', 'data-testid': 'option1-test-id' },
+      { text: 'Option 2', value: 'option2', 'data-testid': 'option2-test-id' },
+      { text: 'Option 3', value: 'option3', 'data-testid': 'option3-test-id' },
+    ];
+
+    const Demo = () => {
+      const [form] = Form.useForm();
+      const layout = {
+        labelCol: { span: 1 },
+        wrapperCol: { span: 11 },
+      };
+      const actionsLayout = {
+        wrapperCol: { offset: 1, span: 11 },
+      };
+
+      return (
+        <Form
+          {...layout}
+          form={form}
+          name={'control-hooks'}
+          onFinish={() => {}}
+          style={{
+            width: '100%',
+          }}
+        >
+          <Form.Item
+            name={'selectValue'}
+            label={'Select'}
+            rules={[{ required: true }]}
+          >
+            <Select
+              clearable
+              multiple
+              onClear={() => {}}
+              onOptionsChange={() => {}}
+              options={options}
+              placeholder={'Select test'}
+              filterable
+            />
+          </Form.Item>
+          <Form.Item {...actionsLayout}>
+            <PrimaryButton htmlType={'submit'} text={'Submit'} />
+            <PrimaryButton
+              htmlType={'button'}
+              onClick={() => {}}
+              text={'Reset'}
+            />
+          </Form.Item>
+        </Form>
+      );
+    };
+
+    const { container, getAllByRole, getByText } = render(<Demo />);
+    const select = container.querySelector('.select-input');
+    select.focus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    const listbox = await waitFor(() => getAllByRole('option'));
+    expect(listbox).toHaveLength(options.length);
+    const option1 = await waitFor(() => getByText('Option 1'));
+    fireEvent.click(option1);
+    const option2 = await waitFor(() => getByText('Option 2'));
+    fireEvent.click(option2);
+    let pills = container.querySelectorAll('.multi-select-pill');
+    expect(pills.length).toEqual(2);
+    select.focus();
+    fireEvent.keyDown(container.querySelector('.select-input'), {
+      key: 'Escape',
+    });
+    await sleep(200);
+    expect(container.querySelector('.dropdown-wrapper')).toBeFalsy();
+    expect(select).toHaveFocus();
+    fireEvent.keyDown(select, { key: 'Enter' });
+    await sleep(200);
+    expect(select).toHaveFocus();
+    pills = container.querySelectorAll('.multi-select-pill');
+    expect(pills.length).toEqual(2);
+  });
 });

--- a/src/components/Form/Tests/index.test.js
+++ b/src/components/Form/Tests/index.test.js
@@ -1417,7 +1417,7 @@ describe('Form', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('should not clear selected item when keboard enter key is pressed on dropdown', async () => {
+  test('should not clear selected item when keyboard enter key is pressed on dropdown', async () => {
     const options = [
       { text: 'Option 1', value: 'option1', 'data-testid': 'option1-test-id' },
       { text: 'Option 2', value: 'option2', 'data-testid': 'option2-test-id' },
@@ -1475,6 +1475,9 @@ describe('Form', () => {
     const select = container.querySelector('.select-input');
     select.focus();
     fireEvent.keyDown(select, { key: 'Enter' });
+    await waitFor(() =>
+      expect(container.querySelector('.dropdown-wrapper')).toBeTruthy()
+    );
     const listbox = await waitFor(() => getAllByRole('option'));
     expect(listbox).toHaveLength(options.length);
     const option1 = await waitFor(() => getByText('Option 1'));

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -48,6 +48,7 @@ import { useMaxVisibleSections } from '../../hooks/useMaxVisibleSections';
 import { usePreviousState } from '../../hooks/usePreviousState';
 import {
   canUseDocElement,
+  contains,
   eventKeys,
   mergeClasses,
   uniqueId,
@@ -577,7 +578,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
             disabled={mergedDisabled}
             key={`select-pill-${index}`}
             label={opt.text}
-            onClose={() => toggleOption(opt)}
+            onClose={(event) => {
+              if (contains(document.activeElement, event.target as Node)) {
+                toggleOption(opt);
+              }
+            }}
             size={selectSizeToPillSizeMap.get(size)}
             tabIndex={0}
             theme={'blueGreen'}


### PR DESCRIPTION
## SUMMARY:
This fix addresses the issue of Selected list item getting unselected when expanded or focus is on select dropdown container.

when keydown is called when enter is pressed on select dropdown. onClick event listener for close button on the selected pill item is getting called causing the selected item to remove from the selected list.

Fixed the issue by adding if guard to call toggle function only when currently active element in document is contained to the target close button.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-95192

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
- Pull the PR branch locally and run `yarn storybook`. 
- Verify the new added Form multiple select story on form and confirm selected items are not getting removed after expanding the select dropdown. (`http://localhost:2022/?path=/story/form--form-select-multiple`)

https://github.com/user-attachments/assets/a7c3ac19-7e23-4e8a-9307-e0769a4fa5d0


