### PR TITLE
feat: added aria-label for replace button

### DIFF
--- a/src/components/Upload/Upload.stories.tsx
+++ b/src/components/Upload/Upload.stories.tsx
@@ -214,6 +214,7 @@ const Drag_and_Drop_Single_Small_Story: ComponentStory<typeof Upload> = (
       console.log('Dropped files', e.dataTransfer.files);
     },
     size: UploadSize.Small,
+    replaceFileAriaLabel: 'Replace file',
     showUploadList: {
       removeIconButtonType: 'button',
       replaceButtonType: 'button',

--- a/src/components/Upload/Upload.tsx
+++ b/src/components/Upload/Upload.tsx
@@ -80,6 +80,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (
     previewFileText: defaultPreviewFileText,
     progress,
     removeFileText: defaultRemoveFileText,
+    replaceFileAriaLabel,
     replaceFileText: defaultReplaceFileText,
     selectFileText: defaultSelectFileText,
     selectMultipleFilesText: defaultSelectMultipleFilesText,
@@ -540,6 +541,7 @@ const InternalUpload: React.ForwardRefRenderFunction<unknown, UploadProps> = (
               removeIcon={removeIcon}
               removeIconButtonType={removeIconButtonType}
               replaceButtonType={replaceButtonType}
+              replaceFileAriaLabel={replaceFileAriaLabel}
               replaceFileText={replaceFileText}
               replaceIcon={replaceIcon}
               showDownloadIconButton={showDownloadIconButton}

--- a/src/components/Upload/Upload.types.tsx
+++ b/src/components/Upload/Upload.types.tsx
@@ -517,6 +517,10 @@ export interface UploadProps<T = any> extends Pick<OcUploadProps, 'capture'> {
    */
   replaceFileText?: string;
   /**
+   * The replace button aria label.
+   */
+  replaceFileAriaLabel?: string;
+  /**
    * The select file string.
    * @default 'Select file'
    */
@@ -724,6 +728,10 @@ export interface UploadListProps<T = any> {
    */
   replaceFileText?: string;
   /**
+   * The replace button aria label.
+   */
+  replaceFileAriaLabel?: string;
+  /**
    * Customize the replace button icon svg path.
    */
   replaceIcon?: IconName | ((file: UploadFile) => IconName);
@@ -893,6 +901,10 @@ export interface ListItemProps {
    * @default 'Replace'
    */
   replaceFileText?: string;
+  /**
+   * The replace button aria label.
+   */
+  replaceFileAriaLabel?: string;
   /**
    * Customize the replace button icon svg path.
    */

--- a/src/components/Upload/UploadList/ListItem.tsx
+++ b/src/components/Upload/UploadList/ListItem.tsx
@@ -39,6 +39,7 @@ const ListItem = React.forwardRef(
       replaceFileText,
       removeIcon: customRemoveIcon,
       replaceIcon: customReplaceIcon,
+      replaceFileAriaLabel,
       showDownloadIconButton: showDownloadIconButton,
       showPreviewIconButton: showPreviewIconButton,
       showRemoveIconButton: showRemoveIconButton,
@@ -197,6 +198,7 @@ const ListItem = React.forwardRef(
             classNames: mergeClasses([styles.iconReplace]),
             disruptive: mergedStatus === 'error',
             htmlType: replaceButtonType,
+            ariaLabel: replaceFileAriaLabel,
             iconProps: {
               path:
                 typeof customReplaceIcon === 'function'

--- a/src/components/Upload/UploadList/index.tsx
+++ b/src/components/Upload/UploadList/index.tsx
@@ -61,6 +61,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<
     removeIcon,
     removeIconButtonType = 'button',
     replaceButtonType = 'button',
+    replaceFileAriaLabel,
     replaceFileText,
     replaceIcon,
     showDownloadIconButton: showDownloadIconButton = false,
@@ -294,6 +295,7 @@ const InternalUploadList: React.ForwardRefRenderFunction<
             removeIcon={removeIcon}
             removeIconButtonType={removeIconButtonType}
             replaceButtonType={replaceButtonType}
+            replaceFileAriaLabel={replaceFileAriaLabel}
             replaceFileText={replaceFileText}
             replaceIcon={replaceIcon}
             showDownloadIconButton={showDownloadIconButton}


### PR DESCRIPTION
## SUMMARY:
Added a prop for an aria-label for the replace button

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:


https://github.com/user-attachments/assets/e037e73d-6f27-4ab9-86f9-73ae25f049c6

