### PR TITLE
fix: snackbar: fixed focus for snackbar

### DIFF
--- a/src/components/InfoBar/InfoBar.tsx
+++ b/src/components/InfoBar/InfoBar.tsx
@@ -86,7 +86,7 @@ export const InfoBar: FC<InfoBarsProps> = React.forwardRef(
 
     useEffect(() => {
       setTimeout(() => {
-        if (ref && 'current' in ref && moveFocusToSnackbar) {
+        if (ref && 'current' in ref && moveFocusToSnackbar && closable) {
           ref.current.focus();
         }
       }, 0);

--- a/src/components/Snackbar/SnackbarContainer.tsx
+++ b/src/components/Snackbar/SnackbarContainer.tsx
@@ -66,51 +66,57 @@ export const SnackbarContainer: FC<SnackbarContainerProps> = ({
   };
 
   const getSnackContainers = (): JSX.Element[] =>
-    Object.keys(positionToClassMap).map((position: SnackbarPosition) => (
-      <div
-        key={position}
-        className={mergeClasses([
-          styles.snackbarContainer,
-          positionToClassMap[position],
-        ])}
-      >
-        {getPositionSnacks(position).map((snack, index) => (
-          <Snackbar
-            ref={(ref) => {
-              if (ref) {
-                snackContainerRef.current[index] = ref;
-              }
-            }}
-            {...snack}
-            key={snack.id}
-            onClose={() => {
-              const index = snackContainerRef.current.findIndex(
-                (ref) => ref?.id === snack.id
-              );
-              if (index !== -1) {
-                snackContainerRef.current.splice(index, 1);
-                const nextElement =
-                  snackContainerRef.current[index] ||
-                  snackContainerRef.current[index - 1];
-                nextElement?.focus();
-              }
-              eat(snack.id);
-              snack.onClose?.();
-            }}
-            tabIndex={0}
-            moveFocusToSnackbar={true}
-            {...(snack.actionButtonProps
-              ? {
-                  onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-                    eat(snack.id);
-                    snack.actionButtonProps?.onClick?.(e);
-                  },
+    Object.keys(positionToClassMap).map((position: SnackbarPosition) => {
+      const positionSnacks = getPositionSnacks(position);
+      const hasClosableSnack = positionSnacks.some((snack) => snack.closable);
+
+      return (
+        <div
+          key={position}
+          className={mergeClasses([
+            styles.snackbarContainer,
+            positionToClassMap[position],
+          ])}
+        >
+          {positionSnacks.map((snack, index) => (
+            <Snackbar
+              ref={(ref) => {
+                if (ref) {
+                  snackContainerRef.current[index] = ref;
                 }
-              : {})}
-          />
-        ))}
-      </div>
-    ));
+              }}
+              {...snack}
+              key={snack.id}
+              onClose={() => {
+                const index = snackContainerRef.current.findIndex(
+                  (ref) => ref?.id === snack.id
+                );
+                if (index !== -1) {
+                  snackContainerRef.current.splice(index, 1);
+                  const nextElement =
+                    snackContainerRef.current[index] ||
+                    snackContainerRef.current[index - 1];
+                  nextElement?.focus();
+                }
+                eat(snack.id);
+                snack.onClose?.();
+              }}
+              {...(hasClosableSnack ? { tabIndex: 0 } : {})}
+              role={hasClosableSnack ? 'status' : 'alert'}
+              moveFocusToSnackbar={hasClosableSnack}
+              {...(snack.actionButtonProps
+                ? {
+                    onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+                      eat(snack.id);
+                      snack.actionButtonProps?.onClick?.(e);
+                    },
+                  }
+                : {})}
+            />
+          ))}
+        </div>
+      );
+    });
 
   return <Portal getContainer={() => parent}>{getSnackContainers()}</Portal>;
 };

--- a/src/components/Snackbar/snack.ts
+++ b/src/components/Snackbar/snack.ts
@@ -40,7 +40,6 @@ export const serve = (props: SnackbarProps): VoidFunction => {
       elementToFocus = props.lastFocusableElement;
     } else {
       elementToFocus = document.activeElement as HTMLElement;
-      console.log('>>elementToFocus', elementToFocus);
     }
   }
 


### PR DESCRIPTION
## SUMMARY:

- Focus was being set on a snackbar without a close option.
- Added condition to only move focus to snackbar when it is closable.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

- pull branch down locally and start storybook (yarn storybook)
- go to Snackbar.
- Verify that the focus does not move to the snackbar container when closable : false .
- Set closable to true in the controls.
- Ensure that focus shifts to the toast message when it appears.
- Verify that pressing the Tab key moves the focus to the close button



https://github.com/user-attachments/assets/d550e6e8-7a22-4d17-a509-39d1ba5469a4


**Steps for Regression:**

**1. When closable: true**

**Expected Behavior:**

- Focus should move to the snackbar when it appears.
- Upon dismissal, focus should return to the element that triggered the snackbar.
- If the triggering element is no longer present in the DOM, focus should return to the fallback element provided via the lastFocusableElement prop.

**Scenarios to cover:**

1A.  Snackbar triggered from an action on the main page – Positive flow

- Verify that focus moves to the snackbar.
- On dismissal, focus returns to the triggering element.

1B. Snackbar triggered from an action on the main page – Negative flow

- Verify that focus moves to the snackbar.
- On dismissal, focus returns to the triggering element.


 **Relevant files to refer:**
- /www/react/src/apps/careerHubExplore/components/common/LocationSearch/index.js
- /www/react/src/apps/careers/utils/index.js
- /www/react/src/apps/schedulingWizard/components/SchedulerWizard.js

1C. Snackbar triggered from an action inside a modal – Positive flow

- Verify that focus moves to the snackbar.
- On dismissal, if the triggering element is present, focus returns to it.
- If not, focus should move to the fallback element (lastFocusableElement).

1D. Snackbar triggered from an action inside a modal – Negative flow

- Verify that focus moves to the snackbar.
- On dismissal, if the triggering element is present, focus returns to it.
- If not, focus should move to the fallback element (lastFocusableElement).

 **Relevant files to refer:**




**3. When closable: false**
**Expected Behavior:**

- Focus should remain on the element that triggered the snackbar.
- Focus should not shift to the snackbar when it appears.

**Scenarios to cover:**

2A. Snackbar triggered from an action on the main page – Positive flow

- Verify that focus remains on the triggering element.

2B. Snackbar triggered from an action on the main page – Negative flow

- Verify that focus remains on the triggering element.

2C. Snackbar triggered from an action inside a modal – Positive flow

- Verify that focus remains on the triggering element.

2D. Snackbar triggered from an action inside a modal – Negative flow

- Verify that focus remains on the triggering element.


