### PR TITLE
fix: dropdown auto click the element when TAB operation is invoked

### DIFF
--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -543,4 +543,34 @@ describe('Dropdown', () => {
     expect(container.querySelector('.dropdown-wrapper')).toBeFalsy();
     expect(referenceElement).toHaveFocus();
   });
+
+  test('Allows tabbing into submenu after click', async () => {
+    const mockEventKeys = {
+      TAB: 'Tab',
+    };
+    const { getByTestId } = render(<DropdownComponent />);
+    const referenceElement = getByTestId('dropdown-reference');
+
+    // Click to open dropdown
+    act(() => {
+      userEvent.click(referenceElement);
+    });
+
+    // Wait for menu to be visible
+    await waitFor(() => screen.getByText('User profile 1'));
+
+    // Verify first menu item is focused
+    await waitFor(() =>
+      expect(screen.getByTestId('User profile 1').matches(':focus')).toBe(true)
+    );
+
+    // Tab to second menu item
+    act(() => {
+      userEvent.type(referenceElement, mockEventKeys.TAB);
+    });
+
+    // Verify dropdown remains open
+    expect(referenceElement.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('User profile 1')).toBeVisible();
+  });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -296,7 +296,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           }, NO_ANIMATION_DURATION);
           const menuButtonEvent: HTMLButtonElement =
             document.activeElement as HTMLButtonElement;
-          menuButtonEvent.click();
+          menuButtonEvent?.focus?.();
         }
         if (event?.key === eventKeys.TAB && event.shiftKey) {
           timeout && clearTimeout(timeout);


### PR DESCRIPTION
## SUMMARY:
Dropdown element is clicking on first element since instead of focus, we were calling onclick event

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-116631

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Go to storybook
2. Go to Dropdown, Single Dropdown
3. Use Keyboard to Tab and when you tab multiple times it should not close or click on the element