### PR TITLE
feat: add dropDownRole and listAriaLabel in Select component

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -34,6 +34,7 @@ export const List = <T extends any>({
   role,
   itemProps,
   getItem,
+  listAriaLabel,
   ...rest
 }: ListProps<T>) => {
   const htmlDir: string = useCanvasDirection();
@@ -252,13 +253,23 @@ export const List = <T extends any>({
     <div {...rest} className={classNames} style={style}>
       {getHeader()}
       {listType === 'ul' && (
-        <ul role={role} className={containerClasses} style={{ ...listStyle }}>
+        <ul
+          role={role}
+          aria-label={listAriaLabel}
+          className={containerClasses}
+          style={{ ...listStyle }}
+        >
           {getItems()}
           {!!renderAdditionalItem && getAdditionalItem()}
         </ul>
       )}
       {listType === 'ol' && (
-        <ol role={role} className={containerClasses} style={{ ...listStyle }}>
+        <ol
+          role={role}
+          aria-label={listAriaLabel}
+          className={containerClasses}
+          style={{ ...listStyle }}
+        >
           {getItems()}
           {!!renderAdditionalItem && getAdditionalItem()}
         </ol>

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -86,4 +86,8 @@ export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
    * @param item
    */
   rowKey?: (item: T) => Key | keyof T;
+  /**
+   * aria-label to be applied to list ul/ol.
+   */
+  listAriaLabel?: string;
 }

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -30,6 +30,7 @@ export const Menu: FC<MenuProps> = ({
   style,
   subHeader, // TODO: Remove in v3.0.0
   variant = MenuVariant.neutral,
+  listAriaLabel,
   ...rest
 }) => {
   const htmlDir: string = useCanvasDirection();
@@ -130,6 +131,7 @@ export const Menu: FC<MenuProps> = ({
       listType={listType}
       role={role}
       style={style}
+      listAriaLabel={listAriaLabel}
     />
   );
 };

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -74,6 +74,10 @@ export interface MenuProps
    * @default MenuVariant.neutral
    */
   variant?: MenuVariant;
+  /**
+   * aria-label for List (ul/ol) inside Menu
+   */
+  listAriaLabel?: string;
 }
 
 export interface DropdownMenuProps extends MenuProps {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -109,6 +109,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
       theme,
       themeContainerId,
       toggleButtonAriaLabel,
+      dropDownRole,
+      listAriaLabel,
       'data-test-id': dataTestId,
     },
     ref: Ref<HTMLDivElement>
@@ -677,6 +679,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
               toggleOption(option);
             }}
             role="listbox"
+            listAriaLabel={listAriaLabel}
           />
         );
       } else {
@@ -873,6 +876,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                   options?.length > 0)
               }
               ref={dropdownRef}
+              role={dropDownRole ? dropDownRole : 'listbox'}
             >
               <div className={styles.selectInputWrapper}>
                 {/* When Dropdown is visible, place Pills in the reference element */}
@@ -881,6 +885,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                   ref={inputRef}
                   aria-activedescendant={currentlySelectedOption.current?.id}
                   aria-controls={selectMenuId?.current}
+                  aria-expanded={dropdownVisible}
                   configContextProps={configContextProps}
                   status={status}
                   theme={mergedTheme}

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -222,4 +222,12 @@ export interface SelectProps
    * The Select toggle dropdown chevron button aria label.
    */
   toggleButtonAriaLabel?: string;
+  /**
+   * Role of the dropdown div.
+   */
+  dropDownRole?: string;
+  /**
+   * aria-label of the list inside Dropdown menu.
+   */
+  listAriaLabel?: string;
 }


### PR DESCRIPTION
## SUMMARY:
The Select Component in octuple internally uses DropDown and List component to show the list of options. Adding support for giving an aria-role in dropdown and aria-label in the list component to solve for following a11y issues:-

1.  Inside the `Select` component, the dropdown div is the parent of list (ul/ol) but both contain role="listbox". This raises an issue that listbox role could not be inside another listbox role. Adding support for aria-role in dropdown helps to give the role="group" to dropdown div.
<img width="1423" alt="Screenshot 2024-10-21 at 11 20 04" src="https://github.com/user-attachments/assets/2c2e0a8a-5a00-441e-b330-2394f196682e">

2.  Inside the `Select` component, the aria-label is missing from the input field list (ul/ol) which has the role="listbox". Adding the aria-label through a prop.
<img width="1423" alt="Screenshot 2024-10-21 at 11 19 33" src="https://github.com/user-attachments/assets/6886dc14-51a0-49d9-9028-28260ef7258e">




## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-110372

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [X] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
