### PR TITLE
Fix: Close dropdown on Shift + Tab and enable cyclic navigation for menu items.

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -464,6 +464,7 @@ const dropdownArgs: Object = {
     role: 'listbox',
     'aria-label': 'Dropdown overlay',
   },
+  toggleDropdownOnShiftTab: true,
 };
 
 Dropdown_Button.args = {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -77,6 +77,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         width,
         overlayTabIndex = 0,
         overlayProps,
+        toggleDropdownOnShiftTab = true,
       },
       ref: React.ForwardedRef<DropdownRef>
     ) => {
@@ -299,7 +300,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           timeout && clearTimeout(timeout);
           timeout = setTimeout(() => {
             if (refs.floating.current.matches(':focus-within')) {
-              toggle(true)(event);
+              toggle(toggleDropdownOnShiftTab)(event);
             }
           }, NO_ANIMATION_DURATION);
         }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -393,6 +393,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           >
             <div
               ref={refs.setFloating}
+              // @ts-expect-error - This is a valid CSSProperties object
               style={dropdownStyles}
               className={dropdownClasses}
               tabIndex={overlayTabIndex}

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -85,6 +85,11 @@ export interface DropdownProps {
    */
   onVisibleChange?: (visible: boolean) => void;
   /**
+   * If the dropdown should be shown when the user presses the shift + tab key
+   * @default true
+   */
+  toggleDropdownOnShiftTab?: boolean;
+  /**
    * The dropdown content
    */
   overlay?: React.ReactElement;

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -35,6 +35,7 @@ export const List = <T extends any>({
   itemProps,
   getItem,
   id,
+  applyCyclicNavigation = false,
   ...rest
 }: ListProps<T>) => {
   const htmlDir: string = useCanvasDirection();
@@ -73,6 +74,8 @@ export const List = <T extends any>({
     const arrowIncrement: boolean = htmlDir === 'rtl' ? arrowLeft : arrowRight;
     const end: boolean = event?.key === eventKeys.END;
     const home: boolean = event?.key === eventKeys.HOME;
+    // If additional item is present, add 1 to the total items.
+    const totalItems = renderAdditionalItem ? items.length + 1 : items.length;
     if (
       ((arrowDown || arrowUp) && layout === 'vertical') ||
       ((arrowDecrement || arrowIncrement) && layout === 'horizontal')
@@ -86,7 +89,9 @@ export const List = <T extends any>({
             (arrowIncrement && layout === 'horizontal')
               ? 1
               : -1;
-          let nextIndex: number = index + step;
+          let nextIndex: number = applyCyclicNavigation
+            ? (index + step + totalItems) % totalItems
+            : index + step;
           const additionalItemIndex: number = items ? items.length : 0;
           if (
             (renderAdditionalItem &&

--- a/src/components/List/List.types.ts
+++ b/src/components/List/List.types.ts
@@ -86,4 +86,9 @@ export interface ListProps<T> extends OcBaseProps<HTMLDivElement> {
    * @param item
    */
   rowKey?: (item: T) => Key | keyof T;
+  /**
+   * Optionally apply cyclic navigation for arrow keys.
+   * @default false
+   */
+  applyCyclicNavigation?: boolean;
 }

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -458,6 +458,7 @@ const menuArgs: object = {
   listType: 'ul',
   role: 'list',
   itemProps: { role: 'listitem' },
+  applyCyclicNavigation: false,
 };
 
 Basic_Menu.args = {


### PR DESCRIPTION
## SUMMARY:
Toggle Dropdown on Shift+Tab Behavior & Cyclic Navigation

- Added functionality to toggle dropdown visibility when pressing Shift + Tab.
- Maintains existing Tab behavior while adding Shift + Tab support.
- Provided a way to handle cyclic navigation for menu items.
- Introduced a flag applyCyclicNavigation in the List component:
  - When set to `true`, cyclic navigation is enabled.
  - When `false` or `unset`, the behavior remains unchanged.

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-118833

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
**Toggle Dropdown on Shift+Tab**

1. Pass `toggleDropdownOnShiftTab ={false}` to dropdown component
2. Navigate to dropdown button
3. Press Enter
4. Once Dropdown appear Press Shift+Tab
5. Observe Dropdown should close.

https://github.com/user-attachments/assets/54390c0e-27c0-4b51-93d0-b87aa9a1159a

**Enabling Cyclic Navigation in Dropdown**

1. Pass `applyCyclicNavigation={true}` to the List/Menu component.
2. Navigate to the dropdown button.
3. Press Enter to open the dropdown.
4. Use arrow keys to navigate through menu items.
5. Observe that focus cycles through the dropdown menu items seamlessly.

https://github.com/user-attachments/assets/88fe98b6-b72c-407d-96e8-1df19b159b11

