### PR TITLE
feat: [Select] make dropdown role=group and pass correct id to options list for a11y

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -321,9 +321,12 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         }
         // If there's an ariaRef, apply the a11y attributes to it, rather than the immediate child.
         if (ariaRef?.current) {
-          ariaRef.current.setAttribute('aria-controls', dropdownId);
           ariaRef.current.setAttribute('aria-expanded', `${mergedVisible}`);
           ariaRef.current.setAttribute('aria-haspopup', 'true');
+
+          if (!ariaRef.current.hasAttribute('aria-controls')) {
+            ariaRef.current.setAttribute('aria-controls', dropdownId);
+          }
 
           if (!ariaRef.current.hasAttribute('role')) {
             ariaRef.current.setAttribute('role', 'button');

--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -66,6 +66,16 @@ describe('List', () => {
     expect(container).toMatchSnapshot();
   });
 
+  test('Renders ol without crashing', () => {
+    const { container, getByTestId } = render(
+      <List {...listProps} listType="ol" />
+    );
+    const list = getByTestId('test-list');
+    expect(() => container).not.toThrowError();
+    expect(list).toBeTruthy();
+    expect(container).toMatchSnapshot();
+  });
+
   test('List is horizontal', () => {
     const { container } = render(<List {...listProps} layout="horizontal" />);
     expect(container.querySelector('.vertical')).toBeFalsy();

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -34,6 +34,7 @@ export const List = <T extends any>({
   role,
   itemProps,
   getItem,
+  id,
   ...rest
 }: ListProps<T>) => {
   const htmlDir: string = useCanvasDirection();
@@ -252,13 +253,23 @@ export const List = <T extends any>({
     <div {...rest} className={classNames} style={style}>
       {getHeader()}
       {listType === 'ul' && (
-        <ul role={role} className={containerClasses} style={{ ...listStyle }}>
+        <ul
+          id={id}
+          role={role}
+          className={containerClasses}
+          style={{ ...listStyle }}
+        >
           {getItems()}
           {!!renderAdditionalItem && getAdditionalItem()}
         </ul>
       )}
       {listType === 'ol' && (
-        <ol role={role} className={containerClasses} style={{ ...listStyle }}>
+        <ol
+          id={id}
+          role={role}
+          className={containerClasses}
+          style={{ ...listStyle }}
+        >
           {getItems()}
           {!!renderAdditionalItem && getAdditionalItem()}
         </ol>

--- a/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/src/components/List/__snapshots__/List.test.tsx.snap
@@ -109,6 +109,115 @@ exports[`List List is horizontal 1`] = `
 </div>
 `;
 
+exports[`List Renders ol without crashing 1`] = `
+<div>
+  <div
+    class="my-ref-class"
+    data-testid="test-list"
+  >
+    <div
+      style="padding-left: 16px;"
+    >
+      <h2>
+        Header
+      </h2>
+    </div>
+    <ol
+      class="list-container my-list-class vertical"
+      role="list"
+    >
+      <li
+        class="list-item my-list-item-class"
+        style="padding: 8px 16px;"
+      >
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User1"
+          href="#"
+          id="User1"
+          role="link"
+          target="_self"
+        >
+          User 1
+        </a>
+      </li>
+      <li
+        class="list-item my-list-item-class"
+        style="padding: 8px 16px;"
+      >
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User2"
+          href="#"
+          id="User2"
+          role="link"
+          target="_self"
+        >
+          User 2
+        </a>
+      </li>
+      <li
+        class="list-item my-list-item-class"
+        style="padding: 8px 16px;"
+      >
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User3"
+          href="#"
+          id="User3"
+          role="link"
+          target="_self"
+        >
+          User 3
+        </a>
+      </li>
+      <li
+        class="list-item my-list-item-class"
+        style="padding: 8px 16px;"
+      >
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User4"
+          href="#"
+          id="User4"
+          role="link"
+          target="_self"
+        >
+          User 4
+        </a>
+      </li>
+      <li
+        class="list-item my-list-item-class"
+        style="padding: 8px 16px;"
+      >
+        <a
+          aria-disabled="false"
+          class="link-style full-width"
+          data-testid="User5"
+          href="#"
+          id="User5"
+          role="link"
+          target="_self"
+        >
+          User 5
+        </a>
+      </li>
+    </ol>
+    <div
+      style="padding-left: 16px;"
+    >
+      <h3>
+        Footer
+      </h3>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`List Renders without crashing 1`] = `
 <div>
   <div

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -873,6 +873,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                   options?.length > 0)
               }
               ref={dropdownRef}
+              role={'group'}
             >
               <div className={styles.selectInputWrapper}>
                 {/* When Dropdown is visible, place Pills in the reference element */}

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Select Renders empty options in multiple mode without crashing 1`] = `
               class="select-input-group input-group right-icon"
             >
               <input
-                aria-controls="dropdown-"
+                aria-controls="list-"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -99,7 +99,7 @@ exports[`Select Renders empty options in single mode without crashing 1`] = `
               class="select-input-group input-group right-icon"
             >
               <input
-                aria-controls="dropdown-"
+                aria-controls="list-"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -176,7 +176,7 @@ exports[`Select Renders null options in multiple mode without crashing 1`] = `
               class="select-input-group input-group right-icon"
             >
               <input
-                aria-controls="dropdown-"
+                aria-controls="list-"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -253,7 +253,7 @@ exports[`Select Renders null options in single mode without crashing 1`] = `
               class="select-input-group input-group right-icon"
             >
               <input
-                aria-controls="dropdown-"
+                aria-controls="list-"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -330,7 +330,7 @@ exports[`Select Renders with default value 1`] = `
               class="select-input-group input-group right-icon"
             >
               <input
-                aria-controls="dropdown-"
+                aria-controls="list-"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -477,7 +477,7 @@ exports[`Select Renders with default values when multiple 1`] = `
               class="select-input-group input-group right-icon"
             >
               <input
-                aria-controls="dropdown-"
+                aria-controls="list-"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -554,7 +554,7 @@ exports[`Select Renders without crashing 1`] = `
               class="select-input-group input-group right-icon"
             >
               <input
-                aria-controls="dropdown-"
+                aria-controls="list-"
                 aria-disabled="false"
                 aria-expanded="false"
                 aria-haspopup="true"
@@ -630,7 +630,7 @@ exports[`Select Select is large 1`] = `
             class="select-input-group input-group right-icon"
           >
             <input
-              aria-controls="dropdown-"
+              aria-controls="list-"
               aria-disabled="false"
               aria-expanded="false"
               aria-haspopup="true"
@@ -705,7 +705,7 @@ exports[`Select Select is medium 1`] = `
             class="select-input-group input-group right-icon"
           >
             <input
-              aria-controls="dropdown-"
+              aria-controls="list-"
               aria-disabled="false"
               aria-expanded="false"
               aria-haspopup="true"
@@ -780,7 +780,7 @@ exports[`Select Select is pill shaped 1`] = `
             class="select-input-group input-group right-icon"
           >
             <input
-              aria-controls="dropdown-"
+              aria-controls="list-"
               aria-disabled="false"
               aria-expanded="false"
               aria-haspopup="true"
@@ -855,7 +855,7 @@ exports[`Select Select is rectangle shaped 1`] = `
             class="select-input-group input-group right-icon"
           >
             <input
-              aria-controls="dropdown-"
+              aria-controls="list-"
               aria-disabled="false"
               aria-expanded="false"
               aria-haspopup="true"
@@ -930,7 +930,7 @@ exports[`Select Select is small 1`] = `
             class="select-input-group input-group right-icon"
           >
             <input
-              aria-controls="dropdown-"
+              aria-controls="list-"
               aria-disabled="false"
               aria-expanded="false"
               aria-haspopup="true"
@@ -1005,7 +1005,7 @@ exports[`Select Select is underline shaped 1`] = `
             class="select-input-group input-group right-icon"
           >
             <input
-              aria-controls="dropdown-"
+              aria-controls="list-"
               aria-disabled="false"
               aria-expanded="false"
               aria-haspopup="true"


### PR DESCRIPTION
## SUMMARY:
The Select Component in octuple internally uses DropDown and List component to show the list of options. Fixing the following a11y issues found by Axe Devtools in Select component:-

1.  Inside the `Select` component, the dropdown div is the parent of list (ul/ol) but both contain `role="listbox"`. This raises an issue that listbox role could not be inside another listbox role. Hence giving the `role="group"` for outer div.
<img width="1423" alt="Screenshot 2024-10-21 at 11 20 04" src="https://github.com/user-attachments/assets/2c2e0a8a-5a00-441e-b330-2394f196682e">

2.  Inside the `Select` component, the aria-label is missing from the input field list (ul/ol) which has the role="listbox". This is because correct `id` has not been passed onto the `<ul>` element so it could be corrected labeled by the `<input>` element using `aria-controls`.
<img width="1423" alt="Screenshot 2024-10-21 at 11 19 33" src="https://github.com/user-attachments/assets/6886dc14-51a0-49d9-9028-28260ef7258e">


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-110373
## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

1. Run storybook with yarn storybook
2. Inspect the Select component. Verify the `<input>` and `<ul role="listbox">` elements are correctly linked through aria-controls={id} (red boxes in below screenshot)
3. Verify the dropdown div (blue box in below screenshot) now contains `role="group"`, which fixes nested the role="listbox" elements issue.
 
<img width="1917" alt="Screenshot 2024-10-23 at 16 47 12" src="https://github.com/user-attachments/assets/50d93f66-a07f-4aef-9965-f305fe52c887">
