### PR TITLE
feat(TextArea): add Clear button

### DIFF
--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -144,6 +144,13 @@ export interface SearchBoxProps
   value?: string;
 }
 
+export type TextAreaLocale = {
+  lang: {
+    locale: string;
+    clearButtonAriaLabelText: string;
+  };
+};
+
 export interface TextAreaProps
   extends Omit<
     InputProps<HTMLTextAreaElement>,
@@ -154,6 +161,11 @@ export interface TextAreaProps
     | 'alignIcon'
     | 'readonly'
   > {
+  /**
+   * The text area close button aria label text.
+   * @default 'Clear text area'
+   */
+  clearButtonAriaLabel?: string;
   /**
    * The text area is expandable.
    * @default false

--- a/src/components/Inputs/Input.types.ts
+++ b/src/components/Inputs/Input.types.ts
@@ -164,6 +164,15 @@ export interface TextAreaProps
    */
   onClear?: () => void;
   /**
+   * Callback fired when the close button is clicked.
+   */
+  onClose?: () => void;
+  /**
+   * Shows a close button in the top-right corner of the text area.
+   * @default false
+   */
+  showCloseButton?: boolean;
+  /**
    * The text area component ref.
    */
   ref?: Ref<HTMLTextAreaElement>;

--- a/src/components/Inputs/TextArea/Locale/ar_SA.tsx
+++ b/src/components/Inputs/TextArea/Locale/ar_SA.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'ar_SA',
+    clearButtonAriaLabelText: 'مسح منطقة النص',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/bg_BG.tsx
+++ b/src/components/Inputs/TextArea/Locale/bg_BG.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'bg_BG',
+    clearButtonAriaLabelText: 'Изчисти текстовото поле',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/cs_CZ.tsx
+++ b/src/components/Inputs/TextArea/Locale/cs_CZ.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'cs_CZ',
+    clearButtonAriaLabelText: 'Vymazat textové pole',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/da_DK.tsx
+++ b/src/components/Inputs/TextArea/Locale/da_DK.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'da_DK',
+    clearButtonAriaLabelText: 'Ryd tekstområde',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/de_DE.tsx
+++ b/src/components/Inputs/TextArea/Locale/de_DE.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'de_DE',
+    clearButtonAriaLabelText: 'Textbereich leeren',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/el_GR.tsx
+++ b/src/components/Inputs/TextArea/Locale/el_GR.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'el_GR',
+    clearButtonAriaLabelText: 'Εκκαθάριση περιοχής κειμένου',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/en_GB.tsx
+++ b/src/components/Inputs/TextArea/Locale/en_GB.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'en_GB',
+    clearButtonAriaLabelText: 'Clear text area',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/en_US.tsx
+++ b/src/components/Inputs/TextArea/Locale/en_US.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'en_US',
+    clearButtonAriaLabelText: 'Clear text area',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/es_DO.tsx
+++ b/src/components/Inputs/TextArea/Locale/es_DO.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'es_DO',
+    clearButtonAriaLabelText: 'Borrar área de texto',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/es_ES.tsx
+++ b/src/components/Inputs/TextArea/Locale/es_ES.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'es_ES',
+    clearButtonAriaLabelText: 'Borrar área de texto',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/es_MX.tsx
+++ b/src/components/Inputs/TextArea/Locale/es_MX.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'es_MX',
+    clearButtonAriaLabelText: 'Borrar área de texto',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/fi_FI.tsx
+++ b/src/components/Inputs/TextArea/Locale/fi_FI.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'fi_FI',
+    clearButtonAriaLabelText: 'Tyhjennä tekstialue',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/fr_BE.tsx
+++ b/src/components/Inputs/TextArea/Locale/fr_BE.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'fr_BE',
+    clearButtonAriaLabelText: 'Effacer la zone de texte',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/fr_CA.tsx
+++ b/src/components/Inputs/TextArea/Locale/fr_CA.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'fr_CA',
+    clearButtonAriaLabelText: 'Effacer la zone de texte',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/fr_FR.tsx
+++ b/src/components/Inputs/TextArea/Locale/fr_FR.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'fr_FR',
+    clearButtonAriaLabelText: 'Effacer la zone de texte',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/he_IL.tsx
+++ b/src/components/Inputs/TextArea/Locale/he_IL.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'he_IL',
+    clearButtonAriaLabelText: 'נקה שטח טקסט',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/hi_IN.tsx
+++ b/src/components/Inputs/TextArea/Locale/hi_IN.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'hi_IN',
+    clearButtonAriaLabelText: 'टेक्स्ट क्षेत्र साफ़ करें',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/hr_HR.tsx
+++ b/src/components/Inputs/TextArea/Locale/hr_HR.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'hr_HR',
+    clearButtonAriaLabelText: 'Očisti tekstualno polje',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/ht_HT.tsx
+++ b/src/components/Inputs/TextArea/Locale/ht_HT.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'ht_HT',
+    clearButtonAriaLabelText: 'Efase zòn tèks la',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/hu_HU.tsx
+++ b/src/components/Inputs/TextArea/Locale/hu_HU.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'hu_HU',
+    clearButtonAriaLabelText: 'Szövegterület törlése',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/it_IT.tsx
+++ b/src/components/Inputs/TextArea/Locale/it_IT.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'it_IT',
+    clearButtonAriaLabelText: 'Cancella area di testo',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/ja_JP.tsx
+++ b/src/components/Inputs/TextArea/Locale/ja_JP.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'ja_JP',
+    clearButtonAriaLabelText: 'テキストエリアをクリア',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/ko_KR.tsx
+++ b/src/components/Inputs/TextArea/Locale/ko_KR.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'ko_KR',
+    clearButtonAriaLabelText: '텍스트 영역 지우기',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/ms_MY.tsx
+++ b/src/components/Inputs/TextArea/Locale/ms_MY.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'ms_MY',
+    clearButtonAriaLabelText: 'Kosongkan kawasan teks',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/nb_NO.tsx
+++ b/src/components/Inputs/TextArea/Locale/nb_NO.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'nb_NO',
+    clearButtonAriaLabelText: 'Tøm tekstområdet',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/nl_BE.tsx
+++ b/src/components/Inputs/TextArea/Locale/nl_BE.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'nl_BE',
+    clearButtonAriaLabelText: 'Tekstgebied wissen',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/nl_NL.tsx
+++ b/src/components/Inputs/TextArea/Locale/nl_NL.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'nl_NL',
+    clearButtonAriaLabelText: 'Tekstgebied wissen',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/pl_PL.tsx
+++ b/src/components/Inputs/TextArea/Locale/pl_PL.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'pl_PL',
+    clearButtonAriaLabelText: 'Wyczyść obszar tekstowy',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/pt_BR.tsx
+++ b/src/components/Inputs/TextArea/Locale/pt_BR.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'pt_BR',
+    clearButtonAriaLabelText: 'Limpar área de texto',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/pt_PT.tsx
+++ b/src/components/Inputs/TextArea/Locale/pt_PT.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'pt_PT',
+    clearButtonAriaLabelText: 'Limpar área de texto',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/ro_RO.tsx
+++ b/src/components/Inputs/TextArea/Locale/ro_RO.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'ro_RO',
+    clearButtonAriaLabelText: 'Șterge zona de text',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/ru_RU.tsx
+++ b/src/components/Inputs/TextArea/Locale/ru_RU.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'ru_RU',
+    clearButtonAriaLabelText: 'Очистить текстовое поле',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/sk_SK.tsx
+++ b/src/components/Inputs/TextArea/Locale/sk_SK.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'sk_SK',
+    clearButtonAriaLabelText: 'Vymazať textové pole',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/sr_RS.tsx
+++ b/src/components/Inputs/TextArea/Locale/sr_RS.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'sr_RS',
+    clearButtonAriaLabelText: 'Обриши текстуално поље',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/sv_SE.tsx
+++ b/src/components/Inputs/TextArea/Locale/sv_SE.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'sv_SE',
+    clearButtonAriaLabelText: 'Rensa textområde',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/te_IN.tsx
+++ b/src/components/Inputs/TextArea/Locale/te_IN.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'te_IN',
+    clearButtonAriaLabelText: 'వచన ప్రాంతాన్ని క్లియర్ చేయండి',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/th_TH.tsx
+++ b/src/components/Inputs/TextArea/Locale/th_TH.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'th_TH',
+    clearButtonAriaLabelText: 'ล้างพื้นที่ข้อความ',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/tr_TR.tsx
+++ b/src/components/Inputs/TextArea/Locale/tr_TR.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'tr_TR',
+    clearButtonAriaLabelText: 'Metin alanını temizle',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/uk_UA.tsx
+++ b/src/components/Inputs/TextArea/Locale/uk_UA.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'uk_UA',
+    clearButtonAriaLabelText: 'Очистити текстове поле',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/vi_VN.tsx
+++ b/src/components/Inputs/TextArea/Locale/vi_VN.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'vi_VN',
+    clearButtonAriaLabelText: 'Xóa vùng văn bản',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/zh_CN.tsx
+++ b/src/components/Inputs/TextArea/Locale/zh_CN.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'zh_CN',
+    clearButtonAriaLabelText: '清除文本区域',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/Locale/zh_TW.tsx
+++ b/src/components/Inputs/TextArea/Locale/zh_TW.tsx
@@ -1,0 +1,10 @@
+import type { TextAreaLocale } from '../../Input.types';
+
+const locale: TextAreaLocale = {
+  lang: {
+    locale: 'zh_TW',
+    clearButtonAriaLabelText: '清除文字區域',
+  },
+};
+
+export default locale;

--- a/src/components/Inputs/TextArea/TextArea.stories.tsx
+++ b/src/components/Inputs/TextArea/TextArea.stories.tsx
@@ -74,6 +74,10 @@ export default {
       options: [true, false],
       control: { type: 'inline-radio' },
     },
+    showCloseButton: {
+      options: [true, false],
+      control: { type: 'inline-radio' },
+    },
     inputWidth: {
       options: [TextInputWidth.fitContent, TextInputWidth.fill],
       control: { type: 'inline-radio' },
@@ -126,7 +130,12 @@ export default {
 const Text_Area_Story: ComponentStory<typeof TextArea> = (args) => {
   const [val, setVal] = useState(args.value);
   return (
-    <TextArea {...args} value={val} onChange={(e) => setVal(e.target.value)} />
+    <TextArea
+      {...args}
+      value={val}
+      onChange={(e) => setVal(e.target.value)}
+      onClose={() => setVal('')}
+    />
   );
 };
 
@@ -169,6 +178,7 @@ Text_Area.args = {
     noStyleChange: false,
   },
   required: false,
+  showCloseButton: false,
   size: TextInputSize.Medium,
   shape: TextInputShape.Rectangle,
   style: {},

--- a/src/components/Inputs/TextArea/TextArea.test.tsx
+++ b/src/components/Inputs/TextArea/TextArea.test.tsx
@@ -3,7 +3,7 @@ import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import { TextArea } from './TextArea';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -38,5 +38,39 @@ describe('TextArea', () => {
       container.querySelector('.text-area').hasAttribute('readonly')
     ).toBeTruthy();
     expect(container.querySelector('.text-area').innerHTML).toBe('Test value');
+  });
+
+  test('Close button is not rendered by default', () => {
+    const { container } = render(<TextArea value="Some text" />);
+    expect(container.querySelector('.text-area-close-button')).toBeNull();
+  });
+
+  test('Close button is rendered when showCloseButton is true and value is present', () => {
+    const { container } = render(
+      <TextArea showCloseButton value="Some text" />
+    );
+    expect(container.querySelector('.text-area-close-button')).toBeTruthy();
+    expect(
+      container
+        .querySelector('.text-area-close-button')
+        .getAttribute('aria-label')
+    ).toBe('Clear');
+  });
+
+  test('Close button click clears the textarea value', () => {
+    const { container } = render(
+      <TextArea showCloseButton value="Some text" onChange={() => {}} />
+    );
+    const closeButton = container.querySelector('.text-area-close-button');
+    expect(closeButton).toBeTruthy();
+    fireEvent.click(closeButton);
+    expect(container.querySelector('.text-area-close-button')).toBeNull();
+  });
+
+  test('Text area with showCloseButton and value matches snapshot', () => {
+    const { container } = render(
+      <TextArea showCloseButton value="Hello world" id="snapshot-textarea" />
+    );
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/src/components/Inputs/TextArea/TextArea.test.tsx
+++ b/src/components/Inputs/TextArea/TextArea.test.tsx
@@ -54,7 +54,7 @@ describe('TextArea', () => {
       container
         .querySelector('.text-area-close-button')
         .getAttribute('aria-label')
-    ).toBe('Clear');
+    ).toBe('Clear text area');
   });
 
   test('Close button click clears the textarea value', () => {

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -173,6 +173,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       { [styles.inputStretch]: inputWidth === TextInputWidth.fill },
       { [styles.readOnly]: !!readonly && !readOnlyProps?.noStyleChange },
       { ['in-form-item']: mergedFormItemInput },
+      { [styles.textAreaWithCloseButton]: showCloseButton },
       getStatusClassNames(mergedStatus, hasFeedback),
     ]);
 

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -65,6 +65,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       onBlur,
       onChange,
       onClear,
+      onClose,
       onFocus,
       onKeyDown,
       onReset,
@@ -73,6 +74,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       readOnlyProps,
       required = false,
       reset = false,
+      showCloseButton = false,
       shape = TextInputShape.Rectangle,
       size = TextInputSize.Medium,
       status,
@@ -329,6 +331,23 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
               tabIndex={0}
               value={inputValue}
             />
+            {showCloseButton && !!inputValue && (
+              <button
+                aria-label="Clear"
+                className={styles.textAreaCloseButton}
+                onClick={() => {
+                  setInputValue('');
+                  onClose?.();
+                  inputField?.focus();
+                }}
+                type="button"
+              >
+                <Icon
+                  path={IconName.mdiClose}
+                  size={inputSizeToIconSizeMap.get(mergedSize)}
+                />
+              </button>
+            )}
             {enableExpand && (
               <Icon
                 classNames={styles.textAreaResizeIcon}

--- a/src/components/Inputs/TextArea/TextArea.tsx
+++ b/src/components/Inputs/TextArea/TextArea.tsx
@@ -34,6 +34,8 @@ import {
 } from '../../../shared/utilities';
 import { Breakpoints, useMatchMedia } from '../../../hooks/useMatchMedia';
 import { useCanvasDirection } from '../../../hooks/useCanvasDirection';
+import { useLocaleReceiver } from '../../LocaleProvider/LocaleReceiver';
+import enUS from './Locale/en_US';
 
 import styles from '../input.module.scss';
 import themedComponentStyles from '../input.theme.module.scss';
@@ -46,6 +48,7 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
       autoFocus = false,
       classNames,
       clear = false,
+      clearButtonAriaLabel,
       configContextProps = {
         noDisabledContext: false,
         noShapeContext: false,
@@ -95,6 +98,8 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
     const xSmallScreenActive: boolean = useMatchMedia(Breakpoints.XSmall);
 
     const htmlDir: string = useCanvasDirection();
+
+    const [textAreaLocale] = useLocaleReceiver('TextArea', enUS);
 
     // TODO: Upgrade to React 18 and use the new `useId` hook.
     // This way the id will match on the server and client.
@@ -334,14 +339,16 @@ export const TextArea: FC<TextAreaProps> = React.forwardRef(
             />
             {showCloseButton && !!inputValue && (
               <button
-                aria-label="Clear"
+                aria-label={
+                  clearButtonAriaLabel ??
+                  textAreaLocale?.lang?.clearButtonAriaLabelText
+                }
                 className={styles.textAreaCloseButton}
                 onClick={() => {
                   setInputValue('');
                   onClose?.();
                   inputField?.focus();
                 }}
-                type="button"
               >
                 <Icon
                   path={IconName.mdiClose}

--- a/src/components/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -18,9 +18,8 @@ exports[`TextArea Text area with showCloseButton and value matches snapshot 1`] 
       Hello world
     </textarea>
     <button
-      aria-label="Clear"
+      aria-label="Clear text area"
       class="text-area-close-button"
-      type="button"
     >
       <span
         class="icon-wrapper"

--- a/src/components/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextArea Text area with showCloseButton and value matches snapshot 1`] 
   >
     <textarea
       aria-disabled="false"
-      class="text-area text-area-no-expand"
+      class="text-area text-area-no-expand text-area-with-close-button"
       cols="50"
       id="snapshot-textarea"
       rows="5"

--- a/src/components/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/src/components/Inputs/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextArea Text area with showCloseButton and value matches snapshot 1`] = `
+<div
+  class="input-wrapper input-medium"
+>
+  <div
+    class="text-area-group"
+  >
+    <textarea
+      aria-disabled="false"
+      class="text-area text-area-no-expand"
+      cols="50"
+      id="snapshot-textarea"
+      rows="5"
+      tabindex="0"
+    >
+      Hello world
+    </textarea>
+    <button
+      aria-label="Clear"
+      class="text-area-close-button"
+      type="button"
+    >
+      <span
+        class="icon-wrapper"
+      >
+        <svg
+          role="presentation"
+          style="width: 20px; height: 20px;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+            style="fill: currentColor;"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</div>
+`;

--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -1219,6 +1219,30 @@
     right: $space-xxs;
   }
 
+  .text-area-close-button {
+    align-items: center;
+    background: transparent;
+    border: none;
+    color: var(--grey-tertiary-color);
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    padding: $space-xxs;
+    position: absolute;
+    right: $space-xxs;
+    top: $space-xxs;
+    z-index: 1;
+
+    &:hover {
+      color: var(--grey-color);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-visible-shadow-color);
+      outline-offset: 2px;
+    }
+  }
+
   &.pill-shape {
     .text-area-resize-icon {
       bottom: 14px;

--- a/src/components/Inputs/input.module.scss
+++ b/src/components/Inputs/input.module.scss
@@ -1210,6 +1210,10 @@
     &.input-stretch {
       width: 100%;
     }
+
+    &.text-area-with-close-button {
+      padding-right: $space-xl;
+    }
   }
 
   .text-area-resize-icon {
@@ -1505,6 +1509,10 @@
       font-size: $text-font-size-4;
       line-height: $text-line-height-5;
       min-height: calc($text-line-height-5 + $space-xxxs + $space-xs * 2);
+
+      &.text-area-with-close-button {
+        padding-right: calc($space-xl + $space-xxs);
+      }
     }
   }
 

--- a/src/components/Locale/Default.tsx
+++ b/src/components/Locale/Default.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/en_US';
 import Table from '../Table/Locale/en_US';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_US';
 import Select from '../Select/Locale/en_US';
+import TextArea from '../Inputs/TextArea/Locale/en_US';
 import Upload from '../Upload/Locale/en_US';
 
 const typeTemplate = '${label} is not a valid ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/ar_SA.tsx
+++ b/src/components/Locale/ar_SA.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/ar_SA';
 import Table from '../Table/Locale/ar_SA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ar_SA';
 import Select from '../Select/Locale/ar_SA';
+import TextArea from '../Inputs/TextArea/Locale/ar_SA';
 import Upload from '../Upload/Locale/ar_SA';
 
 const typeTemplate = '${label} ليس ${type} صالحًا';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/bg_BG.tsx
+++ b/src/components/Locale/bg_BG.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/bg_BG';
 import Table from '../Table/Locale/bg_BG';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/bg_BG';
 import Select from '../Select/Locale/bg_BG';
+import TextArea from '../Inputs/TextArea/Locale/bg_BG';
 import Upload from '../Upload/Locale/bg_BG';
 
 const typeTemplate = '${label} не е валиден ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/cs_CZ.tsx
+++ b/src/components/Locale/cs_CZ.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/cs_CZ';
 import Table from '../Table/Locale/cs_CZ';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/cs_CZ';
 import Select from '../Select/Locale/cs_CZ';
+import TextArea from '../Inputs/TextArea/Locale/cs_CZ';
 import Upload from '../Upload/Locale/cs_CZ';
 
 const localeValues: Locale = {
@@ -32,6 +33,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/da_DK.tsx
+++ b/src/components/Locale/da_DK.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/da_DK';
 import Table from '../Table/Locale/da_DK';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/da_DK';
 import Select from '../Select/Locale/da_DK';
+import TextArea from '../Inputs/TextArea/Locale/da_DK';
 import Upload from '../Upload/Locale/da_DK';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/de_DE.tsx
+++ b/src/components/Locale/de_DE.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/de_DE';
 import Table from '../Table/Locale/de_DE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/de_DE';
 import Select from '../Select/Locale/de_DE';
+import TextArea from '../Inputs/TextArea/Locale/de_DE';
 import Upload from '../Upload/Locale/de_DE';
 
 const typeTemplate = '${label} ist nicht gültig. ${type} erwartet';
@@ -84,6 +85,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/el_GR.tsx
+++ b/src/components/Locale/el_GR.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/el_GR';
 import Table from '../Table/Locale/el_GR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/el_GR';
 import Select from '../Select/Locale/el_GR';
+import TextArea from '../Inputs/TextArea/Locale/el_GR';
 import Upload from '../Upload/Locale/el_GR';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/en_GB.tsx
+++ b/src/components/Locale/en_GB.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/en_GB';
 import Table from '../Table/Locale/en_GB';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/en_GB';
 import Select from '../Select/Locale/en_GB';
+import TextArea from '../Inputs/TextArea/Locale/en_GB';
 import Upload from '../Upload/Locale/en_GB';
 
 const typeTemplate = '${label} is not a valid ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/es_DO.tsx
+++ b/src/components/Locale/es_DO.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/es_DO';
 import Table from '../Table/Locale/es_DO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_DO';
 import Select from '../Select/Locale/es_DO';
+import TextArea from '../Inputs/TextArea/Locale/es_DO';
 import Upload from '../Upload/Locale/es_DO';
 
 const typeTemplate = '${label} no es un ${type} válido';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/es_ES.tsx
+++ b/src/components/Locale/es_ES.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/es_ES';
 import Table from '../Table/Locale/es_ES';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_ES';
 import Select from '../Select/Locale/es_ES';
+import TextArea from '../Inputs/TextArea/Locale/es_ES';
 import Upload from '../Upload/Locale/es_ES';
 
 const typeTemplate = '${label} no es un ${type} válido';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/es_MX.tsx
+++ b/src/components/Locale/es_MX.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/es_MX';
 import Table from '../Table/Locale/es_MX';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/es_MX';
 import Select from '../Select/Locale/es_MX';
+import TextArea from '../Inputs/TextArea/Locale/es_MX';
 import Upload from '../Upload/Locale/es_MX';
 
 const typeTemplate = '${label} no es un ${type} válido';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/fi_FI.tsx
+++ b/src/components/Locale/fi_FI.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/fi_FI';
 import Table from '../Table/Locale/fi_FI';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fi_FI';
 import Select from '../Select/Locale/fi_FI';
+import TextArea from '../Inputs/TextArea/Locale/fi_FI';
 import Upload from '../Upload/Locale/fi_FI';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/fr_BE.tsx
+++ b/src/components/Locale/fr_BE.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/fr_BE';
 import Table from '../Table/Locale/fr_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_BE';
 import Select from '../Select/Locale/fr_BE';
+import TextArea from '../Inputs/TextArea/Locale/fr_BE';
 import Upload from '../Upload/Locale/fr_BE';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/fr_CA.tsx
+++ b/src/components/Locale/fr_CA.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/fr_CA';
 import Table from '../Table/Locale/fr_CA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_CA';
 import Select from '../Select/Locale/fr_CA';
+import TextArea from '../Inputs/TextArea/Locale/fr_CA';
 import Upload from '../Upload/Locale/fr_CA';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/fr_FR.tsx
+++ b/src/components/Locale/fr_FR.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/fr_FR';
 import Table from '../Table/Locale/fr_FR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/fr_FR';
 import Select from '../Select/Locale/fr_FR';
+import TextArea from '../Inputs/TextArea/Locale/fr_FR';
 import Upload from '../Upload/Locale/fr_FR';
 
 const typeTemplate =
@@ -86,6 +87,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/he_IL.tsx
+++ b/src/components/Locale/he_IL.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/he_IL';
 import Table from '../Table/Locale/he_IL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/he_IL';
 import Select from '../Select/Locale/he_IL';
+import TextArea from '../Inputs/TextArea/Locale/he_IL';
 import Upload from '../Upload/Locale/he_IL';
 
 const typeTemplate = '${label} הוא לא ${type} תקין';
@@ -84,6 +85,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/hi_IN.tsx
+++ b/src/components/Locale/hi_IN.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/hi_IN';
 import Table from '../Table/Locale/hi_IN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hi_IN';
 import Select from '../Select/Locale/hi_IN';
+import TextArea from '../Inputs/TextArea/Locale/hi_IN';
 import Upload from '../Upload/Locale/hi_IN';
 
 const typeTemplate = '${label} कोई मान्य ${type} नहीं है';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/hr_HR.tsx
+++ b/src/components/Locale/hr_HR.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/hr_HR';
 import Table from '../Table/Locale/hr_HR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hr_HR';
 import Select from '../Select/Locale/hr_HR';
+import TextArea from '../Inputs/TextArea/Locale/hr_HR';
 import Upload from '../Upload/Locale/hr_HR';
 
 const typeTemplate = '${label} nije valjan ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/ht_HT.tsx
+++ b/src/components/Locale/ht_HT.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/ht_HT';
 import Table from '../Table/Locale/ht_HT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ht_HT';
 import Select from '../Select/Locale/ht_HT';
+import TextArea from '../Inputs/TextArea/Locale/ht_HT';
 import Upload from '../Upload/Locale/ht_HT';
 
 const typeTemplate =
@@ -86,6 +87,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/hu_HU.tsx
+++ b/src/components/Locale/hu_HU.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/hu_HU';
 import Table from '../Table/Locale/hu_HU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/hu_HU';
 import Select from '../Select/Locale/hu_HU';
+import TextArea from '../Inputs/TextArea/Locale/hu_HU';
 import Upload from '../Upload/Locale/hu_HU';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/it_IT.tsx
+++ b/src/components/Locale/it_IT.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/it_IT';
 import Table from '../Table/Locale/it_IT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/it_IT';
 import Select from '../Select/Locale/it_IT';
+import TextArea from '../Inputs/TextArea/Locale/it_IT';
 import Upload from '../Upload/Locale/it_IT';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/ja_JP.tsx
+++ b/src/components/Locale/ja_JP.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/ja_JP';
 import Table from '../Table/Locale/ja_JP';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ja_JP';
 import Select from '../Select/Locale/ja_JP';
+import TextArea from '../Inputs/TextArea/Locale/ja_JP';
 import Upload from '../Upload/Locale/ja_JP';
 
 const typeTemplate = '${label}は有効な${type}ではありません';
@@ -81,6 +82,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/ko_KR.tsx
+++ b/src/components/Locale/ko_KR.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/ko_KR';
 import Table from '../Table/Locale/ko_KR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ko_KR';
 import Select from '../Select/Locale/ko_KR';
+import TextArea from '../Inputs/TextArea/Locale/ko_KR';
 import Upload from '../Upload/Locale/ko_KR';
 
 const typeTemplate = '${label} 유효하지 않은 ${type}';
@@ -81,6 +82,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/ms_MY.tsx
+++ b/src/components/Locale/ms_MY.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/ms_MY';
 import Table from '../Table/Locale/ms_MY';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ms_MY';
 import Select from '../Select/Locale/ms_MY';
+import TextArea from '../Inputs/TextArea/Locale/ms_MY';
 import Upload from '../Upload/Locale/ms_MY';
 
 const localeValues: Locale = {
@@ -32,6 +33,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/nb_NO.tsx
+++ b/src/components/Locale/nb_NO.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/nb_NO';
 import Table from '../Table/Locale/nb_NO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nb_NO';
 import Select from '../Select/Locale/nb_NO';
+import TextArea from '../Inputs/TextArea/Locale/nb_NO';
 import Upload from '../Upload/Locale/nb_NO';
 
 const typeTemplate = '${label} er ikke et gyldig ${type}';
@@ -84,6 +85,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/nl_BE.tsx
+++ b/src/components/Locale/nl_BE.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/nl_BE';
 import Table from '../Table/Locale/nl_BE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_BE';
 import Select from '../Select/Locale/nl_BE';
+import TextArea from '../Inputs/TextArea/Locale/nl_BE';
 import Upload from '../Upload/Locale/nl_BE';
 
 const typeTemplate = '${label} is geen geldige ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/nl_NL.tsx
+++ b/src/components/Locale/nl_NL.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/nl_NL';
 import Table from '../Table/Locale/nl_NL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/nl_NL';
 import Select from '../Select/Locale/nl_NL';
+import TextArea from '../Inputs/TextArea/Locale/nl_NL';
 import Upload from '../Upload/Locale/nl_NL';
 
 const typeTemplate = '${label} is geen geldige ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/pl_PL.tsx
+++ b/src/components/Locale/pl_PL.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/pl_PL';
 import Table from '../Table/Locale/pl_PL';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pl_PL';
 import Select from '../Select/Locale/pl_PL';
+import TextArea from '../Inputs/TextArea/Locale/pl_PL';
 import Upload from '../Upload/Locale/pl_PL';
 
 const typeTemplate = '${label} nie posiada poprawnej wartości dla typu ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/pt_BR.tsx
+++ b/src/components/Locale/pt_BR.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/pt_BR';
 import Table from '../Table/Locale/pt_BR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_BR';
 import Select from '../Select/Locale/pt_BR';
+import TextArea from '../Inputs/TextArea/Locale/pt_BR';
 import Upload from '../Upload/Locale/pt_BR';
 
 const typeTemplate = '${label} não é um ${type} válido';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/pt_PT.tsx
+++ b/src/components/Locale/pt_PT.tsx
@@ -12,6 +12,7 @@ import Stepper from '../Stepper/Locale/pt_PT';
 import Table from '../Table/Locale/pt_PT';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/pt_PT';
 import Select from '../Select/Locale/pt_PT';
+import TextArea from '../Inputs/TextArea/Locale/pt_PT';
 import Upload from '../Upload/Locale/pt_PT';
 
 const localeValues: Locale = {
@@ -29,6 +30,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/ro_RO.tsx
+++ b/src/components/Locale/ro_RO.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/ro_RO';
 import Table from '../Table/Locale/ro_RO';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ro_RO';
 import Select from '../Select/Locale/ro_RO';
+import TextArea from '../Inputs/TextArea/Locale/ro_RO';
 import Upload from '../Upload/Locale/ro_RO';
 
 const typeTemplate = '${label} nu este un ${type} valid';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/ru_RU.tsx
+++ b/src/components/Locale/ru_RU.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/ru_RU';
 import Table from '../Table/Locale/ru_RU';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/ru_RU';
 import Select from '../Select/Locale/ru_RU';
+import TextArea from '../Inputs/TextArea/Locale/ru_RU';
 import Upload from '../Upload/Locale/ru_RU';
 
 const typeTemplate: string = '${label} не является типом ${type}';
@@ -84,6 +85,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/sk_SK.tsx
+++ b/src/components/Locale/sk_SK.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/sk_SK';
 import Table from '../Table/Locale/sk_SK';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/sk_SK';
 import Select from '../Select/Locale/sk_SK';
+import TextArea from '../Inputs/TextArea/Locale/sk_SK';
 import Upload from '../Upload/Locale/sk_SK';
 
 const typeTemplate = '${label} nie je platný ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/sr_RS.tsx
+++ b/src/components/Locale/sr_RS.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/sr_RS';
 import Table from '../Table/Locale/sr_RS';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/sr_RS';
 import Select from '../Select/Locale/sr_RS';
+import TextArea from '../Inputs/TextArea/Locale/sr_RS';
 import Upload from '../Upload/Locale/sr_RS';
 
 const typeTemplate = '${label} nije validan ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/sv_SE.tsx
+++ b/src/components/Locale/sv_SE.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/sv_SE';
 import Table from '../Table/Locale/sv_SE';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/sv_SE';
 import Select from '../Select/Locale/sv_SE';
+import TextArea from '../Inputs/TextArea/Locale/sv_SE';
 import Upload from '../Upload/Locale/sv_SE';
 
 const typeTemplate = '${label} är inte en giltig ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/te_IN.tsx
+++ b/src/components/Locale/te_IN.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/te_IN';
 import Table from '../Table/Locale/te_IN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/te_IN';
 import Select from '../Select/Locale/te_IN';
+import TextArea from '../Inputs/TextArea/Locale/te_IN';
 import Upload from '../Upload/Locale/te_IN';
 
 const typeTemplate = '${label} సరైన ${type} కాదు';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/th_TH.tsx
+++ b/src/components/Locale/th_TH.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/th_TH';
 import Table from '../Table/Locale/th_TH';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/th_TH';
 import Select from '../Select/Locale/th_TH';
+import TextArea from '../Inputs/TextArea/Locale/th_TH';
 import Upload from '../Upload/Locale/th_TH';
 
 const typeTemplate = '${label} ไม่ใช่ ${type} ที่ถูกต้อง';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/tr_TR.tsx
+++ b/src/components/Locale/tr_TR.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/tr_TR';
 import Table from '../Table/Locale/tr_TR';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/tr_TR';
 import Select from '../Select/Locale/tr_TR';
+import TextArea from '../Inputs/TextArea/Locale/tr_TR';
 import Upload from '../Upload/Locale/tr_TR';
 
 const typeTemplate = '${label} geçerli bir ${type} değil';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/uk_UA.tsx
+++ b/src/components/Locale/uk_UA.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/uk_UA';
 import Table from '../Table/Locale/uk_UA';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/uk_UA';
 import Select from '../Select/Locale/uk_UA';
+import TextArea from '../Inputs/TextArea/Locale/uk_UA';
 import Upload from '../Upload/Locale/uk_UA';
 
 const typeTemplate = '${label} не є типом ${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/vi_VN.tsx
+++ b/src/components/Locale/vi_VN.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/vi_VN';
 import Table from '../Table/Locale/vi_VN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/vi_VN';
 import Select from '../Select/Locale/vi_VN';
+import TextArea from '../Inputs/TextArea/Locale/vi_VN';
 import Upload from '../Upload/Locale/vi_VN';
 
 const typeTemplate = '${label} không phải là một ${type} hợp lệ';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/zh_CN.tsx
+++ b/src/components/Locale/zh_CN.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/zh_CN';
 import Table from '../Table/Locale/zh_CN';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_CN';
 import Select from '../Select/Locale/zh_CN';
+import TextArea from '../Inputs/TextArea/Locale/zh_CN';
 import Upload from '../Upload/Locale/zh_CN';
 
 const typeTemplate = '${label}不是一个有效的${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/Locale/zh_TW.tsx
+++ b/src/components/Locale/zh_TW.tsx
@@ -13,6 +13,7 @@ import Stepper from '../Stepper/Locale/zh_TW';
 import Table from '../Table/Locale/zh_TW';
 import TimePicker from '../DateTimePicker/TimePicker/Locale/zh_TW';
 import Select from '../Select/Locale/zh_TW';
+import TextArea from '../Inputs/TextArea/Locale/zh_TW';
 import Upload from '../Upload/Locale/zh_TW';
 
 const typeTemplate = '${label}不是一個有效的${type}';
@@ -85,6 +86,7 @@ const localeValues: Locale = {
   Table,
   TimePicker,
   Select,
+  TextArea,
   Upload,
 };
 

--- a/src/components/LocaleProvider/index.tsx
+++ b/src/components/LocaleProvider/index.tsx
@@ -16,6 +16,7 @@ import type { UploadLocale } from '../Upload/Upload.types';
 import type { ValidateMessages } from '../Form/Internal/OcForm.types';
 import type { SnackbarLocale } from '../Snackbar/Snackbar.types';
 import type { SelectLocale } from '../Select/Select.types';
+import type { TextAreaLocale } from '../Inputs/Input.types';
 import LocaleContext from './Context';
 
 export interface Locale {
@@ -40,6 +41,7 @@ export interface Locale {
   Upload?: UploadLocale;
   Snackbar?: SnackbarLocale;
   Select?: SelectLocale;
+  TextArea?: TextAreaLocale;
 }
 
 export interface LocaleProviderProps {


### PR DESCRIPTION
## SUMMARY:

- Added a clear/close button feature to the TextArea component.
- Introduced showCloseButton prop to enable or disable the button.
- Introduced onClose callback prop to handle button click events.
- Button is displayed only when enabled and the textarea contains a non-empty value.
- Clicking the button clears the textarea value.
- Triggers the onClose callback if provided.
- Returns focus to the textarea after clearing.
- Added accessibility-focused hover and focus-visible styles.

https://github.com/user-attachments/assets/f8080098-ec33-4b00-b436-aa23f06d60e3

<img width="1512" height="908" alt="image" src="https://github.com/user-attachments/assets/b73ee49c-3ab6-43ec-8e6d-8eef06863dd2" />

## GITHUB ISSUE (Open Source Contributors)
NA
## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-190268
## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

### 1. Rendering & Visibility

* Verify the close button is not displayed when `showCloseButton` is omitted or set to `false`.
* Verify the close button is not displayed when `showCloseButton={true}` but the textarea value is empty or undefined.
* Verify the close button is displayed only when:

  * `showCloseButton={true}`
  * Textarea contains a non-empty value.

### 2. Functional Behavior

* Verify clicking the close button clears the textarea value.
* Verify the close button disappears after clearing the value.
* Verify `onClose` callback is triggered exactly once per click.
* Verify no errors occur when `onClose` is not provided.
* Verify focus returns to the textarea after clicking the close button.

### 3. Accessibility

* Verify the close button has `aria-label="Clear"`.
* Verify the button is keyboard accessible using **Tab**.
* Verify it can be activated using **Enter** and **Space**.

