### PR TITLE
fix: snack: Use ID from SnackBarProps and return a close callback fn

### DIFF
--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { snack, Snackbar, SnackbarContainer } from './';
-import { Button, ButtonSize } from '../Button';
+import { Button, ButtonSize, ButtonVariant } from '../Button';
 import { InfoBarType } from '../InfoBar';
 import { IconName } from '../Icon';
 
@@ -94,16 +94,42 @@ const Basic_Story: ComponentStory<typeof Snackbar> = (args) => (
   </>
 );
 
-const Closable_Story: ComponentStory<typeof Snackbar> = (args) => (
-  <>
-    <Button
-      text="Serve closable snack"
-      onClick={() => snack.serve({ ...args })}
-      size={ButtonSize.Small}
-    />
-    <SnackbarContainer />
-  </>
-);
+const Closable_Story: ComponentStory<typeof Snackbar> = (args) => {
+  const [snackId, setSnackId] = useState<string[]>([]);
+
+  const serveSnack = () => {
+    const count = snackId.length;
+    const id = snack.serve({ ...args, content: `${args.content} [${count}]` });
+    setSnackId([...snackId, id]);
+  };
+
+  const closeLastSnack = () => {
+    if (snackId) {
+      snack.eat(snackId[snackId.length - 1]);
+      setSnackId(snackId.slice(0, -1));
+    }
+  };
+
+  return (
+    <>
+      <Button
+        text="Serve closable snack"
+        onClick={serveSnack}
+        size={ButtonSize.Small}
+      />
+      <br />
+      <br />
+      <Button
+        text="Close last snack"
+        onClick={closeLastSnack}
+        size={ButtonSize.Small}
+        variant={ButtonVariant.Neutral}
+        disabled={snackId.length === 0}
+      />
+      <SnackbarContainer />
+    </>
+  );
+};
 
 const With_Action_Story: ComponentStory<typeof Snackbar> = (args) => (
   <>
@@ -164,6 +190,7 @@ Basic.args = {
 
 Closable.args = {
   ...snackArgs,
+  id: undefined,
   closable: true,
   closeButtonProps: {
     ariaLabel: 'Close',

--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -95,18 +95,22 @@ const Basic_Story: ComponentStory<typeof Snackbar> = (args) => (
 );
 
 const Closable_Story: ComponentStory<typeof Snackbar> = (args) => {
-  const [snackId, setSnackId] = useState<string[]>([]);
+  type closeSnack = () => void;
+  const [closeFunctions, setCloseFunctions] = useState<closeSnack[]>([]);
 
   const serveSnack = () => {
-    const count = snackId.length;
-    const id = snack.serve({ ...args, content: `${args.content} [${count}]` });
-    setSnackId([...snackId, id]);
+    const count = closeFunctions.length;
+    const close = snack.serve({
+      ...args,
+      content: `${args.content} [${count}]`,
+    });
+    setCloseFunctions([...closeFunctions, close]);
   };
 
   const closeLastSnack = () => {
-    if (snackId) {
-      snack.eat(snackId[snackId.length - 1]);
-      setSnackId(snackId.slice(0, -1));
+    if (closeFunctions.length > 0) {
+      closeFunctions[closeFunctions.length - 1]();
+      setCloseFunctions(closeFunctions.slice(0, -1));
     }
   };
 
@@ -124,7 +128,7 @@ const Closable_Story: ComponentStory<typeof Snackbar> = (args) => {
         onClick={closeLastSnack}
         size={ButtonSize.Small}
         variant={ButtonVariant.Neutral}
-        disabled={snackId.length === 0}
+        disabled={closeFunctions.length === 0}
       />
       <SnackbarContainer />
     </>

--- a/src/components/Snackbar/Snackbar.test.tsx
+++ b/src/components/Snackbar/Snackbar.test.tsx
@@ -51,30 +51,40 @@ describe('Snackbar', () => {
     expect(wrapper.queryByText(content)).toBe(null);
   });
 
-  test('snack.serve generates an ID when props.id is missing', () => {
-    let id;
+  test('snack.serve generates a close function when props.id is missing', () => {
+    let closeFunction: VoidFunction;
 
     act(() => {
-      id = snack.serve({
+      closeFunction = snack.serve({
         content,
       });
     });
 
-    expect(id).toBeDefined();
-    expect(typeof id).toBe('string');
+    expect(closeFunction).toBeDefined();
+    expect(typeof closeFunction).toBe('function');
   });
 
   test('snack.serve uses provided props.id', () => {
-    const customId = 'custom-id';
-    let id;
-
+    let closeFunction: VoidFunction;
+    expect(wrapper.queryByText(content)).toBe(null);
     act(() => {
-      id = snack.serve({
+      closeFunction = snack.serve({
         content,
-        id: customId,
+        closable: true,
       });
     });
-    expect(id).toBe(customId);
+    jest.runAllTimers();
+
+    // Snack should be visible as it is closable
+    expect(wrapper.queryByText(content)).not.toBe(null);
+
+    // Close the snack
+    act(() => {
+      closeFunction();
+    });
+
+    // Snack should be hidden
+    expect(wrapper.queryByText(content)).toBe(null);
   });
 
   test('test snack.serveNeutral', () => {

--- a/src/components/Snackbar/Snackbar.test.tsx
+++ b/src/components/Snackbar/Snackbar.test.tsx
@@ -51,6 +51,32 @@ describe('Snackbar', () => {
     expect(wrapper.queryByText(content)).toBe(null);
   });
 
+  test('snack.serve generates an ID when props.id is missing', () => {
+    let id;
+
+    act(() => {
+      id = snack.serve({
+        content,
+      });
+    });
+
+    expect(id).toBeDefined();
+    expect(typeof id).toBe('string');
+  });
+
+  test('snack.serve uses provided props.id', () => {
+    const customId = 'custom-id';
+    let id;
+
+    act(() => {
+      id = snack.serve({
+        content,
+        id: customId,
+      });
+    });
+    expect(id).toBe(customId);
+  });
+
   test('test snack.serveNeutral', () => {
     expect(wrapper.queryByText(content)).toBe(null);
     act(() => {

--- a/src/components/Snackbar/Snackbar.types.ts
+++ b/src/components/Snackbar/Snackbar.types.ts
@@ -40,31 +40,26 @@ export interface SnackbarContainerProps {
   parent?: HTMLElement;
 }
 
+export type VoidFunction = () => void;
 export interface ISnack {
   /**
    * Serves a snack.
    */
-  serve: (props: SnackbarProps) => string;
+  serve: (props: SnackbarProps) => VoidFunction;
   /**
    * Serves a neutral snack.
    */
-  serveNeutral: (props: SnackbarProps) => string;
+  serveNeutral: (props: SnackbarProps) => VoidFunction;
   /**
    * Serves a positive snack.
    */
-  servePositive: (props: SnackbarProps) => string;
+  servePositive: (props: SnackbarProps) => VoidFunction;
   /**
    * Serves a warning snack.
    */
-  serveWarning: (props: SnackbarProps) => string;
+  serveWarning: (props: SnackbarProps) => VoidFunction;
   /**
    * Serves a disruptive snack.
    */
-  serveDisruptive: (props: SnackbarProps) => string;
-  /**
-   * Eat a snack.
-   * @param snackId - The id of the snack to eat.
-   * @returns void
-   */
-  eat: (snackId: string) => void;
+  serveDisruptive: (props: SnackbarProps) => VoidFunction;
 }

--- a/src/components/Snackbar/Snackbar.types.ts
+++ b/src/components/Snackbar/Snackbar.types.ts
@@ -44,21 +44,27 @@ export interface ISnack {
   /**
    * Serves a snack.
    */
-  serve: (props: SnackbarProps) => void;
+  serve: (props: SnackbarProps) => string;
   /**
    * Serves a neutral snack.
    */
-  serveNeutral: (props: SnackbarProps) => void;
+  serveNeutral: (props: SnackbarProps) => string;
   /**
    * Serves a positive snack.
    */
-  servePositive: (props: SnackbarProps) => void;
+  servePositive: (props: SnackbarProps) => string;
   /**
    * Serves a warning snack.
    */
-  serveWarning: (props: SnackbarProps) => void;
+  serveWarning: (props: SnackbarProps) => string;
   /**
    * Serves a disruptive snack.
    */
-  serveDisruptive: (props: SnackbarProps) => void;
+  serveDisruptive: (props: SnackbarProps) => string;
+  /**
+   * Eat a snack.
+   * @param snackId - The id of the snack to eat.
+   * @returns void
+   */
+  eat: (snackId: string) => void;
 }

--- a/src/components/Snackbar/snack.ts
+++ b/src/components/Snackbar/snack.ts
@@ -1,6 +1,11 @@
 'use client';
 
-import { ISnack, SnackbarPosition, SnackbarProps } from './Snackbar.types';
+import {
+  ISnack,
+  SnackbarPosition,
+  SnackbarProps,
+  VoidFunction,
+} from './Snackbar.types';
 import { canUseDocElement, generateId } from '../../shared/utilities';
 import { InfoBarType } from '../InfoBar';
 
@@ -11,7 +16,7 @@ export const SNACK_EVENTS: Record<string, string> = {
   EAT: 'eatSnack',
 };
 
-export const serve = (props: SnackbarProps): string => {
+export const serve = (props: SnackbarProps): VoidFunction => {
   const id = props.id ?? generateId();
   const serveSnackEvent = new CustomEvent<SnackbarProps>(SNACK_EVENTS.SERVE, {
     bubbles: true,
@@ -30,7 +35,8 @@ export const serve = (props: SnackbarProps): string => {
       eat(id);
     }, props.duration || 3000);
   }
-  return id;
+  const closeSnack = () => eat(id);
+  return closeSnack;
 };
 
 export const eat = (snackId: string): void => {
@@ -74,5 +80,4 @@ export const snack: ISnack = {
   servePositive,
   serveWarning,
   serveDisruptive,
-  eat,
 };

--- a/src/components/Snackbar/snack.ts
+++ b/src/components/Snackbar/snack.ts
@@ -11,8 +11,8 @@ export const SNACK_EVENTS: Record<string, string> = {
   EAT: 'eatSnack',
 };
 
-export const serve = (props: SnackbarProps): void => {
-  const id = generateId();
+export const serve = (props: SnackbarProps): string => {
+  const id = props.id ?? generateId();
   const serveSnackEvent = new CustomEvent<SnackbarProps>(SNACK_EVENTS.SERVE, {
     bubbles: true,
     cancelable: false,
@@ -30,6 +30,7 @@ export const serve = (props: SnackbarProps): void => {
       eat(id);
     }, props.duration || 3000);
   }
+  return id;
 };
 
 export const eat = (snackId: string): void => {
@@ -73,4 +74,5 @@ export const snack: ISnack = {
   servePositive,
   serveWarning,
   serveDisruptive,
+  eat,
 };


### PR DESCRIPTION
## SUMMARY:

1. The snack.serve will now use the id from SnackBarProps (if supplied). 
2. snack.serve (and related) will now return a close callback.

## JIRA TASK (Eightfold Employees Only):

https://eightfoldai.atlassian.net/browse/ENG-112136

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
1. Run the storybook - `yarn storybook`
2. In the relevant section - http://localhost:2022/?path=/story/snack-bar--closable: make sure that you can serve multiple snacks, and close them from either the snack, or the close button. 

## KNOWN ISSUE:

1. If a snack is closed from "X" icon, the ID still lives in the component state, and will have to be removed using the close snack button.