### PR TITLE
fix: table cells access using shortcut key

### DIFF
--- a/src/components/InlineSvg/InlineSvg.test.tsx
+++ b/src/components/InlineSvg/InlineSvg.test.tsx
@@ -30,14 +30,19 @@ describe('InlineSvg', () => {
 
   test('renders an error icon when the SVG image fails to load', async () => {
     const errorUrl = 'https://example.com/broken.svg';
+    // Mock fetch to simulate a failed request
+    global.fetch = jest.fn(() =>
+      Promise.reject(new Error('Failed to fetch'))
+    ) as jest.Mock;
+
     const { container } = render(
       <InlineSvg url={errorUrl} width={width} height={height} />
     );
+
+    // Wait for error state to be set and component to re-render
     await waitFor(() => {
-      expect(
-        container.querySelector('.svg-display-error-icon')
-      ).toBeInTheDocument();
-    });
+      expect(container.querySelector('.svg-display-error-icon')).toBeInTheDocument();
+    }, { timeout: 3000 });
   });
 
   test('Should call fetchSvg only once', async () => {

--- a/src/components/Table/Hooks/useSorter.tsx
+++ b/src/components/Table/Hooks/useSorter.tsx
@@ -175,7 +175,33 @@ function injectSorter<RecordType>(
         ]),
         title: (renderProps: ColumnTitleProps<RecordType>) => {
           const renderSortTitle = (
-            <div className={styles.tableColumnSorters}>
+            <div 
+              className={mergeClasses([
+                styles.tableColumnSorters,
+                styles.tableColumnHasSorters,
+              ])}
+              onClick={(event: React.MouseEvent<HTMLElement>) => {
+                triggerSorter({
+                  column,
+                  key: columnKey,
+                  sortOrder: nextSortOrder,
+                  multiplePriority: getMultiplePriority(column),
+                });
+              }}
+              onKeyDown={(event: React.KeyboardEvent<HTMLElement>) => {
+                if (event.key === eventKeys.ENTER) {
+                  triggerSorter({
+                    column,
+                    key: columnKey,
+                    sortOrder: nextSortOrder,
+                    multiplePriority: getMultiplePriority(column),
+                  });
+                }
+              }}
+              tabIndex={0}
+              role="button"
+              data-sort-order={sorterOrder}
+            >
               <span className={styles.tableColumnTitle}>
                 {renderColumnTitle(column.title, renderProps)}
               </span>
@@ -214,48 +240,13 @@ function injectSorter<RecordType>(
         onHeaderCell: (col) => {
           const cell: React.HTMLAttributes<HTMLElement> =
             (column.onHeaderCell && column.onHeaderCell(col)) || {};
-          const originOnClick = cell.onClick;
-          const originOKeyDown = cell.onKeyDown;
-          cell.onClick = (event: React.MouseEvent<HTMLElement>) => {
-            triggerSorter({
-              column,
-              key: columnKey,
-              sortOrder: nextSortOrder,
-              multiplePriority: getMultiplePriority(column),
-            });
-            originOnClick?.(event);
+          return {
+            ...cell,
+            className: mergeClasses([
+              cell.className,
+              styles.tableColumnHasSorters,
+            ])
           };
-          cell.onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-            if (event.key === eventKeys.ENTER) {
-              triggerSorter({
-                column,
-                key: columnKey,
-                sortOrder: nextSortOrder,
-                multiplePriority: getMultiplePriority(column),
-              });
-              originOKeyDown?.(event);
-            }
-          };
-
-          // Inform the screen-reader so it can tell the visually impaired user which column is sorted
-          if (sorterOrder) {
-            if (sorterOrder === 'ascend') {
-              cell['aria-sort'] = 'ascending';
-            } else {
-              cell['aria-sort'] = 'descending';
-            }
-          }
-
-          // Ensures the cell has the proper role.
-          cell.role = 'button';
-
-          cell.className = mergeClasses([
-            cell.className,
-            styles.tableColumnHasSorters,
-          ]);
-          cell.tabIndex = 0;
-
-          return cell;
         },
       };
     }

--- a/src/components/Table/Tests/Table.sorter.test.js
+++ b/src/components/Table/Tests/Table.sorter.test.js
@@ -127,18 +127,19 @@ describe('Table.sorter', () => {
     const wrapper = mount(createTable());
 
     const getNameColumn = () => wrapper.find('th').at(0);
+    const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // first assert default state
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
 
     // ascend
-    wrapper.find('.table-column-sorters').simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
     expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
 
     // descend
-    wrapper.find('.table-column-sorters').simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual('descending');
   });
@@ -148,13 +149,15 @@ describe('Table.sorter', () => {
 
     // ascend
     wrapper
-      .find('.table-column-has-sorters')
+      .find('.table-column-sorters')
+      .at(0)
       .simulate('keydown', { key: eventKeys.ENTER });
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
 
     // descend
     wrapper
-      .find('.table-column-has-sorters')
+      .find('.table-column-sorters')
+      .at(0)
       .simulate('keydown', { key: eventKeys.ENTER });
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
   });
@@ -331,16 +334,18 @@ describe('Table.sorter', () => {
     ];
     const wrapper = mount(<Table columns={columns} dataSource={testData} />);
 
-    const getNameColumn = () => wrapper.find('.table-column-has-sorters').at(0);
-    const getAgeColumn = () => wrapper.find('.table-column-has-sorters').at(1);
+    const getNameColumn = () => wrapper.find('th').at(0);
+    const getAgeColumn = () => wrapper.find('th').at(1);
+    const getNameSortButton = () => wrapper.find('.table-column-sorters').at(0);
+    const getAgeSortButton = () => wrapper.find('.table-column-sorters').at(1);
 
     // sort name
-    getNameColumn().simulate('click');
+    getNameSortButton().simulate('click');
     expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
     expect(getAgeColumn().prop('aria-sort')).toEqual(undefined);
 
     // sort age
-    getAgeColumn().simulate('click');
+    getAgeSortButton().simulate('click');
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
     expect(getAgeColumn().prop('aria-sort')).toEqual('ascending');
   });
@@ -384,17 +389,18 @@ describe('Table.sorter', () => {
     const wrapper = mount(<TableTest />);
 
     const getNameColumn = () => wrapper.find('th').at(0);
+    const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // sort name
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
 
     // sort name
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(getNameColumn().prop('aria-sort')).toEqual('descending');
 
     // sort name
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
   });
 
@@ -565,19 +571,20 @@ describe('Table.sorter', () => {
       })
     );
     const getNameColumn = () => wrapper.find('th').at(0);
+    const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // descend
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual('descending');
 
     // ascend
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
     expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
 
     // cancel sort
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
   });
@@ -590,17 +597,18 @@ describe('Table.sorter', () => {
     );
 
     const getNameColumn = () => wrapper.find('th').at(0);
+    const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // default
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
 
     // descend
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual('descending');
 
     // cancel sort
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
   });
@@ -616,17 +624,18 @@ describe('Table.sorter', () => {
     );
 
     const getNameColumn = () => wrapper.find('th').at(0);
+    const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // default
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
 
     // descend
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual('descending');
 
     // cancel sort
-    getNameColumn().simulate('click');
+    getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
     expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
   });
@@ -644,7 +653,7 @@ describe('Table.sorter', () => {
         ]}
       />
     );
-    wrapper.find('th').simulate('click');
+    wrapper.find('.table-column-sorters').simulate('click');
     expect(onClick).toHaveBeenCalled();
   });
 
@@ -739,9 +748,9 @@ describe('Table.sorter', () => {
       </Table>
     );
 
-    wrapper.find('th').first().simulate('click');
+    wrapper.find('.table-column-sorters').first().simulate('click');
 
-    expect(wrapper.find('th.table-column-sort')).toHaveLength(1);
+    expect(wrapper.find('.table-column-sort')).toHaveLength(1);
   });
 
   it('surger should support sorterOrder', () => {

--- a/src/components/Table/Tests/Table.sorter.test.js
+++ b/src/components/Table/Tests/Table.sorter.test.js
@@ -95,7 +95,7 @@ describe('Table.sorter', () => {
     const getNameColumn = () => wrapper.find('th').at(0);
 
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
   });
 
   it('should change aria-sort when default sort order is set to descend', () => {
@@ -114,13 +114,14 @@ describe('Table.sorter', () => {
 
     // Test that it cycles through the order of sortDirections
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
 
     wrapper.find('.table-column-sorters').simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
 
     wrapper.find('.table-column-sorters').simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
   });
 
   it('sort records', () => {
@@ -131,17 +132,18 @@ describe('Table.sorter', () => {
 
     // first assert default state
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
 
     // ascend
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
 
     // descend
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
   });
 
   it('sort records with keydown', () => {
@@ -341,13 +343,15 @@ describe('Table.sorter', () => {
 
     // sort name
     getNameSortButton().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
-    expect(getAgeColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
+    expect(getAgeColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getAgeColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
 
     // sort age
     getAgeSortButton().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
-    expect(getAgeColumn().prop('aria-sort')).toEqual('ascending');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
+    expect(getAgeColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
   });
 
   it('should toggle sort state when columns are put in render', () => {
@@ -393,15 +397,16 @@ describe('Table.sorter', () => {
 
     // sort name
     getSortButton().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
 
     // sort name
     getSortButton().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
 
     // sort name
     getSortButton().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
   });
 
   it('should toggle sort state when columns with non primitive properties are put in render', () => {
@@ -445,18 +450,20 @@ describe('Table.sorter', () => {
     const wrapper = mount(<TableTest />);
 
     const getNameColumn = () => wrapper.find('th').at(0);
+    const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // sort name
-    getNameColumn().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
+    getSortButton().simulate('click');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
 
     // sort name
-    getNameColumn().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    getSortButton().simulate('click');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
 
     // sort name
-    getNameColumn().simulate('click');
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    getSortButton().simulate('click');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
   });
 
   it('should toggle sort state when columns with key are put in render', () => {
@@ -501,67 +508,24 @@ describe('Table.sorter', () => {
 
     const wrapper = mount(<TableTest />);
     const getNameColumn = () => wrapper.find('th').at(0);
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-up')
-    ).toBeFalsy();
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-down')
-    ).toBeFalsy();
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
+
+    // Initial state
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
 
     // sort name
-    getNameColumn().simulate('click');
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-up')
-    ).toBeTruthy();
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-down')
-    ).toBeFalsy();
-    expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
+    getSortButton().simulate('click');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
 
     // sort name
-    getNameColumn().simulate('click');
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-up')
-    ).toBeFalsy();
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-down')
-    ).toBeTruthy();
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    getSortButton().simulate('click');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
 
     // sort name
-    getNameColumn().simulate('click');
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-up')
-    ).toBeFalsy();
-    expect(
-      getNameColumn()
-        .find('.table-column-sorter')
-        .at(0)
-        .hasClass('table-column-sorter-down')
-    ).toBeFalsy();
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    getSortButton().simulate('click');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
   });
 
   it('should first sort by descend, then ascend, then cancel sort', () => {
@@ -576,17 +540,18 @@ describe('Table.sorter', () => {
     // descend
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
 
     // ascend
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Jerry', 'Lucy', 'Tom']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('ascending');
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeTruthy();
 
     // cancel sort
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
   });
 
   it('should first sort by descend, then cancel sort', () => {
@@ -600,17 +565,19 @@ describe('Table.sorter', () => {
     const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // default
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
 
     // descend
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
 
     // cancel sort
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
   });
 
   it('should first sort by descend, then cancel sort. (column prop)', () => {
@@ -627,17 +594,19 @@ describe('Table.sorter', () => {
     const getSortButton = () => wrapper.find('.table-column-sorters').at(0);
 
     // default
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
 
     // descend
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Tom', 'Lucy', 'Jack', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual('descending');
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeTruthy();
 
     // cancel sort
     getSortButton().simulate('click');
     expect(renderedNames(wrapper)).toEqual(['Jack', 'Lucy', 'Tom', 'Jerry']);
-    expect(getNameColumn().prop('aria-sort')).toEqual(undefined);
+    expect(getNameColumn().find('.table-column-sorter-up').exists()).toBeFalsy();
+    expect(getNameColumn().find('.table-column-sorter-down').exists()).toBeFalsy();
   });
 
   it('should support onHeaderCell in sort column', () => {

--- a/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
@@ -13,8 +13,6 @@ LoadedCheerio {
           Node {
             "attribs": Object {
               "class": "table-cell table-column-has-sorters",
-              "role": "button",
-              "tabindex": "0",
             },
             "children": Array [
               Node {
@@ -26,9 +24,11 @@ LoadedCheerio {
                   Node {
                     "attribs": Object {
                       "aria-describedby": "sortTip",
-                      "class": "table-column-sorters tooltip-reference",
+                      "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                       "data-reference-id": "sortTip-reference",
                       "id": "sortTip-reference",
+                      "role": "button",
+                      "tabindex": "0",
                     },
                     "children": Array [
                       Node {
@@ -311,12 +311,16 @@ LoadedCheerio {
                       "class": undefined,
                       "data-reference-id": undefined,
                       "id": undefined,
+                      "role": undefined,
+                      "tabindex": undefined,
                     },
                     "x-attribsPrefix": Object {
                       "aria-describedby": undefined,
                       "class": undefined,
                       "data-reference-id": undefined,
                       "id": undefined,
+                      "role": undefined,
+                      "tabindex": undefined,
                     },
                   },
                 ],
@@ -344,13 +348,9 @@ LoadedCheerio {
             "type": "tag",
             "x-attribsNamespace": Object {
               "class": undefined,
-              "role": undefined,
-              "tabindex": undefined,
             },
             "x-attribsPrefix": Object {
               "class": undefined,
-              "role": undefined,
-              "tabindex": undefined,
             },
           },
         ],
@@ -3174,8 +3174,6 @@ LoadedCheerio {
                                   Node {
                                     "attribs": Object {
                                       "class": "table-cell table-column-has-sorters",
-                                      "role": "button",
-                                      "tabindex": "0",
                                     },
                                     "children": Array [
                                       Node {
@@ -3187,9 +3185,11 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-describedby": "sortTip",
-                                              "class": "table-column-sorters tooltip-reference",
+                                              "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
+                                              "role": "button",
+                                              "tabindex": "0",
                                             },
                                             "children": Array [
                                               Node {
@@ -3472,12 +3472,16 @@ LoadedCheerio {
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
                                               "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                           },
                                         ],
@@ -3505,13 +3509,9 @@ LoadedCheerio {
                                     "type": "tag",
                                     "x-attribsNamespace": Object {
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                     "x-attribsPrefix": Object {
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                   },
                                 ],
@@ -4329,8 +4329,6 @@ LoadedCheerio {
                                 Node {
                                   "attribs": Object {
                                     "class": "table-cell table-column-has-sorters",
-                                    "role": "button",
-                                    "tabindex": "0",
                                   },
                                   "children": Array [
                                     Node {
@@ -4342,9 +4340,11 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-describedby": "sortTip",
-                                            "class": "table-column-sorters tooltip-reference",
+                                            "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "id": "sortTip-reference",
+                                            "role": "button",
+                                            "tabindex": "0",
                                           },
                                           "children": Array [
                                             Node {
@@ -4627,12 +4627,16 @@ LoadedCheerio {
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
                                             "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                         },
                                       ],
@@ -4660,13 +4664,9 @@ LoadedCheerio {
                                   "type": "tag",
                                   "x-attribsNamespace": Object {
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                   "x-attribsPrefix": Object {
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                 },
                               ],
@@ -6255,8 +6255,6 @@ LoadedCheerio {
                                   Node {
                                     "attribs": Object {
                                       "class": "table-cell table-column-has-sorters",
-                                      "role": "button",
-                                      "tabindex": "0",
                                     },
                                     "children": Array [
                                       Node {
@@ -6268,9 +6266,11 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-describedby": "sortTip",
-                                              "class": "table-column-sorters tooltip-reference",
+                                              "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
+                                              "role": "button",
+                                              "tabindex": "0",
                                             },
                                             "children": Array [
                                               Node {
@@ -6553,12 +6553,16 @@ LoadedCheerio {
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
                                               "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                           },
                                         ],
@@ -6586,13 +6590,9 @@ LoadedCheerio {
                                     "type": "tag",
                                     "x-attribsNamespace": Object {
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                     "x-attribsPrefix": Object {
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                   },
                                 ],
@@ -6845,10 +6845,7 @@ LoadedCheerio {
                               "children": Array [
                                 Node {
                                   "attribs": Object {
-                                    "aria-sort": "ascending",
                                     "class": "table-cell table-column-sort table-column-has-sorters",
-                                    "role": "button",
-                                    "tabindex": "0",
                                   },
                                   "children": Array [
                                     Node {
@@ -6860,9 +6857,12 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-describedby": "sortTip",
-                                            "class": "table-column-sorters tooltip-reference",
+                                            "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
+                                            "data-sort-order": "ascend",
                                             "id": "sortTip-reference",
+                                            "role": "button",
+                                            "tabindex": "0",
                                           },
                                           "children": Array [
                                             Node {
@@ -7144,13 +7144,19 @@ LoadedCheerio {
                                             "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
+                                            "data-sort-order": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
                                             "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
+                                            "data-sort-order": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                         },
                                       ],
@@ -7177,16 +7183,10 @@ LoadedCheerio {
                                   "prev": null,
                                   "type": "tag",
                                   "x-attribsNamespace": Object {
-                                    "aria-sort": undefined,
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                   "x-attribsPrefix": Object {
-                                    "aria-sort": undefined,
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                 },
                               ],
@@ -7295,10 +7295,7 @@ LoadedCheerio {
                             "children": Array [
                               Node {
                                 "attribs": Object {
-                                  "aria-sort": "ascending",
                                   "class": "table-cell table-column-sort table-column-has-sorters",
-                                  "role": "button",
-                                  "tabindex": "0",
                                 },
                                 "children": Array [
                                   Node {
@@ -7310,9 +7307,12 @@ LoadedCheerio {
                                       Node {
                                         "attribs": Object {
                                           "aria-describedby": "sortTip",
-                                          "class": "table-column-sorters tooltip-reference",
+                                          "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                           "data-reference-id": "sortTip-reference",
+                                          "data-sort-order": "ascend",
                                           "id": "sortTip-reference",
+                                          "role": "button",
+                                          "tabindex": "0",
                                         },
                                         "children": Array [
                                           Node {
@@ -7594,13 +7594,19 @@ LoadedCheerio {
                                           "aria-describedby": undefined,
                                           "class": undefined,
                                           "data-reference-id": undefined,
+                                          "data-sort-order": undefined,
                                           "id": undefined,
+                                          "role": undefined,
+                                          "tabindex": undefined,
                                         },
                                         "x-attribsPrefix": Object {
                                           "aria-describedby": undefined,
                                           "class": undefined,
                                           "data-reference-id": undefined,
+                                          "data-sort-order": undefined,
                                           "id": undefined,
+                                          "role": undefined,
+                                          "tabindex": undefined,
                                         },
                                       },
                                     ],
@@ -7627,16 +7633,10 @@ LoadedCheerio {
                                 "prev": null,
                                 "type": "tag",
                                 "x-attribsNamespace": Object {
-                                  "aria-sort": undefined,
                                   "class": undefined,
-                                  "role": undefined,
-                                  "tabindex": undefined,
                                 },
                                 "x-attribsPrefix": Object {
-                                  "aria-sort": undefined,
                                   "class": undefined,
-                                  "role": undefined,
-                                  "tabindex": undefined,
                                 },
                               },
                             ],
@@ -7808,10 +7808,7 @@ LoadedCheerio {
                               "children": Array [
                                 Node {
                                   "attribs": Object {
-                                    "aria-sort": "ascending",
                                     "class": "table-cell table-column-sort table-column-has-sorters",
-                                    "role": "button",
-                                    "tabindex": "0",
                                   },
                                   "children": Array [
                                     Node {
@@ -7823,9 +7820,12 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-describedby": "sortTip",
-                                            "class": "table-column-sorters tooltip-reference",
+                                            "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
+                                            "data-sort-order": "ascend",
                                             "id": "sortTip-reference",
+                                            "role": "button",
+                                            "tabindex": "0",
                                           },
                                           "children": Array [
                                             Node {
@@ -8107,13 +8107,19 @@ LoadedCheerio {
                                             "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
+                                            "data-sort-order": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
                                             "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
+                                            "data-sort-order": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                         },
                                       ],
@@ -8140,16 +8146,10 @@ LoadedCheerio {
                                   "prev": null,
                                   "type": "tag",
                                   "x-attribsNamespace": Object {
-                                    "aria-sort": undefined,
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                   "x-attribsPrefix": Object {
-                                    "aria-sort": undefined,
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                 },
                               ],
@@ -8706,10 +8706,7 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "aria-sort": "ascending",
                                       "class": "table-cell table-column-sort table-column-has-sorters",
-                                      "role": "button",
-                                      "tabindex": "0",
                                     },
                                     "children": Array [
                                       Node {
@@ -8721,9 +8718,12 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-describedby": "sortTip",
-                                              "class": "table-column-sorters tooltip-reference",
+                                              "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
+                                              "data-sort-order": "ascend",
                                               "id": "sortTip-reference",
+                                              "role": "button",
+                                              "tabindex": "0",
                                             },
                                             "children": Array [
                                               Node {
@@ -9005,13 +9005,19 @@ LoadedCheerio {
                                               "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
+                                              "data-sort-order": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
                                               "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
+                                              "data-sort-order": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                           },
                                         ],
@@ -9038,16 +9044,10 @@ LoadedCheerio {
                                     "prev": null,
                                     "type": "tag",
                                     "x-attribsNamespace": Object {
-                                      "aria-sort": undefined,
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                     "x-attribsPrefix": Object {
-                                      "aria-sort": undefined,
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                   },
                                 ],
@@ -9156,10 +9156,7 @@ LoadedCheerio {
                               "children": Array [
                                 Node {
                                   "attribs": Object {
-                                    "aria-sort": "ascending",
                                     "class": "table-cell table-column-sort table-column-has-sorters",
-                                    "role": "button",
-                                    "tabindex": "0",
                                   },
                                   "children": Array [
                                     Node {
@@ -9171,9 +9168,12 @@ LoadedCheerio {
                                         Node {
                                           "attribs": Object {
                                             "aria-describedby": "sortTip",
-                                            "class": "table-column-sorters tooltip-reference",
+                                            "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
+                                            "data-sort-order": "ascend",
                                             "id": "sortTip-reference",
+                                            "role": "button",
+                                            "tabindex": "0",
                                           },
                                           "children": Array [
                                             Node {
@@ -9455,13 +9455,19 @@ LoadedCheerio {
                                             "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
+                                            "data-sort-order": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
                                             "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
+                                            "data-sort-order": undefined,
                                             "id": undefined,
+                                            "role": undefined,
+                                            "tabindex": undefined,
                                           },
                                         },
                                       ],
@@ -9488,16 +9494,10 @@ LoadedCheerio {
                                   "prev": null,
                                   "type": "tag",
                                   "x-attribsNamespace": Object {
-                                    "aria-sort": undefined,
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                   "x-attribsPrefix": Object {
-                                    "aria-sort": undefined,
                                     "class": undefined,
-                                    "role": undefined,
-                                    "tabindex": undefined,
                                   },
                                 },
                               ],
@@ -9669,10 +9669,7 @@ LoadedCheerio {
                                 "children": Array [
                                   Node {
                                     "attribs": Object {
-                                      "aria-sort": "ascending",
                                       "class": "table-cell table-column-sort table-column-has-sorters",
-                                      "role": "button",
-                                      "tabindex": "0",
                                     },
                                     "children": Array [
                                       Node {
@@ -9684,9 +9681,12 @@ LoadedCheerio {
                                           Node {
                                             "attribs": Object {
                                               "aria-describedby": "sortTip",
-                                              "class": "table-column-sorters tooltip-reference",
+                                              "class": "table-column-sorters table-column-has-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
+                                              "data-sort-order": "ascend",
                                               "id": "sortTip-reference",
+                                              "role": "button",
+                                              "tabindex": "0",
                                             },
                                             "children": Array [
                                               Node {
@@ -9968,13 +9968,19 @@ LoadedCheerio {
                                               "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
+                                              "data-sort-order": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
                                               "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
+                                              "data-sort-order": undefined,
                                               "id": undefined,
+                                              "role": undefined,
+                                              "tabindex": undefined,
                                             },
                                           },
                                         ],
@@ -10001,16 +10007,10 @@ LoadedCheerio {
                                     "prev": null,
                                     "type": "tag",
                                     "x-attribsNamespace": Object {
-                                      "aria-sort": undefined,
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                     "x-attribsPrefix": Object {
-                                      "aria-sort": undefined,
                                       "class": undefined,
-                                      "role": undefined,
-                                      "tabindex": undefined,
                                     },
                                   },
                                 ],


### PR DESCRIPTION
## SUMMARY:

- removed the `role="button"` and other accessibility attributes from `<th>` to its inside `div`

### ISSUE:
**Issue** was user not able to move to cells which are having buttons, like: `Sorting Button`, `Action button` which you can view in below recording.

https://github.com/user-attachments/assets/4aad86e2-4884-49d8-a079-848a2b8bb6ee


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

JIRA Tickets:

1. https://eightfoldai.atlassian.net/browse/ENG-126322
2. https://eightfoldai.atlassian.net/browse/ENG-126330

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

Verify that the user is able to navigate to different cells using table. shortcut keys which are

1.  Win: ctrl+alt+`Arrow keys`
2. Mac: control+option+`Arrow Keys`

**After Implementing the solution**

https://github.com/user-attachments/assets/9e85b7b9-c44f-4a09-ac29-237982c51dc1


