### PR TITLE
fix: auto close date picker after selection

### DIFF
--- a/src/components/DateTimePicker/Internal/Partials/DecadePartial/Decade.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/DecadePartial/Decade.tsx
@@ -49,6 +49,7 @@ function DecadePartial<DateType>(props: DecadePartialProps<DateType>) {
         },
         onEnter: (): void => {
           onPartialChange('year', viewDate);
+          onSelect(viewDate, 'mouse');
         },
       }),
   };

--- a/src/components/DateTimePicker/Internal/Partials/MonthPartial/Month.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/MonthPartial/Month.tsx
@@ -36,6 +36,7 @@ function MonthPartial<DateType>(props: MonthPartialProps<DateType>) {
         },
         onEnter: (): void => {
           onPartialChange('date', value || viewDate);
+          onSelect(value || viewDate, 'mouse');
         },
       }),
   };

--- a/src/components/DateTimePicker/Internal/Partials/QuarterPartial/Quarter.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/QuarterPartial/Quarter.tsx
@@ -31,6 +31,10 @@ function QuarterPartial<DateType>(props: QuarterPartialProps<DateType>) {
         onUpDown: (diff: number): void => {
           onSelect(generateConfig.addYear(value || viewDate, diff), 'key');
         },
+        onEnter: (): void => {
+          onPartialChange('quarter', value || viewDate);
+          onSelect(value || viewDate, 'mouse');
+        },
       }),
   };
 

--- a/src/components/DateTimePicker/Internal/Partials/YearPartial/Year.tsx
+++ b/src/components/DateTimePicker/Internal/Partials/YearPartial/Year.tsx
@@ -44,6 +44,7 @@ function YearPartial<DateType>(props: YearPartialProps<DateType>) {
             sourceMode === 'date' ? 'date' : 'month',
             value || viewDate
           );
+          onSelect(value || viewDate, 'mouse');
         },
       }),
   };


### PR DESCRIPTION
## SUMMARY:
Support onKeyDown for Partials in the Datepicker for Month, Quarter, Decade and Year


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-116348

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Run Storybook.
2. GO to the DatePicker component with Trap Focus
3. Using Keyboard tab into the component and then make sure the up, down and arrow keys can navigate the layout
4. Select a date and it should be selected and closed.