### PR TITLE
fix: disabled button and replaced aria-describedby with aria-labelledby

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -98,7 +98,7 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
       <div
         aria-controls={`${id}-content`}
         aria-expanded={expanded}
-        aria-describedby={expandButtonDescribedBy || `${id}-header-content`}
+        aria-labelledby={expandButtonDescribedBy || `${id}-header-content`}
         className={styles.clickableArea}
         onClick={onClick}
         onKeyDown={handleKeyDown}
@@ -125,6 +125,7 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
         onKeyDown={handleKeyDown}
         shape={ButtonShape.Round}
         variant={gradient ? ButtonVariant.Secondary : ButtonVariant.Neutral}
+        disabled={true}
         {...expandButtonProps}
       />
     </div>


### PR DESCRIPTION
## SUMMARY:
Fixed accesibility issues reported on accordian 
1. Added disabled prop on accordian 
2. replaced aria-describedby with aria-labelledby

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-110847

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

Go to the Accordian component and check if any accesibility issues are reported for accordian 

No issue reported related to this 
![image](https://github.com/user-attachments/assets/efd93d9e-217b-4588-8c92-a82f9d51c97e)

https://github.com/user-attachments/assets/fd7ae739-d91d-4c6d-bca5-e2e81ad97380

