### PR TITLE
fix(dropdown): recalculate start position when overlaycontent gets updated

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -205,7 +205,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           // Update the position when the overlay content changes
           update();
         }
-      }, [overlay, mergedVisible, update]);
+      }, [overlay, mergedVisible, update, refs.floating]);
 
       const dropdownClasses: string = mergeClasses([
         dropdownClassNames,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -199,6 +199,14 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         );
       }, [refs.reference, refs.floating, update]);
 
+      // Add a new useEffect to update position when overlay content changes
+      useEffect(() => {
+        if (mergedVisible && refs.floating.current) {
+          // Update the position when the overlay content changes
+          update();
+        }
+      }, [overlay, mergedVisible, update]);
+
       const dropdownClasses: string = mergeClasses([
         dropdownClassNames,
         styles.dropdownWrapper,


### PR DESCRIPTION

## SUMMARY:
In dropdown component, the dropdown is opened towards top if the space in the downside is less. When the overlay content changes, and say becomes 3 option from 5 options, the starting position is not updated correctly and the results appear towards top at a distance from input bar creating bad user experience 

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-135599

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Do a local octuple build and sync with the www/react octuple lib. https://eightfoldai.atlassian.net/wiki/spaces/EP/pages/1812922377/Octuple+Development+Tips+Tricks Follow Alternative approach in this.

Login as demo@eightfolddemo-spradhan.com
Go to resourcing page
Click on create project and type in the program name input.
Before starting to type, open the developer tools window so that to decrease space in the downside area so to force dropdown to open up on the top.
Verify that the options shown in the list are positioned in such a way that the list appears attcahed to the input box as in screenshot.

Before changes
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/4d105c8d-a268-46c3-874d-e90d51dc8a32" />

After changes
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/93fdf789-4f14-4e1e-832a-ed024bf5ccab" />
