### PR TITLE
Cpatil/added rest props for checkbox and radio components

### DIFF
--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -55,6 +55,7 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
       value,
       variant = SelectorVariant.Default,
       'data-test-id': dataTestId,
+      ...rest
     },
     ref: Ref<HTMLInputElement>
   ) => {
@@ -208,6 +209,7 @@ export const CheckBox: FC<CheckboxProps> = React.forwardRef(
             value={value}
             readOnly
             role={toggle ? 'switch' : 'checkbox'}
+            {...rest}
           />
           <label htmlFor={checkBoxId.current} className={labelClassNames}>
             {labelPosition == LabelPosition.Start && (

--- a/src/components/CheckBox/CheckBoxGroup.tsx
+++ b/src/components/CheckBox/CheckBoxGroup.tsx
@@ -107,7 +107,7 @@ export const CheckBoxGroup: FC<CheckboxGroupProps> = React.forwardRef(
       <div
         className={checkboxGroupClassNames}
         style={style}
-        role={items.length > 1 ? 'group' : undefined}
+        role={items?.length > 1 ? 'group' : undefined}
         aria-label={ariaLabel}
         id={id}
         ref={ref}

--- a/src/components/CheckBox/CheckBoxGroup.tsx
+++ b/src/components/CheckBox/CheckBoxGroup.tsx
@@ -107,7 +107,7 @@ export const CheckBoxGroup: FC<CheckboxGroupProps> = React.forwardRef(
       <div
         className={checkboxGroupClassNames}
         style={style}
-        role="group"
+        role={items.length > 1 ? 'group' : undefined}
         aria-label={ariaLabel}
         id={id}
         ref={ref}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -52,6 +52,7 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
       value = '',
       variant = SelectorVariant.Default,
       'data-test-id': dataTestId,
+      ...rest
     },
     ref: Ref<HTMLInputElement>
   ) => {
@@ -195,6 +196,7 @@ export const RadioButton: FC<RadioButtonProps> = React.forwardRef(
             value={value}
             onChange={!allowDisabledFocus ? toggleChecked : null}
             readOnly
+            {...rest}
           />
           <label htmlFor={radioButtonId.current} className={labelClassNames}>
             {labelPosition == LabelPosition.Start && (

--- a/src/components/RadioButton/RadioGroup.tsx
+++ b/src/components/RadioButton/RadioGroup.tsx
@@ -103,7 +103,7 @@ export const RadioGroup: FC<RadioGroupProps> = React.forwardRef(
     return (
       <RadioGroupProvider onChange={onChange} value={value}>
         <div
-          role="group"
+          role={items.length > 1 ? 'group' : undefined}
           className={radioGroupClasses}
           style={style}
           ref={ref}


### PR DESCRIPTION
## SUMMARY:
- Added condition for role attribute in checkboxgroup and radiogroup components
- Added rest props in checkbox and radiobutton components

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-122365

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Added rest props in checkbox and radiobutton components. So test if we can add attributes like `aria-required` onto the input element of these 2 components or not.

As we can see in the below screenshot, the `aria-required` is applied to all the checkbox input elements when we pass it through the items array and is also read as required by voice over, if it is true.
![image](https://github.com/user-attachments/assets/5c36c3b7-ff8a-466c-847e-728e3c38c060)


