### PR TITLE
ENG-125708: Added level to dialog with header text

### DIFF
--- a/src/components/Dialog/BaseDialog/BaseDialog.tsx
+++ b/src/components/Dialog/BaseDialog/BaseDialog.tsx
@@ -151,7 +151,13 @@ export const BaseDialog: FC<BaseDialogProps> = React.forwardRef(
             {renderContentAlways && (
               <>
                 <div className={headerClasses}>
-                  <span id={labelId}>
+                  <span
+                    id={labelId}
+                    {...(header && {
+                      role: "heading",
+                      "aria-level": 2
+                    })}
+                  >
                     {headerButtonProps && (
                       <Button
                         classNames={styles.headerButton}


### PR DESCRIPTION
## SUMMARY:

### Issue:
When Dialog was opening at that time the header text is in `span` tag and not assigned with `role: heading` & `aria-level`
### Solution:
If header text is present then `role: heading aria-level:2` will be added to header text

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-125708

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Steps To Reproduce:

1. Open the URL - PCS Logged out - Career site
2. Select any of the job and Apply
3. Upload Resume

Modal will open-> inspect the heading text of Modal

Go to URL: https://stage.eightfold.ai/careers?domain=eightfolddemo-indhumathi.com

![Screenshot 2025-03-20 at 1 17 42 PM](https://github.com/user-attachments/assets/ea333c33-1f00-4fc4-ad38-f664fec1e923)
