### PR TITLE
fix: scroller is interrupting with the mouse events even when it is not visible

### DIFF
--- a/src/components/Table/Internal/Body/Scroller.tsx
+++ b/src/components/Table/Internal/Body/Scroller.tsx
@@ -273,7 +273,7 @@ export const Scroller = React.forwardRef(
                   BUTTON_PADDING
                 : 'unset',
             opacity: endButtonVisible && visible ? 1 : 0,
-            visibility: startButtonVisible && visible ? 'visible' : 'hidden',
+            visibility: endButtonVisible && visible ? 'visible' : 'hidden',
             right:
               direction === 'rtl'
                 ? 'unset'

--- a/src/components/Table/Internal/Body/Scroller.tsx
+++ b/src/components/Table/Internal/Body/Scroller.tsx
@@ -240,6 +240,7 @@ export const Scroller = React.forwardRef(
                 ? 'unset'
                 : startButtonLtrOffset + BUTTON_PADDING,
             opacity: startButtonVisible && visible ? 1 : 0,
+            visibility: startButtonVisible && visible ? 'visible' : 'hidden',
             right:
               direction === 'rtl'
                 ? startButtonRtlOffset + BUTTON_PADDING
@@ -272,6 +273,7 @@ export const Scroller = React.forwardRef(
                   BUTTON_PADDING
                 : 'unset',
             opacity: endButtonVisible && visible ? 1 : 0,
+            visibility: startButtonVisible && visible ? 'visible' : 'hidden',
             right:
               direction === 'rtl'
                 ? 'unset'


### PR DESCRIPTION
## SUMMARY:
Left scroller button in Table row interrupts with mouse events like hover popup, even when it is not visible.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-121104

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. pull branch down locally and build and sync with vscode octuple module under node modules.
2. Verify the hover on Demand pipeline page of resourcing.