### PR TITLE
fix: icon: Add role prop support to MdiIcon component

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -56,7 +56,8 @@ export const Icon: FC<IconProps> = ({
       title={title}
       vertical={vertical}
       spin={spin}
-      {...({ role: iconRole } as any)}
+      // @ts-ignore
+      role={iconRole}
     />
   );
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -27,6 +27,7 @@ export const Icon: FC<IconProps> = ({
   vertical,
   'data-test-id': dataTestId,
   icomoonIconName,
+  iconRole,
 }) => {
   const { icomoonIconSet } = useConfig();
 
@@ -55,6 +56,7 @@ export const Icon: FC<IconProps> = ({
       title={title}
       vertical={vertical}
       spin={spin}
+      {...({ role: iconRole } as any)}
     />
   );
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -27,7 +27,7 @@ export const Icon: FC<IconProps> = ({
   vertical,
   'data-test-id': dataTestId,
   icomoonIconName,
-  iconRole,
+  iconRole = 'presentation',
 }) => {
   const { icomoonIconSet } = useConfig();
 

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -82,4 +82,8 @@ export interface IconProps
    * Unique id used to target element for testing
    */
   'data-test-id'?: string;
+  /**
+   * The icon role.
+   */
+  iconRole?: string;
 }


### PR DESCRIPTION
## SUMMARY:
This PR adds support for passing a custom role to the MdiIcon component through the `iconRole` prop. This allows for better accessibility customization of icons when needed.

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-138365

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
- Verify TypeScript compilation with new type definitions.
- Verify we can pass props to the MdiIcon (SVG) component.

<img width="1512" alt="Screenshot 2025-05-27 at 10 56 16 PM" src="https://github.com/user-attachments/assets/3e7da34e-b45a-440b-b955-b5981adf9eae" />
