### PR TITLE
fix: pill visibility on small screens

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -192,10 +192,10 @@ export const Select: FC<SelectProps> = React.forwardRef(
       return (options || []).filter((option: SelectOption) => option.selected);
     };
 
-    const { count, filled, width } = useMaxVisibleSections(
+    const { count, filled, width, maxPillWidth } = useMaxVisibleSections(
       inputRef,
       pillRefs,
-      168,
+      144,
       8,
       1,
       getSelectedOptionValues().length
@@ -589,6 +589,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
             type={readonly ? PillType.default : PillType.closable}
             style={{
               visibility: index < count ? 'visible' : 'hidden',
+              maxWidth: `${maxPillWidth}px`,
             }}
             {...pillProps}
           />

--- a/src/hooks/useMaxVisibleSections.ts
+++ b/src/hooks/useMaxVisibleSections.ts
@@ -14,18 +14,37 @@ export const useMaxVisibleSections = (
     width: 0,
     count: 0,
     filled: false,
+    maxPillWidth: 144,
   });
 
   const computeVisibleSections = () => {
+    const selectedItemsLength = itemsRef.current?.filter(Boolean)?.length;
+    if (selectedItemsLength === 0) return;
+    const containerWidth =
+      containerRef.current?.getBoundingClientRect().width ?? 0;
+    const firstItemWidth =
+      itemsRef.current?.[0]?.getBoundingClientRect().width ?? extraItemWidth;
+
+    const isSingleItem = selectedItemsLength === 1;
+    const isNarrowContainer = isSingleItem
+      ? containerWidth <= 210
+      : containerWidth <= 350;
+
+    const updatedExtraItemWidth = isSingleItem
+      ? 40
+      : isNarrowContainer
+      ? containerWidth * 0.45
+      : firstItemWidth + 24;
+    const maxPillWidth = isNarrowContainer ? 100 : 144;
     const availableWidth: number =
-      (containerRef.current?.getBoundingClientRect().width - extraItemWidth) *
-      linesToShow;
+      (containerWidth - updatedExtraItemWidth) * linesToShow;
     const sections = itemsRef.current?.reduce(
       (
         acc: {
           width: number;
           count: number;
           filled: boolean;
+          maxPillWidth: number;
         },
         ref: HTMLElement
       ) => {
@@ -45,6 +64,7 @@ export const useMaxVisibleSections = (
         width: 0,
         count: 0,
         filled: false,
+        maxPillWidth: maxPillWidth,
       }
     );
     setMaxSections(sections);


### PR DESCRIPTION
## SUMMARY:
Pill will visible in single/multiselect for smaller screens

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-134598

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
