### PR TITLE
fix(Menu): allow listItemRole override on MenuItemLink and MenuItemSubHeader

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -155,6 +155,10 @@ export interface MenuItemLinkProps
    * Display label of the menu item
    */
   text?: string;
+  /**
+   * Role for the list item (li) element
+   */
+  listItemRole?: string;
 }
 
 export interface MenuItemSubHeaderProps
@@ -164,6 +168,10 @@ export interface MenuItemSubHeaderProps
    * Text of the sub header
    */
   text?: string;
+  /**
+   * Role for the list item (li) element
+   */
+  listItemRole?: string;
 }
 
 export interface IMenuItemRender {

--- a/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItem/MenuItemLink/MenuItemLink.tsx
@@ -17,6 +17,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
       direction,
       disabled,
       iconProps,
+      listItemRole,
       role = 'menuitem',
       size = MenuSize.medium,
       subText,
@@ -68,7 +69,7 @@ export const MenuItemLink: FC<MenuItemLinkProps> = forwardRef(
     );
 
     return (
-      <li className={menuItemClassNames} role="presentation">
+      <li className={menuItemClassNames} role={listItemRole ?? 'presentation'}>
         <Link
           classNames={styles.menuLink}
           disabled={disabled}

--- a/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
+++ b/src/components/Menu/MenuItem/MenuItemSubHeader/MenuItemSubHeader.tsx
@@ -7,7 +7,7 @@ import styles from '../menuItem.module.scss';
 
 export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = forwardRef(
   (
-    { classNames, direction, size, text, wrap, ...rest },
+    { classNames, direction, listItemRole, size, text, wrap, ...rest },
     ref: React.ForwardedRef<HTMLSpanElement>
   ) => {
     const subHeaderClassNames: string = mergeClasses([
@@ -22,7 +22,7 @@ export const MenuItemSubHeader: FC<MenuItemSubHeaderProps> = forwardRef(
       classNames,
     ]);
     return (
-      <li className={subHeaderClassNames} role="presentation">
+      <li className={subHeaderClassNames} role={listItemRole ?? 'presentation'}>
         <span data-disabled {...rest} tabIndex={-1} ref={ref}>
           {text}
         </span>


### PR DESCRIPTION
## SUMMARY:
- `MenuItemLink` and `MenuItemSubHeader` hardcoded `role=\"presentation\"` on their `<li>` wrapper with no override.
- `MenuItemButton` already exposed `listItemRole`; this brings parity so consumers can pass an alternate role (e.g. `\"none\"`, or omit/replace the role) to satisfy a11y requirements without forking the component.
- Default behavior unchanged — when `listItemRole` is not supplied, both components still render `role=\"presentation\"`.

Refs: [ENG-167632](https://eightfoldai.atlassian.net/browse/ENG-167632) — Allyant a11y bug on Events page Create / More / filter dropdowns. The consumer-side change in the main vscode repo will follow, passing the new prop to drop the inappropriate `<li> role=\"presentation\"` on multi-select filter dropdowns.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-167632

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:


[ENG-167632]: https://eightfoldai.atlassian.net/browse/ENG-167632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ