### PR TITLE
fix: overflow issue

### DIFF
--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -55,6 +55,7 @@ $multi-select-count-offset: 54px;
     position: absolute;
     top: 6px;
     z-index: 1;
+    overflow: hidden;
   }
 
   .multi-select-pill {


### PR DESCRIPTION
## SUMMARY:
Fixed horizontal overflow issue when selecting multiple values in select component

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-139762

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. /?path=/story/select--multiple
2. select 5-6 pills in multi select
3. There should be no horizontal scroll in mobile screen
6. Verify step 3 by doing the same on https://eightfoldai.github.io/octuple.github.io/iframe.html?id=select--multiple&viewMode=story (You will observe horizontal scroll on mobile screen)