### PR TITLE
fix: added synthetic mouse event as a second optional param

### DIFF
--- a/src/components/Menu/CascadingMenu.tsx
+++ b/src/components/Menu/CascadingMenu.tsx
@@ -316,7 +316,7 @@ export const MenuComponent: FC<DropdownMenuProps> = forwardRef<
       onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         props.onClick?.(event);
         tree?.events.emit('click');
-        props.onChange?.(item.value);
+        props.onChange?.(item.value, event);
       }}
       onMouseEnter={() => {
         if (allowHover && isOpen) {

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -110,9 +110,10 @@ const BasicOverlay = (args: any) => (
           value: 'menu 6',
         },
       ]}
-      onChange={(item) => {
-        args.onChange(item);
-        console.log(item);
+      onChange={(item, e) => {
+        e?.stopPropagation();
+        args.onChange(item, e);
+        console.log(item, e);
       }}
     />
   </ConfigProvider>
@@ -239,41 +240,66 @@ const SubHeaderOverlay = (args: any) => {
           value: 'menu 6',
         },
       ]}
-      onChange={(item) => {
-        args.onChange(item);
-        console.log(item);
+      onChange={(item, e) => {
+        e?.stopPropagation();
+        args.onChange(item, e);
+        console.log(item, e);
       }}
     />
   );
 };
 
 const Basic_Menu_Story: ComponentStory<typeof Menu> = (args) => (
-  <Dropdown initialFocus overlay={BasicOverlay(args)}>
-    <Button text={'Menu dropdown'} />
-  </Dropdown>
+  <div
+    onClick={() => {
+      console.log('Click event bubbled to parent');
+    }}
+  >
+    <Dropdown initialFocus overlay={BasicOverlay(args)}>
+      <Button text={'Menu dropdown'} />
+    </Dropdown>
+  </div>
 );
 
 const Menu_Story: ComponentStory<typeof Menu> = (args) => (
-  <Dropdown initialFocus overlay={LinkOverlay(args)}>
-    <Button text={'Menu dropdown'} />
-  </Dropdown>
+  <div
+    onClick={() => {
+      console.log('Click event bubbled to parent');
+    }}
+  >
+    <Dropdown initialFocus overlay={LinkOverlay(args)}>
+      <Button text={'Menu dropdown'} />
+    </Dropdown>
+  </div>
 );
 
 const Menu_Header_Story: ComponentStory<typeof Menu> = (args) => (
-  <Dropdown initialFocus overlay={BasicOverlay(args)}>
-    <Button text={'Menu dropdown'} />
-  </Dropdown>
+  <div
+    onClick={() => {
+      console.log('Click event bubbled to parent');
+    }}
+  >
+    <Dropdown initialFocus overlay={BasicOverlay(args)}>
+      <Button text={'Menu dropdown'} />
+    </Dropdown>
+  </div>
 );
 
 const Menu_Sub_Header_Story: ComponentStory<typeof Menu> = (args) => (
   // When hosting selectors, do not close dropdown on click :)
-  <Dropdown
-    closeOnDropdownClick={false}
-    initialFocus
-    overlay={SubHeaderOverlay(args)}
+  <div
+    onClick={() => {
+      console.log('Click event bubbled to parent');
+    }}
   >
-    <Button text={'Menu dropdown'} />
-  </Dropdown>
+    <Dropdown
+      closeOnDropdownClick={false}
+      initialFocus
+      overlay={SubHeaderOverlay(args)}
+    >
+      <Button text={'Menu dropdown'} />
+    </Dropdown>
+  </div>
 );
 
 const Cascading_Menu_Story: ComponentStory<typeof Menu> = (args) => {

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -288,4 +288,81 @@ describe('Menu', () => {
 
     expect(handleClick).toHaveBeenCalled();
   });
+
+  test('Menu onChange passes the event object to the handler', () => {
+    let capturedEvent: React.MouseEvent | undefined;
+
+    const menuChangeHandler = jest.fn((_item, e) => {
+      capturedEvent = e;
+    });
+
+    const { getByText } = render(
+      <Menu
+        onChange={menuChangeHandler}
+        items={[
+          {
+            text: 'Click me',
+            value: 'menu-item',
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(getByText('Click me'));
+
+    expect(menuChangeHandler).toHaveBeenCalled();
+    expect(capturedEvent).toBeDefined();
+    expect(typeof capturedEvent?.stopPropagation).toBe('function');
+  });
+
+  test('Menu onChange provides event parameter that can be used to stop propagation', () => {
+    const parentClickHandler = jest.fn();
+    const menuChangeHandler = jest.fn((_item, e) => {
+      e.stopPropagation();
+      e.stopPropagation();
+    });
+
+    const { getByText } = render(
+      <div onClick={parentClickHandler}>
+        <Menu
+          onChange={menuChangeHandler}
+          items={[
+            {
+              text: 'Click me',
+              value: 'menu-item',
+            },
+          ]}
+        />
+      </div>
+    );
+
+    fireEvent.click(getByText('Click me'));
+
+    expect(menuChangeHandler).toHaveBeenCalled();
+    expect(parentClickHandler).not.toHaveBeenCalled();
+  });
+
+  test('Menu onChange event bubbles to parent when stopPropagation is not called', () => {
+    const parentClickHandler = jest.fn();
+    const menuChangeHandler = jest.fn();
+
+    const { getByText } = render(
+      <div onClick={parentClickHandler}>
+        <Menu
+          onChange={menuChangeHandler}
+          items={[
+            {
+              text: 'Click me',
+              value: 'menu-item',
+            },
+          ]}
+        />
+      </div>
+    );
+
+    fireEvent.click(getByText('Click me'));
+
+    expect(menuChangeHandler).toHaveBeenCalled();
+    expect(parentClickHandler).toHaveBeenCalled();
+  });
 });

--- a/src/components/Menu/Menu.types.ts
+++ b/src/components/Menu/Menu.types.ts
@@ -49,7 +49,7 @@ export interface MenuProps
    * On change callback when menu item is clicked
    * @param value
    */
-  onChange?: (value: any) => void;
+  onChange?: (value: any, event?: React.MouseEvent) => void;
   /**
    * Callback when ok button is clicked
    */

--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -106,8 +106,9 @@ export interface MenuItemButtonProps
   /**
    * On Click handler of the menu item
    * @param value
+   * @param event
    */
-  onClick?: (value: any) => void;
+  onClick?: (value: any, event?: React.MouseEvent<any>) => void;
   /**
    * Secondary action button for the menu item
    */
@@ -164,7 +165,7 @@ export interface MenuItemSubHeaderProps
 export interface IMenuItemRender {
   value: any;
   index: number;
-  onChange: (value: any) => void;
+  onChange: (value: any, event?: React.MouseEvent<any>) => void;
   ref?: React.ForwardedRef<any>;
 }
 

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -74,7 +74,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
         event.preventDefault();
         return;
       }
-      onClick?.(value);
+      onClick?.(value, event);
     };
 
     const getIcon = (): JSX.Element => (


### PR DESCRIPTION
## SUMMARY:
Adding react synthetic event as a second param to onChange handler of Menu Component so that user can stop bubbling.


## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-137350

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Scenario 1 (event.stopPropogation used)
1. Go to Basic Menu component in storybook
2. Open console and click on any item inside opened menu. 
3. "Click event bubbled to parent" should not be consoled since we've used event.stopPropogation in the storybook component.

Scenatio 2 (event.stopPropogation not used)
1. Go to Link Menu component in storybook
2. Open console and click on any item inside opened menu.
3. "Click event bubbled to parent" should be consoled since we've not used event.stopPropogation in the storybook component.