### PR TITLE
fix: select: remove toggle button from tab order

### DIFF
--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -91,6 +91,15 @@ export interface InputIconButtonProps {
    * The input icon button onClick event handler.
    */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  /**
+   * The input icon button role.
+   */
+  role?: string;
+  /**
+   * The tabIndex for the icon button. Default is unset (0 since its a button).
+   * Leverage this to programatically disable the focus for the button as needed.
+   */
+  tabIndex?: number;
 }
 
 export interface ReadOnlyProps {

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -482,8 +482,10 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
             ? iconButtonProps.onClick
             : null
         }
+        role={iconButtonProps.role}
         shape={inputShapeToButtonShapeMap.get(shape)}
         size={inputSizeToButtonSizeMap.get(mergedSize)}
+        tabIndex={iconButtonProps.tabIndex}
         transparent
         variant={ButtonVariant.SystemUI}
       />
@@ -548,8 +550,10 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
                     path: iconButtonProps.iconProps.path,
                   }}
                   id={iconButtonProps.id}
+                  role={iconButtonProps.role}
                   shape={inputShapeToButtonShapeMap.get(shape)}
                   size={inputSizeToButtonSizeMap.get(mergedSize)}
+                  tabIndex={iconButtonProps.tabIndex}
                   variant={ButtonVariant.SystemUI}
                 />
               )}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -773,6 +773,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
               ? toggleButtonAriaLabel
               : 'Toggle dropdown',
             htmlType: 'button',
+            // The button does not need to be the tab order as
+            // the input itself provides the focus and action.
+            tabIndex: -1,
+            role: 'presentation',
             iconProps: {
               path: dropdownVisible
                 ? IconName.mdiChevronUp

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -46,6 +46,8 @@ exports[`Select Renders empty options in multiple mode without crashing 1`] = `
                   aria-disabled="false"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  role="presentation"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -121,6 +123,8 @@ exports[`Select Renders empty options in single mode without crashing 1`] = `
                   aria-disabled="false"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  role="presentation"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -196,6 +200,8 @@ exports[`Select Renders null options in multiple mode without crashing 1`] = `
                   aria-disabled="false"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  role="presentation"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -271,6 +277,8 @@ exports[`Select Renders null options in single mode without crashing 1`] = `
                   aria-disabled="false"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  role="presentation"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -346,6 +354,8 @@ exports[`Select Renders with default value 1`] = `
                   aria-disabled="false"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  role="presentation"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -491,6 +501,8 @@ exports[`Select Renders with default values when multiple 1`] = `
                   aria-disabled="false"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  role="presentation"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -566,6 +578,8 @@ exports[`Select Renders without crashing 1`] = `
                   aria-disabled="false"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                  role="presentation"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -640,6 +654,8 @@ exports[`Select Select is large 1`] = `
                 aria-disabled="false"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-large icon-left"
+                role="presentation"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -713,6 +729,8 @@ exports[`Select Select is medium 1`] = `
                 aria-disabled="false"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                role="presentation"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -786,6 +804,8 @@ exports[`Select Select is pill shaped 1`] = `
                 aria-disabled="false"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium round-shape icon-left"
+                role="presentation"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -859,6 +879,8 @@ exports[`Select Select is rectangle shaped 1`] = `
                 aria-disabled="false"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                role="presentation"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -932,6 +954,8 @@ exports[`Select Select is small 1`] = `
                 aria-disabled="false"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-small icon-left"
+                role="presentation"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -1005,6 +1029,8 @@ exports[`Select Select is underline shaped 1`] = `
                 aria-disabled="false"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
+                role="presentation"
+                tabindex="-1"
                 type="button"
               >
                 <span


### PR DESCRIPTION
## SUMMARY:
This removes focusability from the button in Select components. This resolves an accessibility and usability issue in which the Select component input is focusable in order to open the dropdown, and the button provides unnecessary duplication of that action.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
- Pull down code
- run storybook
- confirm that select component still works as desired:
  - can open the dropdown while keyboard focused on the input 
  - can open the dropdown by click on the input and/or the toggle button