### PR TITLE
Revert "fix: stepper: added aria-current"

### DIFF
--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -802,7 +802,7 @@ export const Stepper: FC<StepperProps> = React.forwardRef(
                             size === StepperSize.Small &&
                             layout === 'horizontal' && (
                               <hr
-                                aria-hidden="true"
+                                aria-hidden='true'
                                 className={mergeClasses([
                                   styles.separator,
                                   {
@@ -821,15 +821,10 @@ export const Stepper: FC<StepperProps> = React.forwardRef(
                                 ])}
                               />
                             )}
-                          <li
-                            {...(index === currentActiveStep && {
-                              'aria-current': 'step',
-                            })}
-                            className={styles.step}
-                          >
+                          <li className={styles.step}>
                             {layout === 'vertical' && (
                               <hr
-                                role="presentation"
+                                role='presentation'
                                 className={mergeClasses([
                                   innerSeparatorClassNames,
                                   (styles as any)[`${step.size}`],
@@ -840,7 +835,7 @@ export const Stepper: FC<StepperProps> = React.forwardRef(
                             )}
                             {size !== StepperSize.Small && (
                               <hr
-                                role="presentation"
+                                role='presentation'
                                 className={mergeClasses([
                                   innerSeparatorClassNames,
                                   (styles as any)[`${step.size}`],

--- a/src/components/Stepper/Tests/__snapshots__/Stepper.test.tsx.snap
+++ b/src/components/Stepper/Tests/__snapshots__/Stepper.test.tsx.snap
@@ -2024,7 +2024,6 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -5054,11 +5053,9 @@ LoadedCheerio {
                     "prev": [Circular],
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -6086,7 +6083,6 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -9116,11 +9112,9 @@ LoadedCheerio {
                   "prev": [Circular],
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -10148,7 +10142,6 @@ LoadedCheerio {
               },
               Node {
                 "attribs": Object {
-                  "aria-current": "step",
                   "class": "step",
                 },
                 "children": Array [
@@ -15202,11 +15195,9 @@ LoadedCheerio {
                 },
                 "type": "tag",
                 "x-attribsNamespace": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
                 "x-attribsPrefix": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
               },
@@ -17228,7 +17219,6 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -20258,11 +20248,9 @@ LoadedCheerio {
                   },
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -22284,7 +22272,6 @@ LoadedCheerio {
                   "parent": [Circular],
                   "prev": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -25314,11 +25301,9 @@ LoadedCheerio {
                     },
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -26636,7 +26621,6 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -27830,11 +27814,9 @@ LoadedCheerio {
                     "prev": [Circular],
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -28430,7 +28412,6 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -29624,11 +29605,9 @@ LoadedCheerio {
                   "prev": [Circular],
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -30224,7 +30203,6 @@ LoadedCheerio {
               },
               Node {
                 "attribs": Object {
-                  "aria-current": "step",
                   "class": "step",
                 },
                 "children": Array [
@@ -32578,11 +32556,9 @@ LoadedCheerio {
                 },
                 "type": "tag",
                 "x-attribsNamespace": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
                 "x-attribsPrefix": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
               },
@@ -33380,7 +33356,6 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -34934,11 +34909,9 @@ LoadedCheerio {
                   },
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -35736,7 +35709,6 @@ LoadedCheerio {
                   "parent": [Circular],
                   "prev": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -37290,11 +37262,9 @@ LoadedCheerio {
                     },
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -37817,7 +37787,6 @@ LoadedCheerio {
                         "namespace": "http://www.w3.org/1999/xhtml",
                         "next": Node {
                           "attribs": Object {
-                            "aria-current": "step",
                             "class": "step",
                           },
                           "children": Array [
@@ -38216,11 +38185,9 @@ LoadedCheerio {
                           "prev": [Circular],
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                         },
@@ -38409,7 +38376,6 @@ LoadedCheerio {
                       "namespace": "http://www.w3.org/1999/xhtml",
                       "next": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -38808,11 +38774,9 @@ LoadedCheerio {
                         "prev": [Circular],
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -39116,7 +39080,6 @@ LoadedCheerio {
                     "namespace": "http://www.w3.org/1999/xhtml",
                     "next": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -39515,11 +39478,9 @@ LoadedCheerio {
                       "prev": [Circular],
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -39708,7 +39669,6 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -40107,11 +40067,9 @@ LoadedCheerio {
                     "prev": [Circular],
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -40415,7 +40373,6 @@ LoadedCheerio {
                 },
                 Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -41120,11 +41077,9 @@ LoadedCheerio {
                   },
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -41336,7 +41291,6 @@ LoadedCheerio {
                   "parent": [Circular],
                   "prev": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -41825,11 +41779,9 @@ LoadedCheerio {
                     },
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -42043,7 +41995,6 @@ LoadedCheerio {
                     "parent": [Circular],
                     "prev": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -42532,11 +42483,9 @@ LoadedCheerio {
                       },
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -42748,7 +42697,6 @@ LoadedCheerio {
                       "parent": [Circular],
                       "prev": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -43237,11 +43185,9 @@ LoadedCheerio {
                         },
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -43455,7 +43401,6 @@ LoadedCheerio {
                         "parent": [Circular],
                         "prev": Node {
                           "attribs": Object {
-                            "aria-current": "step",
                             "class": "step",
                           },
                           "children": Array [
@@ -43944,11 +43889,9 @@ LoadedCheerio {
                           },
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                         },
@@ -44407,7 +44350,6 @@ LoadedCheerio {
                       "namespace": "http://www.w3.org/1999/xhtml",
                       "next": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -44806,11 +44748,9 @@ LoadedCheerio {
                         "prev": [Circular],
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -44999,7 +44939,6 @@ LoadedCheerio {
                     "namespace": "http://www.w3.org/1999/xhtml",
                     "next": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -45398,11 +45337,9 @@ LoadedCheerio {
                       "prev": [Circular],
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -45706,7 +45643,6 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -46105,11 +46041,9 @@ LoadedCheerio {
                     "prev": [Circular],
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -46298,7 +46232,6 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -46697,11 +46630,9 @@ LoadedCheerio {
                   "prev": [Circular],
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -47005,7 +46936,6 @@ LoadedCheerio {
               },
               Node {
                 "attribs": Object {
-                  "aria-current": "step",
                   "class": "step",
                 },
                 "children": Array [
@@ -47710,11 +47640,9 @@ LoadedCheerio {
                 },
                 "type": "tag",
                 "x-attribsNamespace": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
                 "x-attribsPrefix": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
               },
@@ -47926,7 +47854,6 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -48415,11 +48342,9 @@ LoadedCheerio {
                   },
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -48633,7 +48558,6 @@ LoadedCheerio {
                   "parent": [Circular],
                   "prev": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -49122,11 +49046,9 @@ LoadedCheerio {
                     },
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -49338,7 +49260,6 @@ LoadedCheerio {
                     "parent": [Circular],
                     "prev": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -49827,11 +49748,9 @@ LoadedCheerio {
                       },
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -50045,7 +49964,6 @@ LoadedCheerio {
                       "parent": [Circular],
                       "prev": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -50534,11 +50452,9 @@ LoadedCheerio {
                         },
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -51163,7 +51079,6 @@ LoadedCheerio {
                         "namespace": "http://www.w3.org/1999/xhtml",
                         "next": Node {
                           "attribs": Object {
-                            "aria-current": "step",
                             "class": "step",
                           },
                           "children": Array [
@@ -51562,11 +51477,9 @@ LoadedCheerio {
                           "prev": [Circular],
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                         },
@@ -51755,7 +51668,6 @@ LoadedCheerio {
                       "namespace": "http://www.w3.org/1999/xhtml",
                       "next": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -52154,11 +52066,9 @@ LoadedCheerio {
                         "prev": [Circular],
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -52462,7 +52372,6 @@ LoadedCheerio {
                     "namespace": "http://www.w3.org/1999/xhtml",
                     "next": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -52861,11 +52770,9 @@ LoadedCheerio {
                       "prev": [Circular],
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -53054,7 +52961,6 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -53453,11 +53359,9 @@ LoadedCheerio {
                     "prev": [Circular],
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -53761,7 +53665,6 @@ LoadedCheerio {
                 },
                 Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -54466,11 +54369,9 @@ LoadedCheerio {
                   },
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -54682,7 +54583,6 @@ LoadedCheerio {
                   "parent": [Circular],
                   "prev": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -55171,11 +55071,9 @@ LoadedCheerio {
                     },
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -55389,7 +55287,6 @@ LoadedCheerio {
                     "parent": [Circular],
                     "prev": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -55878,11 +55775,9 @@ LoadedCheerio {
                       },
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -56094,7 +55989,6 @@ LoadedCheerio {
                       "parent": [Circular],
                       "prev": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -56583,11 +56477,9 @@ LoadedCheerio {
                         },
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -56801,7 +56693,6 @@ LoadedCheerio {
                         "parent": [Circular],
                         "prev": Node {
                           "attribs": Object {
-                            "aria-current": "step",
                             "class": "step",
                           },
                           "children": Array [
@@ -57290,11 +57181,9 @@ LoadedCheerio {
                           },
                           "type": "tag",
                           "x-attribsNamespace": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                           "x-attribsPrefix": Object {
-                            "aria-current": undefined,
                             "class": undefined,
                           },
                         },
@@ -57868,7 +57757,6 @@ LoadedCheerio {
                       "namespace": "http://www.w3.org/1999/xhtml",
                       "next": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -58267,11 +58155,9 @@ LoadedCheerio {
                         "prev": [Circular],
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -58460,7 +58346,6 @@ LoadedCheerio {
                     "namespace": "http://www.w3.org/1999/xhtml",
                     "next": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -58859,11 +58744,9 @@ LoadedCheerio {
                       "prev": [Circular],
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -59167,7 +59050,6 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -59566,11 +59448,9 @@ LoadedCheerio {
                     "prev": [Circular],
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -59759,7 +59639,6 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -60158,11 +60037,9 @@ LoadedCheerio {
                   "prev": [Circular],
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -60466,7 +60343,6 @@ LoadedCheerio {
               },
               Node {
                 "attribs": Object {
-                  "aria-current": "step",
                   "class": "step",
                 },
                 "children": Array [
@@ -61171,11 +61047,9 @@ LoadedCheerio {
                 },
                 "type": "tag",
                 "x-attribsNamespace": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
                 "x-attribsPrefix": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
               },
@@ -61387,7 +61261,6 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -61876,11 +61749,9 @@ LoadedCheerio {
                   },
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -62094,7 +61965,6 @@ LoadedCheerio {
                   "parent": [Circular],
                   "prev": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -62583,11 +62453,9 @@ LoadedCheerio {
                     },
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -62799,7 +62667,6 @@ LoadedCheerio {
                     "parent": [Circular],
                     "prev": Node {
                       "attribs": Object {
-                        "aria-current": "step",
                         "class": "step",
                       },
                       "children": Array [
@@ -63288,11 +63155,9 @@ LoadedCheerio {
                       },
                       "type": "tag",
                       "x-attribsNamespace": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                       "x-attribsPrefix": Object {
-                        "aria-current": undefined,
                         "class": undefined,
                       },
                     },
@@ -63506,7 +63371,6 @@ LoadedCheerio {
                       "parent": [Circular],
                       "prev": Node {
                         "attribs": Object {
-                          "aria-current": "step",
                           "class": "step",
                         },
                         "children": Array [
@@ -63995,11 +63859,9 @@ LoadedCheerio {
                         },
                         "type": "tag",
                         "x-attribsNamespace": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                         "x-attribsPrefix": Object {
-                          "aria-current": undefined,
                           "class": undefined,
                         },
                       },
@@ -65337,7 +65199,6 @@ LoadedCheerio {
                   "namespace": "http://www.w3.org/1999/xhtml",
                   "next": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -67071,11 +66932,9 @@ LoadedCheerio {
                     "prev": [Circular],
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },
@@ -67671,7 +67530,6 @@ LoadedCheerio {
                 "namespace": "http://www.w3.org/1999/xhtml",
                 "next": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -69405,11 +69263,9 @@ LoadedCheerio {
                   "prev": [Circular],
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -70005,7 +69861,6 @@ LoadedCheerio {
               },
               Node {
                 "attribs": Object {
-                  "aria-current": "step",
                   "class": "step",
                 },
                 "children": Array [
@@ -72899,11 +72754,9 @@ LoadedCheerio {
                 },
                 "type": "tag",
                 "x-attribsNamespace": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
                 "x-attribsPrefix": Object {
-                  "aria-current": undefined,
                   "class": undefined,
                 },
               },
@@ -74061,7 +73914,6 @@ LoadedCheerio {
                 "parent": [Circular],
                 "prev": Node {
                   "attribs": Object {
-                    "aria-current": "step",
                     "class": "step",
                   },
                   "children": Array [
@@ -75795,11 +75647,9 @@ LoadedCheerio {
                   },
                   "type": "tag",
                   "x-attribsNamespace": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                   "x-attribsPrefix": Object {
-                    "aria-current": undefined,
                     "class": undefined,
                   },
                 },
@@ -76957,7 +76807,6 @@ LoadedCheerio {
                   "parent": [Circular],
                   "prev": Node {
                     "attribs": Object {
-                      "aria-current": "step",
                       "class": "step",
                     },
                     "children": Array [
@@ -78691,11 +78540,9 @@ LoadedCheerio {
                     },
                     "type": "tag",
                     "x-attribsNamespace": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                     "x-attribsPrefix": Object {
-                      "aria-current": undefined,
                       "class": undefined,
                     },
                   },


### PR DESCRIPTION
Reverts EightfoldAI/octuple#974
the fix may cause regression for many steppers where aria-current is alredy defined in child components instead of <li tag