### PR TITLE
fix: dropdown items are not moving to the next tab index due to stopPropagation

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -282,21 +282,16 @@ export const Dropdown: FC<DropdownProps> = React.memo(
       };
 
       const handleFloatingKeyDown = (event: React.KeyboardEvent): void => {
-        event.stopPropagation();
         if (event?.key === eventKeys.ESCAPE) {
           toggle(false)(event);
         }
         if (event?.key === eventKeys.TAB) {
-          event.preventDefault();
           timeout && clearTimeout(timeout);
           timeout = setTimeout(() => {
             if (!refs.floating.current.matches(':focus-within')) {
               toggle(false)(event);
             }
           }, NO_ANIMATION_DURATION);
-          const menuButtonEvent: HTMLButtonElement =
-            document.activeElement as HTMLButtonElement;
-          menuButtonEvent?.focus?.();
         }
         if (event?.key === eventKeys.TAB && event.shiftKey) {
           timeout && clearTimeout(timeout);


### PR DESCRIPTION
## SUMMARY:
There was a bug introduced recently to make the focus of the dropdown sticky.
This regressed any input fields to be stuck on first focus

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-116631

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Go to storybook
2. Check the Dropdown Advanced
3. Make sure you can tab into the checkbox



https://github.com/user-attachments/assets/93450c52-aed9-4ff6-8b71-15c8da1bf6ab

