### PR TITLE
fix(table): update aria labels, add handleRowHover function

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -2,6 +2,7 @@
 
 import React, {
   forwardRef,
+  Key,
   ReactNode,
   useCallback,
   useContext,
@@ -637,6 +638,20 @@ function InternalTable<RecordType extends object = any>(
       typeof indentSize === 'number' ? indentSize : 15;
   }
 
+  // ========================== Row Hover ==========================
+  const handleRowHoverEnter = (
+    index: number,
+    rowKey: Key,
+    event: React.MouseEvent<HTMLElement>
+  ) => {
+    const record = rawData[index];
+    if (!record) return;
+    const title = (record as { title?: string })?.title || '';
+    setScrollLeftAriaLabel(`Scroll ${title} left`);
+    setScrollRightAriaLabel(`Scroll ${title} right`);
+    onRowHoverEnter(index, rowKey, event);
+  };
+
   // ============================ Render ============================
   const transformColumns = useCallback(
     (innerColumns: ColumnsType<RecordType>): ColumnsType<RecordType> =>
@@ -833,7 +848,7 @@ function InternalTable<RecordType extends object = any>(
               transformColumns={
                 transformColumns as OcTableProps<RecordType>['transformColumns']
               }
-              onRowHoverEnter={onRowHoverEnter}
+              onRowHoverEnter={handleRowHoverEnter}
               onRowHoverLeave={onRowHoverLeave}
               scrollLeftAriaLabelText={scrollLeftAriaLabelText}
               scrollRightAriaLabelText={scrollRightAriaLabelText}


### PR DESCRIPTION
## SUMMARY:
1. The scrollable buttons announces "Scroll left" and "Scroll right" 
2. Added a function that modifies the aria labels for each row announcing "Scroll {Row header name} left/right"

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-111201

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Go to the Table, select Fixed columns with Scroller
2. check for the announcement of the scroll right and scroll left buttons
3. Aria-label is associated to each title

https://github.com/user-attachments/assets/41a97522-1b64-4fad-8589-b1585da4873c


