### PR TITLE
fix: plus n button focus will be on by default

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -110,6 +110,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       themeContainerId,
       toggleButtonAriaLabel,
       'data-test-id': dataTestId,
+      keepCountPillFocus = true,
     },
     ref: Ref<HTMLDivElement>
   ) => {
@@ -618,6 +619,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
           const accessibleLabel = `and ${remainingCount} more ${
             remainingCount === 1 ? 'option' : 'options'
           } selected`;
+          // if keepCountPillFocus is true, keep the count pill focusable
+          if (
+            keepCountPillFocus &&
+            'tabIndex' in pillProps &&
+            pillProps.tabIndex === -1
+          ) {
+            pillProps.tabIndex = 0;
+          }
           pills.push(
             <Pill
               classNames={countPillClassNames}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -620,13 +620,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
             remainingCount === 1 ? 'option' : 'options'
           } selected`;
           // if keepCountPillFocus is true, keep the count pill focusable
-          if (
-            keepCountPillFocus &&
+          const updatedPillProps = {
+            ...pillProps,
+            ...(keepCountPillFocus &&
             'tabIndex' in pillProps &&
             pillProps.tabIndex === -1
-          ) {
-            pillProps.tabIndex = 0;
-          }
+              ? { tabIndex: 0 }
+              : {}),
+          };
           pills.push(
             <Pill
               classNames={countPillClassNames}
@@ -655,7 +656,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
               }}
               aria-label={accessibleLabel}
               role="button"
-              {...pillProps}
+              {...updatedPillProps}
             />
           );
         }

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -222,4 +222,9 @@ export interface SelectProps
    * The Select toggle dropdown chevron button aria label.
    */
   toggleButtonAriaLabel?: string;
+  /**
+   * Whether to keep the count pill focusable.
+   * @default true
+   */
+  keepCountPillFocus?: boolean;
 }


### PR DESCRIPTION
## SUMMARY:
Semantic Control:
Fixed an issue where if tabIndex=-1 was added to pillProps then +n button was not controllable.
Fix: Added keepCountPillFocus=true as a default prop to Select

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-136058

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
<img width="623" alt="image" src="https://github.com/user-attachments/assets/3ffe7c47-7a9d-4994-bb04-a5ad484cf5b6" />
