### PR TITLE
fix: remove non existent tooltip aria-describedby reference

### DIFF
--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`Breadcrumb Crumb should support string \`0\` 1`] = `
           id="tooltip--wrapper"
         >
           <a
-            aria-describedby="tooltip-"
             aria-disabled="false"
             class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
             data-reference-id="tooltip--reference"
@@ -59,7 +58,6 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width secondary"
               data-reference-id="tooltip--reference"
@@ -98,7 +96,6 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width disruptive"
               data-reference-id="tooltip--reference"
@@ -138,7 +135,6 @@ exports[`Breadcrumb Crumb should use custom links 1`] = `
           >
             <span
               aria-current="location"
-              aria-describedby="tooltip-"
               class="breadcrumb-link my-breadcrumb-links-class breadcrumb-link-read-only tooltip-reference"
               data-reference-id="tooltip--reference"
               id="tooltip--reference"
@@ -174,7 +170,6 @@ exports[`Breadcrumb Renders without crashing 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
@@ -214,7 +209,6 @@ exports[`Breadcrumb Renders without crashing 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
@@ -254,7 +248,6 @@ exports[`Breadcrumb Renders without crashing 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
@@ -294,7 +287,6 @@ exports[`Breadcrumb Renders without crashing 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
@@ -334,7 +326,6 @@ exports[`Breadcrumb Renders without crashing 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
@@ -374,7 +365,6 @@ exports[`Breadcrumb Renders without crashing 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
@@ -414,7 +404,6 @@ exports[`Breadcrumb Renders without crashing 1`] = `
             id="tooltip--wrapper"
           >
             <a
-              aria-describedby="tooltip-"
               aria-disabled="false"
               class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
               data-reference-id="tooltip--reference"
@@ -469,7 +458,6 @@ exports[`Breadcrumb should support custom attribute 1`] = `
           id="tooltip--wrapper"
         >
           <a
-            aria-describedby="tooltip-"
             aria-disabled="false"
             class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
             data-custom="custom-item"
@@ -509,7 +497,6 @@ exports[`Breadcrumb should support custom attribute 1`] = `
           id="tooltip--wrapper"
         >
           <a
-            aria-describedby="tooltip-"
             aria-disabled="false"
             class="link-style full-width primary breadcrumb-link my-breadcrumb-links-class tooltip-reference"
             data-reference-id="tooltip--reference"

--- a/src/components/Skill/Tests/__snapshots__/SkillBlock.test.tsx.snap
+++ b/src/components/Skill/Tests/__snapshots__/SkillBlock.test.tsx.snap
@@ -77,7 +77,6 @@ exports[`SkillBlock Skill block has no border 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -192,7 +191,6 @@ exports[`SkillBlock Skill block is bordered 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -306,7 +304,6 @@ exports[`SkillBlock Skill block is disabled 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -421,7 +418,6 @@ exports[`SkillBlock Skill block is readonly 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -536,7 +532,6 @@ exports[`SkillBlock Skill block renders 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -677,7 +672,6 @@ exports[`SkillBlock Skill block uses custom props 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -913,7 +907,6 @@ exports[`SkillBlock Skill is a below and upskilling assessment block and the ico
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1028,7 +1021,6 @@ exports[`SkillBlock Skill is a below and upskilling assessment block and the ico
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1168,7 +1160,6 @@ exports[`SkillBlock Skill is a below assessment block and the icon is enabled 1`
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1283,7 +1274,6 @@ exports[`SkillBlock Skill is a below assessment block and the icon is not enable
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1400,7 +1390,6 @@ exports[`SkillBlock Skill is a clickable block 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1515,7 +1504,6 @@ exports[`SkillBlock Skill is a default block 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1646,7 +1634,6 @@ exports[`SkillBlock Skill is a default block with custom iconProps 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1772,7 +1759,6 @@ exports[`SkillBlock Skill is a default block with custom inlineSvgProps 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -1887,7 +1873,6 @@ exports[`SkillBlock Skill is a default block with customButtonProps 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -2035,7 +2020,6 @@ exports[`SkillBlock Skill is a default block with endorseButtonProps 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -2191,7 +2175,6 @@ exports[`SkillBlock Skill is a default block with highlightButtonProps 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -2378,7 +2361,6 @@ exports[`SkillBlock Skill is a exceed and upskilling assessment block and the ic
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -2493,7 +2475,6 @@ exports[`SkillBlock Skill is a exceed and upskilling assessment block and the ic
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -2633,7 +2614,6 @@ exports[`SkillBlock Skill is a exceed assessment block and the icon is enabled 1
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -2748,7 +2728,6 @@ exports[`SkillBlock Skill is a exceed assessment block and the icon is not enabl
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -2879,7 +2858,6 @@ exports[`SkillBlock Skill is a highlight block 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -3010,7 +2988,6 @@ exports[`SkillBlock Skill is a match block 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -3163,7 +3140,6 @@ exports[`SkillBlock Skill is a meet and upskilling assessment block and the icon
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -3278,7 +3254,6 @@ exports[`SkillBlock Skill is a meet and upskilling assessment block and the icon
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -3418,7 +3393,6 @@ exports[`SkillBlock Skill is a meet assessment block and the icon is enabled 1`]
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -3533,7 +3507,6 @@ exports[`SkillBlock Skill is a meet assessment block and the icon is not enabled
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -3648,7 +3621,6 @@ exports[`SkillBlock Skill is a required block 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -3770,7 +3742,6 @@ exports[`SkillBlock Skill is a required block with lineClamp and long text 1`] =
                   id="tooltip--wrapper"
                 >
                   <input
-                    aria-describedby="tooltip-"
                     aria-disabled="false"
                     class="thumb tooltip-reference"
                     data-reference-id="tooltip--reference"
@@ -3886,7 +3857,6 @@ exports[`SkillBlock Skill is a required block with the required mark hidden 1`] 
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -4026,7 +3996,6 @@ exports[`SkillBlock Skill is a upskilling assessment block and the icon is enabl
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -4141,7 +4110,6 @@ exports[`SkillBlock Skill is a upskilling assessment block and the icon is not e
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"
@@ -4258,7 +4226,6 @@ exports[`SkillBlock Skill overflow item menu 1`] = `
                 id="tooltip--wrapper"
               >
                 <input
-                  aria-describedby="tooltip-"
                   aria-disabled="false"
                   class="thumb tooltip-reference"
                   data-reference-id="tooltip--reference"

--- a/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
+++ b/src/components/Table/Tests/__snapshots__/Table.sorter.test.js.snap
@@ -25,7 +25,6 @@ LoadedCheerio {
                 "children": Array [
                   Node {
                     "attribs": Object {
-                      "aria-describedby": "sortTip",
                       "class": "table-column-sorters tooltip-reference",
                       "data-reference-id": "sortTip-reference",
                       "id": "sortTip-reference",
@@ -309,7 +308,6 @@ LoadedCheerio {
                     "prev": null,
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-describedby": undefined,
                       "class": undefined,
                       "data-reference-id": undefined,
                       "id": undefined,
@@ -317,7 +315,6 @@ LoadedCheerio {
                       "tabindex": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-describedby": undefined,
                       "class": undefined,
                       "data-reference-id": undefined,
                       "id": undefined,
@@ -3192,7 +3189,6 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "aria-describedby": "sortTip",
                                               "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
@@ -3476,7 +3472,6 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
@@ -3484,7 +3479,6 @@ LoadedCheerio {
                                               "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
@@ -4353,7 +4347,6 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "aria-describedby": "sortTip",
                                             "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "id": "sortTip-reference",
@@ -4637,7 +4630,6 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "id": undefined,
@@ -4645,7 +4637,6 @@ LoadedCheerio {
                                             "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "id": undefined,
@@ -6285,7 +6276,6 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "aria-describedby": "sortTip",
                                               "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "id": "sortTip-reference",
@@ -6569,7 +6559,6 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
@@ -6577,7 +6566,6 @@ LoadedCheerio {
                                               "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "id": undefined,
@@ -6882,7 +6870,6 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "aria-describedby": "sortTip",
                                             "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "data-sort-order": "ascend",
@@ -7167,7 +7154,6 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "data-sort-order": undefined,
@@ -7176,7 +7162,6 @@ LoadedCheerio {
                                             "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "data-sort-order": undefined,
@@ -7338,7 +7323,6 @@ LoadedCheerio {
                                     "children": Array [
                                       Node {
                                         "attribs": Object {
-                                          "aria-describedby": "sortTip",
                                           "class": "table-column-sorters tooltip-reference",
                                           "data-reference-id": "sortTip-reference",
                                           "data-sort-order": "ascend",
@@ -7623,7 +7607,6 @@ LoadedCheerio {
                                         "prev": null,
                                         "type": "tag",
                                         "x-attribsNamespace": Object {
-                                          "aria-describedby": undefined,
                                           "class": undefined,
                                           "data-reference-id": undefined,
                                           "data-sort-order": undefined,
@@ -7632,7 +7615,6 @@ LoadedCheerio {
                                           "tabindex": undefined,
                                         },
                                         "x-attribsPrefix": Object {
-                                          "aria-describedby": undefined,
                                           "class": undefined,
                                           "data-reference-id": undefined,
                                           "data-sort-order": undefined,
@@ -7857,7 +7839,6 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "aria-describedby": "sortTip",
                                             "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "data-sort-order": "ascend",
@@ -8142,7 +8123,6 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "data-sort-order": undefined,
@@ -8151,7 +8131,6 @@ LoadedCheerio {
                                             "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "data-sort-order": undefined,
@@ -8761,7 +8740,6 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "aria-describedby": "sortTip",
                                               "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "data-sort-order": "ascend",
@@ -9046,7 +9024,6 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "data-sort-order": undefined,
@@ -9055,7 +9032,6 @@ LoadedCheerio {
                                               "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "data-sort-order": undefined,
@@ -9217,7 +9193,6 @@ LoadedCheerio {
                                       "children": Array [
                                         Node {
                                           "attribs": Object {
-                                            "aria-describedby": "sortTip",
                                             "class": "table-column-sorters tooltip-reference",
                                             "data-reference-id": "sortTip-reference",
                                             "data-sort-order": "ascend",
@@ -9502,7 +9477,6 @@ LoadedCheerio {
                                           "prev": null,
                                           "type": "tag",
                                           "x-attribsNamespace": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "data-sort-order": undefined,
@@ -9511,7 +9485,6 @@ LoadedCheerio {
                                             "tabindex": undefined,
                                           },
                                           "x-attribsPrefix": Object {
-                                            "aria-describedby": undefined,
                                             "class": undefined,
                                             "data-reference-id": undefined,
                                             "data-sort-order": undefined,
@@ -9736,7 +9709,6 @@ LoadedCheerio {
                                         "children": Array [
                                           Node {
                                             "attribs": Object {
-                                              "aria-describedby": "sortTip",
                                               "class": "table-column-sorters tooltip-reference",
                                               "data-reference-id": "sortTip-reference",
                                               "data-sort-order": "ascend",
@@ -10021,7 +9993,6 @@ LoadedCheerio {
                                             "prev": null,
                                             "type": "tag",
                                             "x-attribsNamespace": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "data-sort-order": undefined,
@@ -10030,7 +10001,6 @@ LoadedCheerio {
                                               "tabindex": undefined,
                                             },
                                             "x-attribsPrefix": Object {
-                                              "aria-describedby": undefined,
                                               "class": undefined,
                                               "data-reference-id": undefined,
                                               "data-sort-order": undefined,

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -354,6 +354,24 @@ describe('Tooltip', () => {
     expect(container.querySelector('#test-div-id')).toBeTruthy();
   });
 
+  test('Tooltip preserves custom aria-describedby on reference element', async () => {
+    const { container } = render(
+      <Tooltip
+        content={<div data-testid="tooltip">This is a tooltip.</div>}
+        trigger="hover"
+      >
+        <div className="test-div" aria-describedby="custom-description">
+          test
+        </div>
+      </Tooltip>
+    );
+    fireEvent.mouseOver(container.querySelector('.test-div'));
+    await waitFor(() => screen.getByTestId('tooltip'));
+    expect(
+      container.querySelector('.test-div').getAttribute('aria-describedby')
+    ).toBe('custom-description');
+  });
+
   test('Tooltip is dismissed on click outside', async () => {
     const { container } = render(
       <Tooltip
@@ -444,7 +462,7 @@ describe('Tooltip', () => {
     const content = getByTestId('test-truncate-id');
     fireEvent.mouseEnter(content);
     await waitFor(() => expect(screen.queryByTestId('tooltip')).toBeNull());
-    expect(content.getAttribute('aria-describedby')).not.toBeNull();
+    expect(content.getAttribute('aria-describedby')).toBeNull();
   });
 
   test('enables tooltip when content is truncated', async () => {
@@ -495,6 +513,9 @@ describe('Tooltip', () => {
     const content = getByTestId('test-truncate-id');
     fireEvent.mouseEnter(content);
     await waitFor(() => screen.getByTestId('tooltip'));
-    expect(content.getAttribute('aria-describedby')).not.toBeNull();
+    await waitFor(() => {
+      const updatedContent = screen.getByTestId('test-truncate-id');
+      expect(updatedContent.getAttribute('aria-describedby')).not.toBeNull();
+    });
   });
 });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -397,15 +397,17 @@ export const Tooltip: FC<TooltipProps> = React.memo(
               'tooltip-reference',
             ]);
 
+            const ariaDescribedBy =
+              node.props?.['aria-describedby'] || tooltipId?.current;
+
             const clonedElementProps: RenderProps = {
               id: node.props?.id ? node.props?.id : tooltipReferenceId?.current,
               key: node.props?.key ? node.props?.key : tooltipId?.current,
               // If the content is not a string, the element of the content should be
               // manually targeted by id via `aria-describedby` to be announced by screen readers.
               // As this is an edge case, don't worry about it here, instead take the override if available.
-              'aria-describedby': node.props?.['aria-describedby']
-                ? node.props?.['aria-describedby']
-                : tooltipId?.current,
+              // Only assign aria-describedby if the tooltip element is present in the DOM.
+              'aria-describedby': mergedVisible ? ariaDescribedBy : undefined,
               'data-reference-id': tooltipReferenceId?.current,
             };
 


### PR DESCRIPTION
## SUMMARY:
A11y fix: 
Only add `aria-describedby` on a tooltip reference element when the tooltip is visible. When the tooltip is not visible the tooltip element is not in DOM and hence the reference is broken.

## GITHUB ISSUE (Open Source Contributors)


## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-141226

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. Go to storybook for multi select. /?path=/story/select--multiple
2. Select the long text item which will be showing tooltips.
3. Verify that there is no ARC toolkit error for invalid aria-describedby.
4. Hover over a pill to show its tooltip, and while the tooltip is visible, verify that aria-describedby is set on the reference element.
5. [Regression test]: Verify that tooltip hover in/out works fine.
