### PR TITLE
fix: accordionButton: changed role

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -108,7 +108,7 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
         {badgeProps && <Badge classNames={styles.badge} {...badgeProps} />}
       </div>
       <Button
-        role="presenation"
+        role="presentation"
         tabIndex={-1}
         aria-controls={`${id}-content`}
         disabled={disabled}

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Accordion Accordion is large 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         class="button button-neutral button-medium round-shape icon-left"
-        role="presenation"
+        role="presentation"
         tabindex="-1"
       >
         <span
@@ -153,7 +153,7 @@ exports[`Accordion Accordion is medium 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         class="button button-neutral button-medium round-shape icon-left"
-        role="presenation"
+        role="presentation"
         tabindex="-1"
       >
         <span
@@ -250,7 +250,7 @@ exports[`Accordion Accordion is not bordered 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         class="button button-neutral button-medium round-shape icon-left"
-        role="presenation"
+        role="presentation"
         tabindex="-1"
       >
         <span
@@ -347,7 +347,7 @@ exports[`Accordion Accordion is pill shaped 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         class="button button-neutral button-medium round-shape icon-left"
-        role="presenation"
+        role="presentation"
         tabindex="-1"
       >
         <span
@@ -444,7 +444,7 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         class="button button-neutral button-medium round-shape icon-left"
-        role="presenation"
+        role="presentation"
         tabindex="-1"
       >
         <span
@@ -636,7 +636,7 @@ exports[`Accordion Accordion renders custom content and its buttons are clickabl
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         class="button button-neutral button-medium round-shape icon-left"
-        role="presenation"
+        role="presentation"
         tabindex="-1"
       >
         <span
@@ -733,7 +733,7 @@ exports[`Accordion Renders without crashing 1`] = `
         aria-controls="myAccordionId-content"
         aria-disabled="false"
         class="button button-neutral button-medium round-shape icon-left"
-        role="presenation"
+        role="presentation"
         tabindex="-1"
       >
         <span


### PR DESCRIPTION
## SUMMARY:
Fixed role name typo from presenation to presentation

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

- pull branch down locally and start storybook (yarn storybook)
- With screen reader on, check accordion expand/collapse button has no role or role presentation.

