### PR TITLE
fix: menuitem: added containerRole prop to menu item components

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -57,6 +57,10 @@ export interface MenuItemProps {
    * @default false
    */
   wrap?: boolean;
+  /**
+   * Menu Item Container Role
+   */
+  containerRole?: string;
 }
 
 type NativeMenuButtonProps = Omit<OcBaseProps<HTMLButtonElement>, 'children'>;

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -37,6 +37,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
       value,
       variant = MenuVariant.neutral,
       wrap = false,
+      containerRole,
       ...rest
     },
     ref: React.ForwardedRef<HTMLButtonElement>
@@ -170,6 +171,10 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
       return dropdownMenuItems ? dropdownMenuButton() : menuButton();
     };
 
-    return <li className={menuItemClassNames}>{renderedItem()}</li>;
+    return (
+      <li className={menuItemClassNames} role={containerRole}>
+        {renderedItem()}
+      </li>
+    );
   }
 );

--- a/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
+++ b/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
@@ -7,7 +7,14 @@ import styles from '../menuItem.module.scss';
 
 export const MenuItemCustom: FC<MenuItemCustomProps> = forwardRef(
   (
-    { classNames, index, onChange, size = MenuSize.medium, ...item },
+    {
+      classNames,
+      index,
+      onChange,
+      size = MenuSize.medium,
+      containerRole,
+      ...item
+    },
     ref: React.ForwardedRef<any>
   ) => {
     const menuItemClassNames: string = mergeClasses([
@@ -21,7 +28,7 @@ export const MenuItemCustom: FC<MenuItemCustomProps> = forwardRef(
     ]);
 
     return (
-      <li className={menuItemClassNames}>
+      <li className={menuItemClassNames} role={containerRole}>
         {item.render({ index, value: item, onChange, ref: ref })}
       </li>
     );

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -24,6 +24,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
       text,
       variant = MenuVariant.neutral,
       wrap = false,
+      containerRole,
       ...rest
     },
     ref: React.ForwardedRef<HTMLAnchorElement>
@@ -68,7 +69,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
     );
 
     return (
-      <li className={menuItemClassNames}>
+      <li className={menuItemClassNames} role={containerRole}>
         <Link
           classNames={styles.menuLink}
           disabled={disabled}

--- a/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
+++ b/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
@@ -7,7 +7,7 @@ import styles from '../menuItem.module.scss';
 
 export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = forwardRef(
   (
-    { classNames, direction, size, text, wrap, ...rest },
+    { classNames, direction, size, text, wrap, containerRole, ...rest },
     ref: React.ForwardedRef<HTMLSpanElement>
   ) => {
     const subHeaderClassNames: string = mergeClasses([
@@ -22,7 +22,7 @@ export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = forwardRef(
       classNames,
     ]);
     return (
-      <li className={subHeaderClassNames}>
+      <li className={subHeaderClassNames} role={containerRole}>
         <span data-disabled {...rest} tabIndex={-1} ref={ref}>
           {text}
         </span>


### PR DESCRIPTION
## SUMMARY:
Adds containerRole support to Menu Items to improve semantic structure and accessibility:

- Adds containerRole prop to MenuItemButton, MenuItemLink, MenuItemCustom, and MenuItemSubHeader components
- Enables custom role assignment for menu item container elements
- Improves semantic structure of menu items for better accessibility
- Maintains consistency across different menu item types

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-99021

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

1. Verify containerRole prop is properly applied to all menu item types
2. Test different role values for menu item containers
3. Check ARIA attributes and roles are correctly rendered
4. Verify existing menu functionality remains intact

<img width="1512" alt="Screenshot 2025-01-07 at 4 12 48 PM" src="https://github.com/user-attachments/assets/d8e91797-64b3-44da-9412-7f76633ab939" />
