### PR TITLE
fix: formError: fixed focus not moving to 1st required input on error

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -97,7 +97,7 @@ const InternalForm: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
 
     let defaultScrollToFirstError: Options = { block: 'nearest' };
 
-    if (scrollToFirstError && errorInfo.errorFields.length) {
+    if (scrollToFirstError || errorInfo.errorFields.length) {
       if (typeof scrollToFirstError === 'object') {
         defaultScrollToFirstError = scrollToFirstError;
       }

--- a/src/components/Form/Hooks/useForm.ts
+++ b/src/components/Form/Hooks/useForm.ts
@@ -65,11 +65,12 @@ export default function useForm<Values = any>(
               block: 'nearest',
               ...options,
             });
-            if (node.tagName !== 'INPUT') {
+            if (node.tagName === 'INPUT') {
+              node.focus();
+            } else {
               const focusableElement = node.querySelector('input');
               focusableElement?.focus();
             }
-            node?.focus();
           }
         },
         getFieldInstance: (name: OcNamePath) => {

--- a/src/components/Form/Hooks/useForm.ts
+++ b/src/components/Form/Hooks/useForm.ts
@@ -65,6 +65,11 @@ export default function useForm<Values = any>(
               block: 'nearest',
               ...options,
             });
+            if (node.tagName !== 'INPUT') {
+              const focusableElement = node.querySelector('input');
+              focusableElement?.focus();
+            }
+            node?.focus();
           }
         },
         getFieldInstance: (name: OcNamePath) => {


### PR DESCRIPTION
## SUMMARY:
fixed an issue with focus not moving to 1st required input on error.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
Jira task - https://eightfoldai.atlassian.net/browse/ENG-107285

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

- pull branch down locally and start storybook (yarn storybook)
- with screen reader on, goto form component.
- Submit an empty form with required fields and observe that focus is moving or getting activated on the 1st empty input required field.