### PR TITLE
fix(Snackbar): add aria-hidden to empty snackbar position regions

### DIFF
--- a/src/components/Snackbar/Snackbar.test.tsx
+++ b/src/components/Snackbar/Snackbar.test.tsx
@@ -258,11 +258,41 @@ describe('Snackbar', () => {
         });
       });
 
+      // Only the active position's region is accessible to screen readers;
+      // empty regions are hidden via aria-hidden.
       const regions = wrapper.getAllByRole('region', {
         name: /notifications/i,
       });
       expect(regions).toBeTruthy();
-      expect(regions.length).toBe(6);
+      expect(regions.length).toBe(1);
+    });
+
+    test('empty position regions have aria-hidden="true"', () => {
+      // Before any snack: all 6 position regions are hidden from ATs
+      const allRegions = document.querySelectorAll('[role="region"]');
+      expect(allRegions.length).toBe(6);
+      allRegions.forEach((region) => {
+        expect(region.getAttribute('aria-hidden')).toBe('true');
+      });
+    });
+
+    test('active position region does not have aria-hidden; empty positions do', () => {
+      act(() => {
+        snack.serve({ content, position: 'top-center' });
+      });
+
+      // 5 empty positions remain aria-hidden
+      const hiddenRegions = document.querySelectorAll(
+        '[role="region"][aria-hidden="true"]'
+      );
+      expect(hiddenRegions.length).toBe(5);
+
+      // The region containing the active snack is accessible
+      const visibleRegions = wrapper.getAllByRole('region', {
+        name: /notifications/i,
+      });
+      expect(visibleRegions.length).toBe(1);
+      expect(visibleRegions[0].getAttribute('aria-hidden')).toBeNull();
     });
 
     test('non-closable snackbar should have role="alert"', () => {

--- a/src/components/Snackbar/SnackbarContainer.tsx
+++ b/src/components/Snackbar/SnackbarContainer.tsx
@@ -135,6 +135,7 @@ export const SnackbarContainer: FC<SnackbarContainerProps> = ({
         <div
           role="region"
           aria-label={mergedLocale.lang!.notificationsRegionAriaLabelText}
+          aria-hidden={positionSnacks.length === 0 || undefined}
           key={position}
           className={mergeClasses([
             styles.snackbarContainer,


### PR DESCRIPTION
## SUMMARY:
For ENG-192648:-
Problem:-Too many announcements of notifications - On this page, screen reader announces “Notifications region” multiple times which is confusing to the reader.

Solution:- Fix the notification region issue through aria-hidden true.

For ENG-192652:-
Problem:- Screen Reader Focuses and Announces “Notification Region” Multiple Times Without Context.
Occurs across all screens after the Get Help button in the footer.
When navigating with the Down Arrow key after the Get Help button:
• The term “Notification region” is focused and announced multiple times by the screen reader.
• No visible notifications are present, and the purpose of this region is unclear.
• This behavior is misleading and disrupts navigation for screen reader users.
Repeated focus and announcement of an unexplained region creates confusion, increases cognitive load, and negatively affects accessibility.

Solution:- Fix the notification region issue through aria-hidden true.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-192648
https://eightfoldai.atlassian.net/browse/ENG-192652

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

`SnackbarContainer` sets `aria-hidden="true"` on any of the 6 position `role="region"` divs that have no active snacks, and removes it when a snack is present.                                                                                                                                                                         
                                                            
All 6 regions on initial render | Every `[role="region"]` has `aria-hidden="true"` 

https://github.com/user-attachments/assets/1d35f9ea-78c5-4420-bb06-a3c1a9e0e9f2

https://github.com/user-attachments/assets/d5915940-529d-4755-9395-395e38aaefd2


<img width="2847" height="1646" alt="image" src="https://github.com/user-attachments/assets/885e43bd-80a0-46e7-9f88-df17b6063895" />
