### PR TITLE
Revert "Added handlekeydown event in panel component to close panel on escape key (#982)"

### DIFF
--- a/src/components/Panel/Panel.test.tsx
+++ b/src/components/Panel/Panel.test.tsx
@@ -148,18 +148,6 @@ describe('Panel', () => {
     expect(wrapper.find('.button-primary').text()).toBe('Close');
   });
 
-  test('Should call onClose when escape key is pressed', () => {
-    const onClose = jest.fn();
-    wrapper.setProps({
-      visible: true,
-      onClose,
-    });
-
-    // Simulate escape key press
-    const escapeKeyEvent = new KeyboardEvent('keydown', { key: 'Escape' });
-    document.dispatchEvent(escapeKeyEvent);
-  });
-
   test('Should render content when renderContentAlways is true', () => {
     const { getByText } = render(
       <Panel renderContentAlways>

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -6,7 +6,6 @@ import React, {
   useImperativeHandle,
   useRef,
   useState,
-  useCallback,
 } from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';
@@ -137,19 +136,6 @@ export const Panel = React.forwardRef<PanelRef, PanelProps>(
           : mergedLocale.lang!.closeButtonAriaLabelText
       );
     }, [mergedLocale]);
-
-    const handleEscapeKey = useCallback((event: KeyboardEvent) => {
-      if (event.key === 'Escape' && visible) {
-        onClose?.(event);
-      }
-    }, [onClose, visible]);
-
-    useEffect(() => {
-      document.addEventListener('keydown', handleEscapeKey);
-      return () => {
-        document.removeEventListener('keydown', handleEscapeKey); 
-      };
-    }, [handleEscapeKey]);
 
     const panelBackdropClasses: string = mergeClasses([
       styles.panelBackdrop,

--- a/src/components/Panel/Panel.types.ts
+++ b/src/components/Panel/Panel.types.ts
@@ -19,8 +19,7 @@ export type PanelPlacement = 'top' | 'right' | 'bottom' | 'left';
 
 export type EventType =
   | React.KeyboardEvent<HTMLDivElement>
-  | React.MouseEvent<HTMLDivElement | HTMLButtonElement>
-  | KeyboardEvent;
+  | React.MouseEvent<HTMLDivElement | HTMLButtonElement>;
 
 export type CloseButtonProps = Omit<ButtonProps, 'onClick' | 'iconProps'>;
 


### PR DESCRIPTION
## SUMMARY:
This reverts commit 6a492b2bd8f0f9d739a65d1bf68cf6cd123966e0.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
This is revert pr
