### PR TITLE
fix: dropdown :added condition to close the dialog on shift tab

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -307,7 +307,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         if (event?.key === eventKeys.TAB && event.shiftKey) {
           timeout && clearTimeout(timeout);
           timeout = setTimeout(() => {
-            if (refs.floating.current.matches(':focus-within')) {
+            if (!refs.floating.current.matches(':focus-within')) {
               toggle(toggleDropdownOnShiftTab)(event);
             }
           }, NO_ANIMATION_DURATION);


### PR DESCRIPTION
## SUMMARY:
Added functionality to close the dropdown when Shift + Tab is pressed while the focus is on the first option, to handle focus loss behavior

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-139569

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Pull branch down locally and start storybook (yarn storybook)
Go to dropdown
Make the toggleDropdownOnShiftTab false
Verify whether the dropdown closes when pressing Shift+Tab while the focus is on the first option


https://github.com/user-attachments/assets/146db414-7275-4abd-a8f3-46d5714d6dc9






