### PR TITLE
feat: dropdown: added overlay props

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -460,6 +460,10 @@ const dropdownArgs: Object = {
   disabled: false,
   closeOnDropdownClick: true,
   portal: false,
+  overlayProps: {
+    role: 'listbox',
+    'aria-label': 'Dropdown overlay',
+  },
 };
 
 Dropdown_Button.args = {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -76,6 +76,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         visible,
         width,
         overlayTabIndex = 0,
+        overlayProps,
       },
       ref: React.ForwardedRef<DropdownRef>
     ) => {
@@ -400,6 +401,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
               onKeyDown={handleFloatingKeyDown}
               id={dropdownId}
               role={role}
+              {...overlayProps}
             >
               {overlay}
             </div>

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -161,6 +161,10 @@ export interface DropdownProps {
    * The ref of the dropdown
    */
   ref?: Ref<DropdownRef>;
+  /**
+   * The props of the overlay
+   */
+  overlayProps?: HTMLDivElement;
 }
 
 export type DropdownRef = {


### PR DESCRIPTION
## SUMMARY:
ISSUE - not able to add aria-attributes required to make overlay accessible
fix - added and overlayProp to dropdown and spread it on overlay container

## GITHUB ISSUE (Open Source Contributors) NA

## JIRA TASK (Eightfold Employees Only):  
https://eightfoldai.atlassian.net/browse/ENG-130143

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Verify TypeScript  compilation with new type definitions
2. verify we can pass props to overlay container
3. possible regressions - just spreading props to overlay container so there shouldn't be any regressions

![Screenshot 2025-02-28 at 4 42 06 PM](https://github.com/user-attachments/assets/22e4fd3e-1d47-49ba-843e-1ddf34cde729)


