### PR TITLE
[Fix][TM-oncall]: Upload container max width 100%

### DIFF
--- a/src/components/Upload/upload.module.scss
+++ b/src/components/Upload/upload.module.scss
@@ -352,6 +352,7 @@ $upload-picture-card-size: 104px;
     }
 
     &-container {
+      max-width: 100%;
       border-radius: $border-radius-xl;
       margin: 0 auto;
       padding: $space-xl;


### PR DESCRIPTION
## SUMMARY:
- Fix max width on Large dropzone container
- Before vs after
<img width="400" alt="Screenshot 2025-02-03 at 8 49 55 PM" src="https://github.com/user-attachments/assets/5d017d76-9907-4b87-b166-cec066384fdd" />
<img width="400" alt="Screenshot 2025-02-03 at 8 49 41 PM" src="https://github.com/user-attachments/assets/45508e6f-f8bb-44e0-82d7-2a3582bea71d" />

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-126557

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
- open storybook http://octuple.eightfold-corp.ai/?path=/story/upload--drag-and-drop-single-large
- (large dropzone)
- Upload a file with large name, the name should not overflow
- Before vs after
<img width="400" alt="Screenshot 2025-02-03 at 8 49 55 PM" src="https://github.com/user-attachments/assets/5d017d76-9907-4b87-b166-cec066384fdd" />
<img width="400" alt="Screenshot 2025-02-03 at 8 49 41 PM" src="https://github.com/user-attachments/assets/45508e6f-f8bb-44e0-82d7-2a3582bea71d" />