### PR TITLE
fix(Select): accessibility fix for aria live announcement and aria property

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -666,6 +666,24 @@ describe('Select', () => {
     expect(screen.getByTestId('option1-test-id').matches(':focus')).toBe(true);
   });
 
+  test('Updates aria-activedescendant when an option receives focus via keyboard navigation', async () => {
+    // ArrowDown in a filterable select calls focusFirstElement(), which focuses
+    // the first <li role="option">, firing focusin and updating the attribute.
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select options={options} filterable placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    select.focus();
+    fireEvent.click(select);
+    await waitFor(() => getAllByRole('option'));
+
+    fireEvent.keyDown(select, { key: 'ArrowDown' });
+
+    await waitFor(() =>
+      expect(select.getAttribute('aria-activedescendant')).toBe('Option 1-0')
+    );
+  });
+
   test('Does not focus the first focusable element when dropdown is visible and not filterable and initialFocus is false', async () => {
     const { getAllByRole, getByPlaceholderText } = render(
       <Select

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -962,23 +962,6 @@ export const Select: FC<SelectProps> = React.forwardRef(
       updateLayout();
     }, [dropdownWidth, selectWidth]);
 
-    // Keep aria-activedescendant in sync with keyboard navigation without
-    // triggering React re-renders (which would cause the inline OptionMenu
-    // component to be remounted and destroy focus).
-    //
-    // Strategy: manipulate the DOM attribute directly on the underlying <input>
-    // element via inputRef.  React only reconciles attributes it knows about
-    // through JSX props; because we do NOT pass aria-activedescendant as a
-    // controlled prop we can set/remove it imperatively and React will leave it
-    // alone between renders.
-    //
-    // • When the dropdown closes: clear the attribute (per ARIA spec the
-    //   attribute must not reference an element that is not rendered).
-    // • When the dropdown opens: pre-populate with the currently selected
-    //   option's id so screen readers receive an immediate hint.
-    // • While the dropdown is open: listen for focusin on the document and
-    //   update the attribute whenever an option element (role="option") receives
-    //   focus – covers ArrowDown/Up navigation without touching Dropdown internals.
     useEffect(() => {
       const input = inputRef.current;
       if (!dropdownVisible) {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -354,7 +354,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
           visibleOptionsCount !== 1
             ? selectLocale?.lang?.resultsAvailableText
             : selectLocale?.lang?.resultAvailableText;
-        message = `${visibleOptionsCount} ${countLabel}`;
+        message = searchQuery
+          ? `${searchQuery},${visibleOptionsCount} ${countLabel}`
+          : `${visibleOptionsCount} ${countLabel}`;
       } else {
         const noResultsText = selectLocale?.lang?.noResultsFoundText;
         message = searchQuery ? `${noResultsText} ${searchQuery}` : '';
@@ -768,6 +770,15 @@ export const Select: FC<SelectProps> = React.forwardRef(
                 (opt: SelectOption) => opt.value === value
               );
               currentlySelectedOption.current = option;
+              // Imperatively update aria-activedescendant so screen readers
+              // announce the selected option even when the selection is driven
+              // by a pointer event (which does not fire a focusin event).
+              if (option?.id) {
+                inputRef.current?.setAttribute(
+                  'aria-activedescendant',
+                  option.id
+                );
+              }
               toggleOption(option);
             }}
             role="listbox"
@@ -951,6 +962,50 @@ export const Select: FC<SelectProps> = React.forwardRef(
       updateLayout();
     }, [dropdownWidth, selectWidth]);
 
+    // Keep aria-activedescendant in sync with keyboard navigation without
+    // triggering React re-renders (which would cause the inline OptionMenu
+    // component to be remounted and destroy focus).
+    //
+    // Strategy: manipulate the DOM attribute directly on the underlying <input>
+    // element via inputRef.  React only reconciles attributes it knows about
+    // through JSX props; because we do NOT pass aria-activedescendant as a
+    // controlled prop we can set/remove it imperatively and React will leave it
+    // alone between renders.
+    //
+    // • When the dropdown closes: clear the attribute (per ARIA spec the
+    //   attribute must not reference an element that is not rendered).
+    // • When the dropdown opens: pre-populate with the currently selected
+    //   option's id so screen readers receive an immediate hint.
+    // • While the dropdown is open: listen for focusin on the document and
+    //   update the attribute whenever an option element (role="option") receives
+    //   focus – covers ArrowDown/Up navigation without touching Dropdown internals.
+    useEffect(() => {
+      const input = inputRef.current;
+      if (!dropdownVisible) {
+        input?.removeAttribute('aria-activedescendant');
+      }
+
+      const selected = (options || []).find(
+        (opt: SelectOption) => opt.selected && !opt.hideOption
+      );
+      if (selected?.id) {
+        input?.setAttribute('aria-activedescendant', selected.id);
+      }
+
+      const handleFocusIn = (event: FocusEvent): void => {
+        const target = event.target as HTMLElement;
+        if (target?.id && target.getAttribute('role') === 'option') {
+          input?.setAttribute('aria-activedescendant', target.id);
+        }
+      };
+
+      document.addEventListener('focusin', handleFocusIn);
+      return () => {
+        document.removeEventListener('focusin', handleFocusIn);
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dropdownVisible]);
+
     return (
       <ResizeObserver onResize={updateLayout}>
         <ThemeContextProvider
@@ -1004,7 +1059,6 @@ export const Select: FC<SelectProps> = React.forwardRef(
                 {dropdownVisible && showPills() ? getPills() : null}
                 <TextInput
                   ref={inputRef}
-                  aria-activedescendant={currentlySelectedOption.current?.id}
                   aria-controls={selectMenuId?.current}
                   aria-expanded={dropdownVisible}
                   configContextProps={configContextProps}


### PR DESCRIPTION
## SUMMARY:
**Select**:
- aria-activedescendant update issue:
aria-activedescendant is only being set after an option is selected. It should also update dynamically when the combobox receives focus and the user navigates through options with the keyboard, so screen readers can announce the currently highlighted option in real time.

- Live region announcement issue:
A polite live region (aria-live="polite") is missing for search result status updates. The implementation should announce the number of available results (or no results) whenever the filtered options change, so screen reader users are informed of search result updates.

## GITHUB ISSUE (Open Source Contributors)
NA

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-167727
https://eightfoldai.atlassian.net/browse/ENG-167639
https://eightfoldai.atlassian.net/browse/ENG-167744

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

  "Updates aria-activedescendant when an option receives focus via keyboard navigation"                                                  
  - Opens the dropdown via click on a filterable Select
  - Fires ArrowDown on the input                                                                                                         
  - Asserts that aria-activedescendant on the input equals "Option 1-0" (the first option's id)
  
  Live region announces results correctly
  - Announces result count (“n results available”) for each search result