### PR TITLE
[fix] [two state button] loader background color inconsistent when checked

### DIFF
--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -1510,7 +1510,7 @@
   color: var(--color);
 
   .loader {
-    background: var(--button-two-state-background-color);
+    background: var(--bg);
   }
 
   .loader-dot {


### PR DESCRIPTION
## SUMMARY:
- When checked prop is true for 2 state button , the loader background is default and not button background

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-121243

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist (storybook tests)
- [ ] I have added unittests for this change

## TEST PLAN:
- Visit storybook for `TwoStateButton`
- Toggle loading to True
- toggle checked to True, before vs after
<img width="400" alt="Screenshot 2024-12-12 at 9 19 50 AM" src="https://github.com/user-attachments/assets/71446a53-32eb-42d4-83bb-27a5ad0bdf3b" />
<img width="400" alt="Screenshot 2024-12-12 at 9 10 10 AM" src="https://github.com/user-attachments/assets/a0b4cafd-1f06-44fb-9648-25ada7290638" />

- Regression test: checked false, loading true, etc ... 
<img width="400" alt="Screenshot 2024-12-12 at 9 10 20 AM" src="https://github.com/user-attachments/assets/09b58c0a-c4da-4303-a042-cccb8fd13b4f" />
