### PR TITLE
[fix] revert InlineSvg changes

### DIFF
--- a/src/components/InlineSvg/InlineSvg.test.tsx
+++ b/src/components/InlineSvg/InlineSvg.test.tsx
@@ -1,26 +1,14 @@
 import '@testing-library/jest-dom/extend-expect';
-import fetch from 'cross-fetch';
+
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { InlineSvg } from './InlineSvg';
 
-jest.mock('cross-fetch', () => {
-  return jest.fn(() =>
-    Promise.resolve({
-      text: () => '<svg>Mock SVG</svg>',
-    })
-  );
-});
-
 describe('InlineSvg', () => {
   const url = 'https://static.vscdn.net/images/learning-opp.svg';
   const width = '300px';
   const height = '200px';
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
 
   test('renders a skeleton while loading the SVG image if enabled', async () => {
     const { container } = render(
@@ -53,21 +41,29 @@ describe('InlineSvg', () => {
   });
 
   test('Should call fetchSvg only once', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => '<svg>Mock SVG</svg>' })
+    ) as jest.Mock;
+
     const { rerender } = render(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
   test('Should call fetchSvg twice', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => '<svg>Mock SVG</svg>' })
+    ) as jest.Mock;
+
     const { rerender } = render(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url" />);
     rerender(<InlineSvg url="mock-url-diff" />);
     rerender(<InlineSvg url="mock-url-diff" />);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/InlineSvg/InlineSvg.tsx
+++ b/src/components/InlineSvg/InlineSvg.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useEffect, useMemo, useState, useRef, FC, Ref } from 'react';
-import fetch from 'cross-fetch';
 import { InlineSvgProps } from './InlineSvg.types';
 import { Icon, IconName } from '../Icon';
 import { Skeleton, SkeletonVariant } from '../Skeleton';


### PR DESCRIPTION
## SUMMARY:
Revert the usage of cross-fetch in InlineSvg and use fetch only

## GITHUB ISSUE (Open Source Contributors)
na
## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-116802
## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
InlineSvg should still work