### PR TITLE
fix: more button a11y fixes

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -498,7 +498,7 @@ describe('Select', () => {
       render(<Select options={options} filterable placeholder="Select test" />);
     const select = getByPlaceholderText('Select test');
     fireEvent.click(select);
-    userEvent.type(select, 'Option 1');
+    fireEvent.change(select, { target: { value: 'Option 1' } });
     await waitFor(() => getAllByRole('option'));
     const option1 = getByText('Option 1');
     const option2 = queryByText('Option 2');

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -768,14 +768,16 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (mergedDisabled) {
         return;
       }
-      if (event.key === eventKeys.SPACE)
-        if (
-          filterable &&
-          event?.key === eventKeys.ARROWDOWN &&
-          document.activeElement === event.target
-        ) {
-          dropdownRef.current?.focusFirstElement?.();
-        }
+      if (event.key === eventKeys.SPACE) {
+        event.preventDefault();
+      }
+      if (
+        filterable &&
+        event?.key === eventKeys.ARROWDOWN &&
+        document.activeElement === event.target
+      ) {
+        dropdownRef.current?.focusFirstElement?.();
+      }
     };
 
     const clearButtonClassNames: string = mergeClasses([

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -617,7 +617,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
           const remainingCount = moreOptionsCount - count;
           const accessibleLabel = `and ${remainingCount} more ${
             remainingCount === 1 ? 'option' : 'options'
-          }`;
+          } selected`;
           pills.push(
             <Pill
               classNames={countPillClassNames}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -638,7 +638,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                   event.key === eventKeys.ENTER ||
                   event.key === eventKeys.SPACE
                 ) {
-                  // event.preventDefault();
+                  event.preventDefault();
                   if (!dropdownVisible) {
                     setDropdownVisibility(true);
                   }
@@ -768,16 +768,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (mergedDisabled) {
         return;
       }
-      if (event.key === eventKeys.SPACE) {
-        event.preventDefault();
-      }
-      if (
-        filterable &&
-        event?.key === eventKeys.ARROWDOWN &&
-        document.activeElement === event.target
-      ) {
-        dropdownRef.current?.focusFirstElement?.();
-      }
+      if (event.key === eventKeys.SPACE)
+        if (
+          filterable &&
+          event?.key === eventKeys.ARROWDOWN &&
+          document.activeElement === event.target
+        ) {
+          dropdownRef.current?.focusFirstElement?.();
+        }
     };
 
     const clearButtonClassNames: string = mergeClasses([

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -638,7 +638,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                   event.key === eventKeys.ENTER ||
                   event.key === eventKeys.SPACE
                 ) {
-                  event.preventDefault();
+                  // event.preventDefault();
                   if (!dropdownVisible) {
                     setDropdownVisibility(true);
                   }
@@ -767,6 +767,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
       onKeyDown?.(event);
       if (mergedDisabled) {
         return;
+      }
+      if (event.key === eventKeys.SPACE) {
+        event.preventDefault();
       }
       if (
         filterable &&

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -614,16 +614,38 @@ export const Select: FC<SelectProps> = React.forwardRef(
           pills.push(pill());
         }
         if (pills?.length === count && filled) {
+          const remainingCount = moreOptionsCount - count;
+          const accessibleLabel = `and ${remainingCount} more ${
+            remainingCount === 1 ? 'option' : 'options'
+          }`;
           pills.push(
             <Pill
               classNames={countPillClassNames}
               disabled={mergedDisabled}
               id="select-pill-count"
               key="select-count"
-              label={'+' + (moreOptionsCount - count)}
+              label={'+' + remainingCount}
               tabIndex={0}
               theme={'blueGreen'}
               size={selectSizeToPillSizeMap.get(mergedSize)}
+              onClick={() => {
+                if (!dropdownVisible) {
+                  setDropdownVisibility(true);
+                }
+              }}
+              onKeyDown={(event) => {
+                if (
+                  event.key === eventKeys.ENTER ||
+                  event.key === eventKeys.SPACE
+                ) {
+                  event.preventDefault();
+                  if (!dropdownVisible) {
+                    setDropdownVisibility(true);
+                  }
+                }
+              }}
+              aria-label={accessibleLabel}
+              role="button"
               {...pillProps}
             />
           );


### PR DESCRIPTION
## SUMMARY:
Meaningful label:
Instead of “+1”, screen reader should read it as “and 1 more option(s) selected”.

Semantic Control:
On Enter/Space/Clicking “+1”, select should open with the focus on the first item of select menu

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-136058

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
1. /?path=/story/select--multiple
2. turn on voice mode
3. Focus on +1 button
4. Meaning label (announce button and "more options selected")
<img width="770" alt="image" src="https://github.com/user-attachments/assets/aa89ded8-66a6-4f3d-ab4e-c5703dfd8867" />
5. Click/"Enter"/"Space" while +1 button is focus, it should open the dropdown and focus on first element.
