### PR TITLE
Exclude sub header options from the Select results count announcement

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -4,6 +4,7 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
 import { SelectShape, SelectSize } from './Select.types';
 import { Select } from './';
+import { MenuItemType } from '../Menu';
 import { sleep } from '../../tests/Utilities';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -1008,6 +1009,110 @@ describe('Select', () => {
 
       await waitFor(() => {
         expect(getByRole('status').textContent).toBe(lastMessage);
+      });
+    });
+
+    describe('Grouped options with sub headers', () => {
+      const groupedOptions = [
+        { text: 'Group One', value: 'group-one', type: MenuItemType.subHeader },
+        { text: 'Apple', value: 'apple' },
+        { text: 'Banana', value: 'banana' },
+        { text: 'Group Two', value: 'group-two', type: MenuItemType.subHeader },
+        { text: 'Cherry', value: 'cherry' },
+      ];
+
+      // Keeps sub headers visible while filtering, mirroring grouped Select
+      // consumers that render persistent group labels.
+      const groupAwareFilterOption = (
+        option: { type?: MenuItemType; text?: string },
+        query: string
+      ): boolean => {
+        if (option.type === MenuItemType.subHeader) return true;
+        const q = (query || '').toLowerCase();
+        return !q || (option.text || '').toLowerCase().includes(q);
+      };
+
+      test('Excludes sub headers from announced count when dropdown opens', async () => {
+        const { getByPlaceholderText, getByRole } = render(
+          <Select
+            options={groupedOptions}
+            filterable
+            placeholder="Select test"
+          />
+        );
+        const input = getByPlaceholderText('Select test');
+        fireEvent.click(input);
+
+        await waitFor(() => {
+          expect(getByRole('status')).toHaveTextContent('3 matches found.');
+        });
+      });
+
+      test('Excludes visible sub headers from announced count while filtering', async () => {
+        const { getByPlaceholderText, getByRole, container } = render(
+          <Select
+            options={groupedOptions}
+            filterable
+            filterOption={groupAwareFilterOption}
+            placeholder="Select test"
+          />
+        );
+        const input = getByPlaceholderText('Select test');
+        fireEvent.click(input);
+
+        fireEvent.change(container.querySelector('.select-input'), {
+          target: { value: 'a' },
+        });
+
+        await waitFor(() => {
+          expect(getByRole('status')).toHaveTextContent('a,2 matches found.');
+        });
+      });
+
+      test('Announces singular count when one option matches alongside visible sub headers', async () => {
+        const { getByPlaceholderText, getByRole, container } = render(
+          <Select
+            options={groupedOptions}
+            filterable
+            filterOption={groupAwareFilterOption}
+            placeholder="Select test"
+          />
+        );
+        const input = getByPlaceholderText('Select test');
+        fireEvent.click(input);
+
+        fireEvent.change(container.querySelector('.select-input'), {
+          target: { value: 'banana' },
+        });
+
+        await waitFor(() => {
+          expect(getByRole('status')).toHaveTextContent(
+            'banana,1 match found.'
+          );
+        });
+      });
+
+      test('Announces no-results message when only sub headers remain visible', async () => {
+        const { getByPlaceholderText, getByRole, container } = render(
+          <Select
+            options={groupedOptions}
+            filterable
+            filterOption={groupAwareFilterOption}
+            placeholder="Select test"
+          />
+        );
+        const input = getByPlaceholderText('Select test');
+        fireEvent.click(input);
+
+        fireEvent.change(container.querySelector('.select-input'), {
+          target: { value: 'zzz' },
+        });
+
+        await waitFor(() => {
+          expect(getByRole('status')).toHaveTextContent(
+            'No match found for zzz'
+          );
+        });
       });
     });
   });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -22,7 +22,7 @@ import ThemeContext, {
   ThemeContextProvider,
 } from '../ConfigProvider/ThemeContext';
 import { Dropdown, DropdownRef, NO_ANIMATION_DURATION } from '../Dropdown';
-import { Menu } from '../Menu';
+import { Menu, MenuItemType } from '../Menu';
 import {
   TextInput,
   TextInputIconAlign,
@@ -344,8 +344,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
         return lastLiveRegionMessageRef.current;
       }
 
+      // Sub header options are presentational group labels (role="presentation"),
+      // not selectable results, so they must not be included in the announced count.
       const visibleOptionsCount: number = (options || []).filter(
-        (opt: SelectOption) => !opt.hideOption
+        (opt: SelectOption) =>
+          !opt.hideOption && opt.type !== MenuItemType.subHeader
       ).length;
 
       let message: string;


### PR DESCRIPTION
## SUMMARY:

The `Select` live region announced an inflated result count for grouped dropdowns because presentational sub header options (`role="presentation"`) were counted as selectable results. A grouped, filterable `Select` with 3 options under 2 group headers announced *"5 matches found."* to screen readers — and announced a false positive count when only headers remained visible after filtering.

- Exclude `MenuItemType.subHeader` options from the visible-options count used to build the live region message.
- No visual or DOM change — only the announced count is affected, and flat (ungrouped) `Select`s are completely unaffected (options without a `type` are counted exactly as before).
- Also corrects the no-results case: when a query leaves only group headers visible, the live region now correctly announces *"No match found for &lt;query&gt;"*.

**Note:** Fixes the issue shown in the video of the latest comment in the attached JIRA

## GITHUB ISSUE (Open Source Contributors)

N/A

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-167727

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

**Automated**

1. `yarn jest src/components/Select/Select.test.tsx` — all 63 Select tests pass, including the new `Live region announcements › Grouped options with sub headers` suite (4 cases: count on open, count while filtering, single-match, and headers-only no-match). Verified red→green: the 4 new tests fail against the unpatched component and pass with the fix.

**Manual (screen reader)**
Test groupID: demo@eightfolddemo-pasthana.com
 
1. Open the dropdown with VoiceOver / NVDA active.
2. Go to homepage -> Create position -> Duplicate from position -> Duplicate on any position -> Start typing, eg. 's'
3. Confirm the live region announces only the number of selectable options (e.g. *"3 matches found."*) and no longer counts the group headers.
4. Type a query that matches a subset of options; confirm the announced count reflects only matching options.
5. Type a query that matches nothing; confirm it announces *"No match found for &lt;query&gt;"* rather than a header-only count.