### PR TITLE
Ypatadia/pagination default fix/eng 158360

### DIFF
--- a/src/components/Carousel/Tests/__snapshots__/Slide.test.tsx.snap
+++ b/src/components/Carousel/Tests/__snapshots__/Slide.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Slide loads and displays Carousel component 1`] = `
           <button
             aria-current="false"
             aria-disabled="false"
-            aria-label="page 2 of 2"
+            aria-label="page 2 of 3"
             class="pagination-button button button-neutral button-medium"
           >
             <span

--- a/src/components/Pagination/Pager.tsx
+++ b/src/components/Pagination/Pager.tsx
@@ -257,7 +257,7 @@ export const Pager: FC<PagerProps> = React.forwardRef(
                     ' ' +
                     locale.lang.pagerText +
                     ' ' +
-                    _pagers.toLocaleString()
+                    pageCount.toLocaleString()
                   }
                 />
               </li>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -247,7 +247,7 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
     };
 
     const getPageCount = (): number => {
-      let pages: number;
+      let pages: number = 0;
 
       if (total) {
         pages = Math.ceil(total / _pageSize);

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Pagination Pagination should render as dots 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 2 of 2,3,4"
+          aria-label="page 2 of 5"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -65,7 +65,7 @@ exports[`Pagination Pagination should render as dots 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 3 of 2,3,4"
+          aria-label="page 3 of 5"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -79,7 +79,7 @@ exports[`Pagination Pagination should render as dots 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 4 of 2,3,4"
+          aria-label="page 4 of 5"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -254,7 +254,7 @@ exports[`Pagination Pagination should render normally 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 2 of 2,3,4"
+          aria-label="page 2 of 5"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -268,7 +268,7 @@ exports[`Pagination Pagination should render normally 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 3 of 2,3,4"
+          aria-label="page 3 of 5"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -282,7 +282,7 @@ exports[`Pagination Pagination should render normally 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 4 of 2,3,4"
+          aria-label="page 4 of 5"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -430,7 +430,7 @@ exports[`Pagination Pagination should render with all elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 2 of 2,3"
+          aria-label="page 2 of 4"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -444,7 +444,7 @@ exports[`Pagination Pagination should render with all elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 3 of 2,3"
+          aria-label="page 3 of 4"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -582,7 +582,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 2 of 2,3,4,5,6,7,8,9"
+          aria-label="page 2 of 10"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -596,7 +596,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 3 of 2,3,4,5,6,7,8,9"
+          aria-label="page 3 of 10"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -610,7 +610,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 4 of 2,3,4,5,6,7,8,9"
+          aria-label="page 4 of 10"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -624,7 +624,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="true"
           aria-disabled="false"
-          aria-label="page 5 of 2,3,4,5,6,7,8,9"
+          aria-label="page 5 of 10"
           class="pagination-button active button button-neutral button-medium"
         >
           <span
@@ -638,7 +638,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 6 of 2,3,4,5,6,7,8,9"
+          aria-label="page 6 of 10"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -652,7 +652,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 7 of 2,3,4,5,6,7,8,9"
+          aria-label="page 7 of 10"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -666,7 +666,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 8 of 2,3,4,5,6,7,8,9"
+          aria-label="page 8 of 10"
           class="pagination-button button button-neutral button-medium"
         >
           <span
@@ -680,7 +680,7 @@ exports[`Pagination Pagination should render with some elements 1`] = `
         <button
           aria-current="false"
           aria-disabled="false"
-          aria-label="page 9 of 2,3,4,5,6,7,8,9"
+          aria-label="page 9 of 10"
           class="pagination-button button button-neutral button-medium"
         >
           <span


### PR DESCRIPTION
## SUMMARY:
1. Passed default value to pageCount to fix `Cannot read properties of undefined (reading 'toLocaleString')`
2. Removed default value of ariaHeading and kept the condition wrapped in `ariaHeading !== undefined` because of https://eightfoldai.slack.com/archives/CELVBNG6A/p1756503552646709

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-158360

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
