### PR TITLE
fix: a11y: Fix role inheritance for select options

### DIFF
--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -170,6 +170,10 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
       return dropdownMenuItems ? dropdownMenuButton() : menuButton();
     };
 
-    return <li className={menuItemClassNames}>{renderedItem()}</li>;
+    return (
+      <li className={menuItemClassNames} role="presentation">
+        {renderedItem()}
+      </li>
+    );
   }
 );

--- a/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
+++ b/src/components/Menu/MenuItem/MenuItemCustom/MenuItemCustom.tsx
@@ -21,7 +21,7 @@ export const MenuItemCustom: FC<MenuItemCustomProps> = forwardRef(
     ]);
 
     return (
-      <li className={menuItemClassNames}>
+      <li className={menuItemClassNames} role="presentation">
         {item.render({ index, value: item, onChange, ref: ref })}
       </li>
     );

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -68,7 +68,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
     );
 
     return (
-      <li className={menuItemClassNames}>
+      <li className={menuItemClassNames} role="presentation">
         <Link
           classNames={styles.menuLink}
           disabled={disabled}

--- a/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
+++ b/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
@@ -22,7 +22,7 @@ export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = forwardRef(
       classNames,
     ]);
     return (
-      <li className={subHeaderClassNames}>
+      <li className={subHeaderClassNames} role="presentation">
         <span data-disabled {...rest} tabIndex={-1} ref={ref}>
           {text}
         </span>

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`Menu Menu is large 1`] = `
         >
           <li
             class="menu-item large neutral my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -82,6 +83,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item large neutral disabled my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -108,6 +110,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item-sub-header large my-menu-item-class"
+            role="presentation"
           >
             <span
               data-disabled="true"
@@ -120,6 +123,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item large neutral my-menu-item-class"
+            role="presentation"
           >
             <a
               aria-disabled="false"
@@ -147,6 +151,7 @@ exports[`Menu Menu is large 1`] = `
           </li>
           <li
             class="menu-item-custom large my-menu-item-class"
+            role="presentation"
           >
             <div
               aria-label="Radio Group"
@@ -279,6 +284,7 @@ exports[`Menu Menu is medium 1`] = `
         >
           <li
             class="menu-item medium neutral my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -323,6 +329,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item medium neutral disabled my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -349,6 +356,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item-sub-header medium my-menu-item-class"
+            role="presentation"
           >
             <span
               data-disabled="true"
@@ -361,6 +369,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item medium neutral my-menu-item-class"
+            role="presentation"
           >
             <a
               aria-disabled="false"
@@ -388,6 +397,7 @@ exports[`Menu Menu is medium 1`] = `
           </li>
           <li
             class="menu-item-custom medium my-menu-item-class"
+            role="presentation"
           >
             <div
               aria-label="Radio Group"
@@ -520,6 +530,7 @@ exports[`Menu Menu is small 1`] = `
         >
           <li
             class="menu-item small neutral my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -564,6 +575,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item small neutral disabled my-menu-item-class"
+            role="presentation"
           >
             <button
               class="menu-item-button"
@@ -590,6 +602,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item-sub-header small my-menu-item-class"
+            role="presentation"
           >
             <span
               data-disabled="true"
@@ -602,6 +615,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item small neutral my-menu-item-class"
+            role="presentation"
           >
             <a
               aria-disabled="false"
@@ -629,6 +643,7 @@ exports[`Menu Menu is small 1`] = `
           </li>
           <li
             class="menu-item-custom small my-menu-item-class"
+            role="presentation"
           >
             <div
               aria-label="Radio Group"


### PR DESCRIPTION
## SUMMARY:
Roles for select options were set on internal elements enclosed inside the li element. This resulted li interfering with accessibility tools while deducing the aria attributes for the enclosed items as all accessibility were set on enclosed items.

This commit sets the role for enclosing li as presentation.

`role="presentation"` (or equivalently `role="none"`) is an ARIA attribute that indicates an element is being used only for visual presentation and should be ignored by assistive technologies like screen readers. It effectively removes the semantic meaning of the element while keeping its visual appearance and behaviour.

**Before**
<img width="1396" alt="Image" src="https://github.com/user-attachments/assets/72bee192-734c-4a94-a0b8-e00cced8486d" />

<img width="1396" alt="Image" src="https://github.com/user-attachments/assets/3a8f9068-7692-4bff-bed4-3ef952ebd42e" />

<img width="1396" alt="Image" src="https://github.com/user-attachments/assets/5170152e-0f7b-481b-856d-00927f757360" />

**After**
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/6811763b-1b58-41b8-89b4-6bf2cbd1db02" />

This helps in deducing the aria attributes for the enclosed items correctly.
## GITHUB ISSUE (Open Source Contributors)
https://github.com/EightfoldAI/octuple/issues/942
## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-129109
## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
