### PR TITLE
fix: select: populate selected options text on component render

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -217,6 +217,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
           ...option,
         }))
       );
+      getSelectedOptionText();
     }, [_options]);
 
     // Populate options on isLoading change


### PR DESCRIPTION
## SUMMARY:
The `selectedOptionText` inside the Select component was not setting when we are opening a HookForm in edit mode with pre-filled values. 
<img width="1002" alt="Screenshot 2024-11-08 at 18 24 07" src="https://github.com/user-attachments/assets/aab85c36-f441-4be3-9e8f-1e7649a48e2a">

Reason: Currently, the `selectedOptionText` is only calculated at render + when selected options changes. But in case of HookForm with initialValues, we use the hook_form's setValue method to pass on the initial value to SelectField which updates the `options` prop inside octuple's `Select` component. 

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-116130

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Login as a pcs candidate `/candidate/login?domain=eightfolddemo-pcsx-demo.com` ([sprajapati+demo4@eightfold.ai](mailto:sprajapati+demo4@eightfold.ai) / Welcome@1)
2. Go to Forms Center dashboard: `/careers/forms/center?domain=eightfolddemo-pcsx-demo.com&customredirect=1&tab=expense`
3. Click on `Edit` on any existing form request. Verify that the Category and Currency fields are pre-filled. Reload the page and verify again.