### PR TITLE
a11y: Added aria hidden to expandable button

### DIFF
--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -100,6 +100,11 @@ export interface InputIconButtonProps {
    * Leverage this to programatically disable the focus for the button as needed.
    */
   tabIndex?: number;
+  /**
+   * Whether or not to apply the aria-hidden attribute to the icon button.
+   * @default false
+   */
+  ariaHidden?: boolean;
 }
 
 export interface ReadOnlyProps {

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -488,6 +488,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
         tabIndex={iconButtonProps.tabIndex}
         transparent
         variant={ButtonVariant.SystemUI}
+        aria-hidden={iconButtonProps.ariaHidden || false}
       />
     );
 

--- a/src/components/Inputs/TextInput/TextInput.tsx
+++ b/src/components/Inputs/TextInput/TextInput.tsx
@@ -488,7 +488,7 @@ export const TextInput: FC<TextInputProps> = React.forwardRef(
         tabIndex={iconButtonProps.tabIndex}
         transparent
         variant={ButtonVariant.SystemUI}
-        aria-hidden={iconButtonProps.ariaHidden || false}
+        aria-hidden={iconButtonProps.ariaHidden}
       />
     );
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -782,6 +782,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
             // the input itself provides the focus and action.
             tabIndex: -1,
             role: 'presentation',
+            ariaHidden: true,
             iconProps: {
               path: dropdownVisible
                 ? IconName.mdiChevronUp


### PR DESCRIPTION
## SUMMARY:

- Added `aria-hidden=true` to select expandable button as it was not passing aria attribute not allowed check from Accessibility insights tool.
- The button was already out of tab order and with role presentation.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
Jira task - https://eightfoldai.atlassian.net/browse/ENG-122358

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

- Go to select component and run Accessibility insights tool and check if there are no `aria-allowed-role` error.
<img width="1237" alt="Screenshot 2024-12-30 at 2 45 26 PM" src="https://github.com/user-attachments/assets/fcf21e0b-d605-4791-aa3f-b0a304f24a35" />

