### PR TITLE
fix: eng-120721 : added role to date picker span tag

### DIFF
--- a/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
+++ b/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
@@ -230,7 +230,7 @@ export default function generateRangePicker<DateType>(
               clearIconAriaLabelText={clearIconAriaLabelText}
               id={id}
               separator={
-                <span aria-label="to" className={styles.pickerSeparator} aria-hidden="true">
+                <span className={styles.pickerSeparator}>
                   <Icon
                     color="var(--grey-tertiary-color)"
                     path={IconName.mdiArrowRightThin}

--- a/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
+++ b/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
@@ -230,7 +230,7 @@ export default function generateRangePicker<DateType>(
               clearIconAriaLabelText={clearIconAriaLabelText}
               id={id}
               separator={
-                <span aria-label="to" className={styles.pickerSeparator}>
+                <span role="text" aria-label="to" className={styles.pickerSeparator}>
                   <Icon
                     color="var(--grey-tertiary-color)"
                     path={IconName.mdiArrowRightThin}

--- a/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
+++ b/src/components/DateTimePicker/DatePicker/Generate/generateRangePicker.tsx
@@ -230,7 +230,7 @@ export default function generateRangePicker<DateType>(
               clearIconAriaLabelText={clearIconAriaLabelText}
               id={id}
               separator={
-                <span role="text" aria-label="to" className={styles.pickerSeparator}>
+                <span aria-label="to" className={styles.pickerSeparator} aria-hidden="true">
                   <Icon
                     color="var(--grey-tertiary-color)"
                     path={IconName.mdiArrowRightThin}


### PR DESCRIPTION
## SUMMARY:

The tool  Accessibility Insights for web reports an issue ARIA attributes prohibited for element without any role. To fix this issue a
Removed aria-label attribute from span arrow

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-120721

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

Search for DateTimePicker component -> check for RangePicker component -> check for separator arrow role 

<img width="336" alt="image" src="https://github.com/user-attachments/assets/7b65e35f-5454-4c2d-87ce-405a3d3f111b" />

![image](https://github.com/user-attachments/assets/a30ad2ff-0f8b-45bb-92c3-314e5e8d6d1f)

on route : /events/edit?plannedEventId=xaoNqQjGk0Z
The Date picker arrow under Date and TIme edit section does not report an issue on ARC tool

![image](https://github.com/user-attachments/assets/a4b1346f-a66d-498a-9877-60bd5889b5f2)

