### PR TITLE
fix: pills: Remove pointer-events: none from readonly pill

### DIFF
--- a/src/components/Pills/pills.module.scss
+++ b/src/components/Pills/pills.module.scss
@@ -43,7 +43,6 @@
 
   &.readOnly {
     cursor: default;
-    pointer-events: none;
   }
 
   &.xsmall {


### PR DESCRIPTION
## SUMMARY:

The `pointer-events: none` CSS is causing NVDA to not read the pills. To make our pill component accessible, we will remove it from Octuple and will override in the apps if needed.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

https://eightfoldai.atlassian.net/browse/ENG-103348

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

1. Run storybook with `yarn storybook` 
2. Go to pills, and make sure each pill is readable by NVDA once you click on it.
