### PR TITLE
fix: remove unused event parameter from Table sorter onClick handler

### DIFF
--- a/src/components/Table/Hooks/useSorter.tsx
+++ b/src/components/Table/Hooks/useSorter.tsx
@@ -175,12 +175,12 @@ function injectSorter<RecordType>(
         ]),
         title: (renderProps: ColumnTitleProps<RecordType>) => {
           const renderSortTitle = (
-            <div 
+            <div
               className={mergeClasses([
                 styles.tableColumnSorters,
                 styles.tableColumnHasSorters,
               ])}
-              onClick={(event: React.MouseEvent<HTMLElement>) => {
+              onClick={() => {
                 triggerSorter({
                   column,
                   key: columnKey,
@@ -245,7 +245,7 @@ function injectSorter<RecordType>(
             className: mergeClasses([
               cell.className,
               styles.tableColumnHasSorters,
-            ])
+            ]),
           };
         },
       };


### PR DESCRIPTION
## SUMMARY:
Removing an unused event parameter in the Table Sorter onClick function

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-126322

## CHANGE TYPE:

- [X] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [X] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
> This is a lint error