### PR TITLE
fix: snackbar: added lastfocusableElement prop

### DIFF
--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { FC, Ref, useContext, useEffect, useState } from 'react';
+import React, { FC, Ref, useContext, useEffect, useRef, useState } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';
 import ThemeContext, {
@@ -48,6 +48,7 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
       type = InfoBarType.neutral,
       ...rest
     } = props;
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
 
     const contextualGradient: Gradient = useContext(GradientContext);
     const mergedGradient: boolean = configContextProps.noGradientContext
@@ -81,6 +82,14 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
           : mergedLocale.lang!.closeButtonAriaLabelText
       );
     }, [mergedLocale]);
+
+    useEffect(() => {
+      setTimeout(() => {
+        if (closeButtonRef.current) {
+          closeButtonRef.current.focus();
+        }
+      }, 1000);
+    }, [closeButtonRef, closable]);
 
     const infoBarClassNames: string = mergeClasses([
       styles.infoBar,
@@ -129,7 +138,6 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
                 className={infoBarClassNames}
                 ref={ref}
                 style={style}
-                role={role}
               >
                 <Icon
                   path={getIconName()}
@@ -141,7 +149,9 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
                     contentWrapperClassNames,
                   ])}
                 >
-                  <div className={messageClasses}>{content}</div>
+                  <div className={messageClasses} role={role}>
+                    {content}
+                  </div>
                   {actionButtonProps && (
                     <Button
                       buttonWidth={ButtonWidth.fitContent}
@@ -162,6 +172,7 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
                     iconProps={{ path: closeIcon }}
                     onClick={onClose}
                     shape={ButtonShape.Round}
+                    ref={closeButtonRef}
                     transparent
                     {...closeButtonProps}
                     classNames={mergeClasses([

--- a/src/components/InfoBar/__snapshots__/InfoBar.test.tsx.snap
+++ b/src/components/InfoBar/__snapshots__/InfoBar.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`InfoBar InfoBar is Disruptive 1`] = `
 <div>
   <div
     class="info-bar disruptive"
-    role="alert"
   >
     <span
       aria-hidden="false"
@@ -27,6 +26,7 @@ exports[`InfoBar InfoBar is Disruptive 1`] = `
     >
       <div
         class="message body2"
+        role="alert"
       >
         InfoBar test disruptive
       </div>
@@ -39,7 +39,6 @@ exports[`InfoBar InfoBar is Neutral 1`] = `
 <div>
   <div
     class="info-bar neutral"
-    role="alert"
   >
     <span
       aria-hidden="false"
@@ -62,6 +61,7 @@ exports[`InfoBar InfoBar is Neutral 1`] = `
     >
       <div
         class="message body2"
+        role="alert"
       >
         InfoBar test neutral
       </div>
@@ -74,7 +74,6 @@ exports[`InfoBar InfoBar is Positive 1`] = `
 <div>
   <div
     class="info-bar positive"
-    role="alert"
   >
     <span
       aria-hidden="false"
@@ -97,6 +96,7 @@ exports[`InfoBar InfoBar is Positive 1`] = `
     >
       <div
         class="message body2"
+        role="alert"
       >
         InfoBar test positive
       </div>
@@ -109,7 +109,6 @@ exports[`InfoBar InfoBar is Warning 1`] = `
 <div>
   <div
     class="info-bar warning"
-    role="alert"
   >
     <span
       aria-hidden="false"
@@ -132,6 +131,7 @@ exports[`InfoBar InfoBar is Warning 1`] = `
     >
       <div
         class="message body2"
+        role="alert"
       >
         InfoBar test warning
       </div>
@@ -144,7 +144,6 @@ exports[`InfoBar InfoBar is bordered 1`] = `
 <div>
   <div
     class="info-bar bordered neutral"
-    role="alert"
   >
     <span
       aria-hidden="false"
@@ -167,6 +166,7 @@ exports[`InfoBar InfoBar is bordered 1`] = `
     >
       <div
         class="message body2"
+        role="alert"
       >
         InfoBar test border
       </div>
@@ -179,7 +179,6 @@ exports[`InfoBar Renders a custom icon when the icon prop uses a custom icon 1`]
 <div>
   <div
     class="info-bar neutral"
-    role="alert"
   >
     <span
       aria-hidden="false"
@@ -202,6 +201,7 @@ exports[`InfoBar Renders a custom icon when the icon prop uses a custom icon 1`]
     >
       <div
         class="message body2"
+        role="alert"
       >
         InfoBar test icon
       </div>
@@ -214,7 +214,6 @@ exports[`InfoBar Renders without crashing 1`] = `
 <div>
   <div
     class="info-bar neutral"
-    role="alert"
   >
     <span
       aria-hidden="false"
@@ -237,6 +236,7 @@ exports[`InfoBar Renders without crashing 1`] = `
     >
       <div
         class="message body2"
+        role="alert"
       >
         InfoBar test render
       </div>

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -11,6 +11,7 @@ export const Snackbar: FC<SnackbarProps> = ({ classNames, ...rest }) => {
   const snackbarClasses = mergeClasses([styles.snackbar, classNames]);
   return (
     <InfoBar
+      tabIndex={0}
       {...rest}
       classNames={snackbarClasses}
       contentClassNames={styles.content}

--- a/src/components/Snackbar/SnackbarContainer.tsx
+++ b/src/components/Snackbar/SnackbarContainer.tsx
@@ -67,6 +67,7 @@ export const SnackbarContainer: FC<SnackbarContainerProps> = ({
       >
         {getPositionSnacks(position).map((snack) => (
           <Snackbar
+            tabIndex={-1}
             {...snack}
             key={snack.id}
             onClose={() => {


### PR DESCRIPTION
## SUMMARY:

- Added a prop `lastFocusableElement` which takes the reference of the element which triggers the snackbar,
-  So that on close of the snackbar the focus correctly returns to the element that triggered it.

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-133628

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

- pull branch down locally and start storybook (yarn storybook)
- go to Snackbar
- Set closable to true in the controls
- Verify if focus goes to the close button on snackbar.

case 1] snackbar triggerd when input is incorrect

https://github.com/user-attachments/assets/1f25f3f5-7ddc-4fe2-95dc-699514d9cffe


case2] snackbar triggered on button click.


https://github.com/user-attachments/assets/2e729dc2-1b7e-4a45-9b78-a096f9905ace

