### PR TITLE
Fixed closeButton props from pill to return pill label from ariaLabel

### DIFF
--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -137,7 +137,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
             badgeProps={{ classNames: styles.badge }}
             iconProps={{ path: IconName.mdiClose }}
             {...closeButtonProps}
-            ariaLabel={ closeButtonProps.ariaLabel || closeButtonProps?.getAriaLabel(label)}
+            ariaLabel={ closeButtonProps?.ariaLabel || closeButtonProps?.getAriaLabel(label)}
             onClick={!mergedDisabled ? onClose : null}
             size={pillSizeToButtonSizeMap.get(size)}
             classNames={styles.closeButton}

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -137,6 +137,11 @@ export const Pill: FC<PillProps> = React.forwardRef(
             badgeProps={{ classNames: styles.badge }}
             iconProps={{ path: IconName.mdiClose }}
             {...closeButtonProps}
+            ariaLabel={closeButtonProps?.ariaLabel 
+              ? (typeof closeButtonProps.ariaLabel === 'function' 
+                  ? (closeButtonProps.ariaLabel as (label: string) => string)(label)
+                  : closeButtonProps.ariaLabel)
+              : undefined}
             onClick={!mergedDisabled ? onClose : null}
             size={pillSizeToButtonSizeMap.get(size)}
             classNames={styles.closeButton}

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -3,7 +3,7 @@
 import React, { FC, Ref, useContext } from 'react';
 import { ThemeNames } from '../ConfigProvider';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
-import { PillIconAlign, PillProps, PillSize, PillType } from './Pills.types';
+import { PillIconAlign, PillProps, PillSize, PillType, isAriaLabelFunction } from './Pills.types';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { Button, ButtonSize } from '../Button';
 import { Icon, IconName, IconSize } from '../Icon';
@@ -100,6 +100,17 @@ export const Pill: FC<PillProps> = React.forwardRef(
       { [styles.aiAgent]: theme === ThemeNames.AIAgent },
     ]);
 
+    const getAriaLabel = (pillLabel: string): string | undefined => {
+      if (!closeButtonProps?.ariaLabel) {
+        return undefined;
+      }
+      const ariaLabel = closeButtonProps.ariaLabel;
+      if (isAriaLabelFunction(ariaLabel)) {
+        return ariaLabel(pillLabel);
+      }
+      return ariaLabel;
+    };
+
     const getIcon = (): JSX.Element => (
       <Icon
         {...iconProps}
@@ -137,11 +148,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
             badgeProps={{ classNames: styles.badge }}
             iconProps={{ path: IconName.mdiClose }}
             {...closeButtonProps}
-            ariaLabel={closeButtonProps?.ariaLabel 
-              ? (typeof closeButtonProps.ariaLabel === 'function' 
-                  ? (closeButtonProps.ariaLabel as (label: string) => string)(label)
-                  : closeButtonProps.ariaLabel)
-              : undefined}
+            ariaLabel={getAriaLabel(label)}
             onClick={!mergedDisabled ? onClose : null}
             size={pillSizeToButtonSizeMap.get(size)}
             classNames={styles.closeButton}

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -3,7 +3,7 @@
 import React, { FC, Ref, useContext } from 'react';
 import { ThemeNames } from '../ConfigProvider';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
-import { PillIconAlign, PillProps, PillSize, PillType, isAriaLabelFunction } from './Pills.types';
+import { PillIconAlign, PillProps, PillSize, PillType } from './Pills.types';
 import DisabledContext, { Disabled } from '../ConfigProvider/DisabledContext';
 import { Button, ButtonSize } from '../Button';
 import { Icon, IconName, IconSize } from '../Icon';
@@ -100,17 +100,6 @@ export const Pill: FC<PillProps> = React.forwardRef(
       { [styles.aiAgent]: theme === ThemeNames.AIAgent },
     ]);
 
-    const getAriaLabel = (pillLabel: string): string | undefined => {
-      if (!closeButtonProps?.ariaLabel) {
-        return undefined;
-      }
-      const ariaLabel = closeButtonProps.ariaLabel;
-      if (isAriaLabelFunction(ariaLabel)) {
-        return ariaLabel(pillLabel);
-      }
-      return ariaLabel;
-    };
-
     const getIcon = (): JSX.Element => (
       <Icon
         {...iconProps}
@@ -148,7 +137,7 @@ export const Pill: FC<PillProps> = React.forwardRef(
             badgeProps={{ classNames: styles.badge }}
             iconProps={{ path: IconName.mdiClose }}
             {...closeButtonProps}
-            ariaLabel={getAriaLabel(label)}
+            ariaLabel={ closeButtonProps.ariaLabel || closeButtonProps?.getAriaLabel(label)}
             onClick={!mergedDisabled ? onClose : null}
             size={pillSizeToButtonSizeMap.get(size)}
             classNames={styles.closeButton}

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -148,6 +148,9 @@ With_Icon.args = {
 Closable.args = {
   ...pillArgs,
   type: PillType.closable,
+  closeButtonProps: {
+    ariaLabel: (label: string) => `Delete ${label}`,
+  },
 };
 
 Custom_Closable.args = {

--- a/src/components/Pills/Pills.stories.tsx
+++ b/src/components/Pills/Pills.stories.tsx
@@ -149,7 +149,7 @@ Closable.args = {
   ...pillArgs,
   type: PillType.closable,
   closeButtonProps: {
-    ariaLabel: (label: string) => `Delete ${label}`,
+    getAriaLabel: (label: string) => `Delete ${label}`,
   },
 };
 

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -29,7 +29,9 @@ export enum PillSize {
 export type closeButtonProps = Omit<
   ButtonProps,
   'icon' | 'onClick' | 'size' | 'classNames'
->;
+> & {
+  ariaLabel?: string | ((label: string) => string);
+};
 
 /**
  * Props for the pill button shown on right of the label

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -33,6 +33,13 @@ export type closeButtonProps = Omit<
   ariaLabel?: string | ((label: string) => string);
 };
 
+// Type guard for ariaLabel function
+export const isAriaLabelFunction = (
+  ariaLabel: string | ((label: string) => string)
+): ariaLabel is (label: string) => string => {
+  return typeof ariaLabel === 'function';
+};
+
 /**
  * Props for the pill button shown on right of the label
  */
@@ -67,7 +74,9 @@ export interface PillProps extends OcBaseProps<HTMLElement> {
    * Props for the close button,
    * if type is set to PillType.closable
    */
-  closeButtonProps?: closeButtonProps;
+  closeButtonProps?: closeButtonProps & {
+    ariaLabel?: string | ((label: string) => string);
+  };
   /**
    * Custom color for the pill
    */

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -29,9 +29,7 @@ export enum PillSize {
 export type closeButtonProps = Omit<
   ButtonProps,
   'icon' | 'onClick' | 'size' | 'classNames'
-> & {
-  ariaLabel?: string | ((label: string) => string);
-};
+>;
 
 // Type guard for ariaLabel function
 export const isAriaLabelFunction = (
@@ -75,7 +73,7 @@ export interface PillProps extends OcBaseProps<HTMLElement> {
    * if type is set to PillType.closable
    */
   closeButtonProps?: closeButtonProps & {
-    ariaLabel?: string | ((label: string) => string);
+    getAriaLabel?: (label: string) => string;
   };
   /**
    * Custom color for the pill

--- a/src/components/Pills/Pills.types.ts
+++ b/src/components/Pills/Pills.types.ts
@@ -31,12 +31,6 @@ export type closeButtonProps = Omit<
   'icon' | 'onClick' | 'size' | 'classNames'
 >;
 
-// Type guard for ariaLabel function
-export const isAriaLabelFunction = (
-  ariaLabel: string | ((label: string) => string)
-): ariaLabel is (label: string) => string => {
-  return typeof ariaLabel === 'function';
-};
 
 /**
  * Props for the pill button shown on right of the label


### PR DESCRIPTION
## SUMMARY:
Fixed closeButtonProps from Pill props 
Added support to ariaLabel from closeButtonProps to return pill label 

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-141606

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Open storybook 
Open story of Pill -> Closable 
Check the aria-label of Closable Button 

<img width="1463" alt="Screenshot 2025-04-23 at 2 29 48 PM" src="https://github.com/user-attachments/assets/1b66d6ea-7795-4617-9e8b-e4c6d7676452" />

