### PR TITLE
Show background color of the selected option to its full width

### DIFF
--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -165,6 +165,7 @@ $multi-select-count-offset: 54px;
 .selected-option {
   background-color: var(--primary-background1-color);
   color: var(--primary-color);
+  width: fit-content;
 }
 
 .select-menu-empty {


### PR DESCRIPTION
## SUMMARY:
Currently if the selected option text is longer than the dropdown width, the background color doesn't span the entire text rather it only shows up until the dropdown width. As part of this change, we show the selected option's background color to its fullwidth 

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-132022

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
