### PR TITLE
fix: getAriaLabel check before use

### DIFF
--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -139,9 +139,8 @@ export const Pill: FC<PillProps> = React.forwardRef(
             {...closeButtonProps}
             ariaLabel={
               closeButtonProps?.ariaLabel ??
-              (closeButtonProps?.getAriaLabel
-                ? closeButtonProps.getAriaLabel?.(label)
-                : `Delete ${label || 'item'}`)
+              closeButtonProps?.getAriaLabel?.(label) ??
+              `Delete ${label || 'item'}`
             }
             onClick={!mergedDisabled ? onClose : null}
             size={pillSizeToButtonSizeMap.get(size)}

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -138,9 +138,9 @@ export const Pill: FC<PillProps> = React.forwardRef(
             iconProps={{ path: IconName.mdiClose }}
             {...closeButtonProps}
             ariaLabel={
-              closeButtonProps?.ariaLabel ||
+              closeButtonProps?.ariaLabel ??
               (closeButtonProps?.getAriaLabel
-                ? closeButtonProps.getAriaLabel(label)
+                ? closeButtonProps.getAriaLabel?.(label)
                 : `Delete ${label || 'item'}`)
             }
             onClick={!mergedDisabled ? onClose : null}

--- a/src/components/Pills/Pill.tsx
+++ b/src/components/Pills/Pill.tsx
@@ -137,7 +137,12 @@ export const Pill: FC<PillProps> = React.forwardRef(
             badgeProps={{ classNames: styles.badge }}
             iconProps={{ path: IconName.mdiClose }}
             {...closeButtonProps}
-            ariaLabel={ closeButtonProps?.ariaLabel || closeButtonProps?.getAriaLabel(label)}
+            ariaLabel={
+              closeButtonProps?.ariaLabel ||
+              (closeButtonProps?.getAriaLabel
+                ? closeButtonProps.getAriaLabel(label)
+                : `Delete ${label || 'item'}`)
+            }
             onClick={!mergedDisabled ? onClose : null}
             size={pillSizeToButtonSizeMap.get(size)}
             classNames={styles.closeButton}

--- a/src/components/Pills/__snapshots__/Pill.test.tsx.snap
+++ b/src/components/Pills/__snapshots__/Pill.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Pill Pill should render as closable 1`] = `
     </span>
     <button
       aria-disabled="false"
+      aria-label="Delete A closable pill"
       class="close-button button button-default button-small pill-shape icon-left"
     >
       <span

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -416,6 +416,7 @@ exports[`Select Renders with default values when multiple 1`] = `
         </span>
         <button
           aria-disabled="false"
+          aria-label="Delete Option 2"
           class="close-button button button-default button-small pill-shape icon-left"
         >
           <span
@@ -449,6 +450,7 @@ exports[`Select Renders with default values when multiple 1`] = `
         </span>
         <button
           aria-disabled="false"
+          aria-label="Delete Option 3"
           class="close-button button button-default button-small pill-shape icon-left"
         >
           <span


### PR DESCRIPTION
## SUMMARY:
vscode npm test failed because of https://github.com/EightfoldAI/octuple/pull/981/files

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-141606

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/2b9d897a-4614-4e00-93fa-2458b9d3b999" />

