### PR TITLE
fix: added data-testid to the accordion button

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -116,6 +116,7 @@ export const AccordionSummary: FC<AccordionSummaryProps> = ({
         {badgeProps && <Badge classNames={styles.badge} {...badgeProps} />}
       </div>
       <Button
+        data-testid="accordian-arrow-button"
         ref={buttonRef}
         tabIndex={-1}
         role="presentation"

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -53,6 +53,7 @@ exports[`Accordion Accordion is large 1`] = `
       </div>
       <button
         class="button button-neutral button-medium round-shape icon-left"
+        data-testid="accordian-arrow-button"
         role="presentation"
         tabindex="-1"
       >
@@ -147,6 +148,7 @@ exports[`Accordion Accordion is medium 1`] = `
       </div>
       <button
         class="button button-neutral button-medium round-shape icon-left"
+        data-testid="accordian-arrow-button"
         role="presentation"
         tabindex="-1"
       >
@@ -241,6 +243,7 @@ exports[`Accordion Accordion is not bordered 1`] = `
       </div>
       <button
         class="button button-neutral button-medium round-shape icon-left"
+        data-testid="accordian-arrow-button"
         role="presentation"
         tabindex="-1"
       >
@@ -335,6 +338,7 @@ exports[`Accordion Accordion is pill shaped 1`] = `
       </div>
       <button
         class="button button-neutral button-medium round-shape icon-left"
+        data-testid="accordian-arrow-button"
         role="presentation"
         tabindex="-1"
       >
@@ -429,6 +433,7 @@ exports[`Accordion Accordion is rectangle shaped 1`] = `
       </div>
       <button
         class="button button-neutral button-medium round-shape icon-left"
+        data-testid="accordian-arrow-button"
         role="presentation"
         tabindex="-1"
       >
@@ -618,6 +623,7 @@ exports[`Accordion Accordion renders custom content and its buttons are clickabl
       </div>
       <button
         class="button button-neutral button-medium round-shape icon-left"
+        data-testid="accordian-arrow-button"
         role="presentation"
         tabindex="-1"
       >
@@ -712,6 +718,7 @@ exports[`Accordion Renders without crashing 1`] = `
       </div>
       <button
         class="button button-neutral button-medium round-shape icon-left"
+        data-testid="accordian-arrow-button"
         role="presentation"
         tabindex="-1"
       >


### PR DESCRIPTION
## SUMMARY:

Fixed added data-testId to the accordian button to fix playwrights
## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-110847

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

Go to accordian component and check if arrow button has data-testId

![image](https://github.com/user-attachments/assets/48d2a20c-0ee4-41d7-aa80-e6a4739aaa7b)
