### PR TITLE
chore: add onerror to avatar component

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -354,6 +354,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
       onKeyDown,
       onMouseEnter,
       onMouseLeave,
+      onError,
       outline,
       popupProps = undefined,
       randomiseTheme,
@@ -484,6 +485,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
               onKeyDown={onKeyDown}
               onMouseEnter={onMouseEnter}
               onMouseLeave={onMouseLeave}
+              onError={onError}
               src={src}
               style={calculatedOutline}
               tabIndex={0}
@@ -540,6 +542,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
             onKeyDown={onKeyDown}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
+            onError={onError}
             ref={ref}
             style={{ ...wrapperContainerStyle, ...(calculatedOutline ?? {}) }}
           >


### PR DESCRIPTION
## SUMMARY:
Add onError prop to avatar component

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-122634

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
[WIP] Test by running storybook locally