### PR TITLE
fix: dropdown: fixed dropdown container focus issue

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -392,7 +392,6 @@ export const Dropdown: FC<DropdownProps> = React.memo(
               ref={refs.setFloating}
               style={dropdownStyles}
               className={dropdownClasses}
-              tabIndex={0}
               onClick={
                 closeOnDropdownClick ? toggle(false, showDropdown) : null
               }


### PR DESCRIPTION
## SUMMARY:
Issue When the user navigating through dropdown using shift + tab the focus is moving to the dropdown list container.
Fix: Focus should not be moved on dropdown container, focus should be move to the dropdown items, when we use the tab or shift + tab.


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-118833

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

1. Open the dropdown
2. Navigate between the dropdown items using tab and shift + tab
3. Observe the dropdown container: focus should not be moved on dropdown container

https://github.com/user-attachments/assets/85538d87-2813-4547-a605-49a6f6bab675



