### PR TITLE
Improve Select combobox keyboard navigation and accessible names, and scope Panel Escape to open comboboxes

### DIFF
--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -96,7 +96,7 @@ export const Panel = React.forwardRef<PanelRef, PanelProps>(
       theme,
       themeContainerId,
       focusTrap = true,
-      escapeTargetSelector = '[role="listbox"], [role="menu"], [role="tooltip"], .dropdown-wrapper, .tooltip-wrapper',
+      escapeTargetSelector = '[role="listbox"], [role="menu"], [role="tooltip"], [role="combobox"][aria-expanded="true"], .dropdown-wrapper, .tooltip-wrapper',
       ...rest
     } = props;
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -685,6 +685,67 @@ describe('Select', () => {
     );
   });
 
+  test('Clear button has an accessible name', () => {
+    const { container } = render(
+      <Select
+        defaultValue="option2"
+        options={options}
+        clearable
+        placeholder="Select test"
+      />
+    );
+    const clearButton = container.querySelector('.clear-icon-button');
+    expect(clearButton).toBeTruthy();
+    expect(clearButton.getAttribute('aria-label')).toBe('Clear selection');
+  });
+
+  test('Clear button uses the provided clearButtonAriaLabel', () => {
+    const { container } = render(
+      <Select
+        defaultValue="option2"
+        options={options}
+        clearable
+        clearButtonAriaLabel="Clear priority"
+        placeholder="Select test"
+      />
+    );
+    expect(
+      container.querySelector('.clear-icon-button').getAttribute('aria-label')
+    ).toBe('Clear priority');
+  });
+
+  test('Clears aria-activedescendant after selecting and closing', async () => {
+    // Closed dropdown unmounts its options; the attribute must not point at a gone option.
+    const { getByPlaceholderText, getByText } = render(
+      <Select options={options} placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    fireEvent.click(select);
+    const option1 = await waitFor(() => getByText('Option 1'));
+    fireEvent.click(option1);
+    await waitFor(() =>
+      expect((select as HTMLInputElement).value).toBe('Option 1')
+    );
+    await waitFor(() =>
+      expect(select.getAttribute('aria-activedescendant')).toBeFalsy()
+    );
+  });
+
+  test('Does not set aria-activedescendant from an option focus while closed', () => {
+    // A closed Select must ignore option focusin (e.g. from another Select's listbox).
+    const { getByPlaceholderText } = render(
+      <Select options={options} placeholder="Select test" />
+    );
+    const select = getByPlaceholderText('Select test');
+    const foreignOption = document.createElement('button');
+    foreignOption.id = 'list--option-0';
+    foreignOption.setAttribute('role', 'option');
+    document.body.appendChild(foreignOption);
+    fireEvent.focusIn(foreignOption);
+    expect(select.getAttribute('aria-activedescendant')).toBeFalsy();
+    foreignOption.remove();
+  });
+
   test('Does not focus the first focusable element when dropdown is visible and not filterable and initialFocus is false', async () => {
     const { getAllByRole, getByPlaceholderText } = render(
       <Select

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -166,7 +166,7 @@ describe('Select', () => {
         {
           'data-testid': 'option1-test-id',
           hideOption: false,
-          id: 'Option 1-0',
+          id: 'list--option-0',
           object: undefined,
           role: 'option',
           selected: true,
@@ -199,7 +199,7 @@ describe('Select', () => {
         {
           'data-testid': 'option1-test-id',
           hideOption: false,
-          id: 'Option 1-0',
+          id: 'list--option-0',
           object: undefined,
           role: 'option',
           selected: true,
@@ -209,7 +209,7 @@ describe('Select', () => {
         {
           'data-testid': 'option2-test-id',
           hideOption: false,
-          id: 'Option 2-1',
+          id: 'list--option-1',
           object: undefined,
           role: 'option',
           selected: true,
@@ -263,7 +263,7 @@ describe('Select', () => {
         {
           'data-testid': 'option2-test-id',
           hideOption: false,
-          id: 'Option 2-1',
+          id: 'list--option-1',
           object: undefined,
           role: 'option',
           selected: true,
@@ -278,7 +278,7 @@ describe('Select', () => {
         {
           'data-testid': 'option1-test-id',
           hideOption: false,
-          id: 'Option 1-0',
+          id: 'list--option-0',
           object: undefined,
           role: 'option',
           selected: true,
@@ -323,7 +323,7 @@ describe('Select', () => {
         {
           'data-testid': 'option1-test-id',
           hideOption: false,
-          id: 'Option 1-0',
+          id: 'list--option-0',
           object: undefined,
           role: 'option',
           selected: true,
@@ -333,7 +333,7 @@ describe('Select', () => {
         {
           'data-testid': 'option2-test-id',
           hideOption: false,
-          id: 'Option 2-1',
+          id: 'list--option-1',
           object: undefined,
           role: 'option',
           selected: true,
@@ -343,7 +343,7 @@ describe('Select', () => {
         {
           'data-testid': 'option3-test-id',
           hideOption: false,
-          id: 'Option 3-2',
+          id: 'list--option-2',
           object: undefined,
           role: 'option',
           selected: true,
@@ -387,7 +387,7 @@ describe('Select', () => {
         {
           'data-testid': 'option2-test-id',
           hideOption: false,
-          id: 'Option 2-1',
+          id: 'list--option-1',
           object: undefined,
           role: 'option',
           selected: true,
@@ -681,7 +681,7 @@ describe('Select', () => {
     fireEvent.keyDown(select, { key: 'ArrowDown' });
 
     await waitFor(() =>
-      expect(select.getAttribute('aria-activedescendant')).toBe('Option 1-0')
+      expect(select.getAttribute('aria-activedescendant')).toBe('list--option-0')
     );
   });
 
@@ -890,7 +890,7 @@ describe('Select', () => {
     fireEvent.click(option1);
 
     await waitFor(() => {
-      const pill = container.querySelector('#selectPillOption\\ 1-0');
+      const pill = container.querySelector('#selectPilllist--option-0');
       expect(pill).toBeTruthy();
     });
 
@@ -916,7 +916,7 @@ describe('Select', () => {
     fireEvent.click(option2);
 
     await waitFor(() => {
-      const pill2 = container.querySelector('#selectPillOption\\ 2-1');
+      const pill2 = container.querySelector('#selectPilllist--option-1');
       expect(pill2).toBeTruthy();
     });
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -70,6 +70,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       classNames,
       clear = false,
       clearable = false,
+      clearButtonAriaLabel = 'Clear selection',
       configContextProps = {
         noDisabledContext: false,
         noShapeContext: false,
@@ -900,6 +901,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       alignIcon: TextInputIconAlign.Right,
       clearable: clearable && !readonly,
       clearButtonClassNames: clearButtonClassNames,
+      clearButtonAriaLabel,
       inputWidth: inputWidth,
       iconButtonProps: !readonly
         ? {
@@ -975,13 +977,18 @@ export const Select: FC<SelectProps> = React.forwardRef(
       const selected = (options || []).find(
         (opt: SelectOption) => opt.selected && !opt.hideOption
       );
-      if (selected?.id) {
+      if (dropdownVisible && selected?.id) {
         input?.setAttribute('aria-activedescendant', selected.id);
       }
 
       const handleFocusIn = (event: FocusEvent): void => {
         const target = event.target as HTMLElement;
-        if (target?.id && target.getAttribute('role') === 'option') {
+        // Only this Select's own options.
+        if (
+          dropdownVisible &&
+          target?.id?.startsWith(`${selectMenuId.current}-option-`) &&
+          target.getAttribute('role') === 'option'
+        ) {
           input?.setAttribute('aria-activedescendant', target.id);
         }
       };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -151,7 +151,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       (_options || []).map((option: SelectOption, index: number) => ({
         selected: false,
         hideOption: false,
-        id: option.text + '-' + index,
+        id: `${selectMenuId.current}-option-${index}`,
         object: option.object,
         role: 'option',
         'aria-selected': option.selected,
@@ -218,7 +218,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
         (_options || []).map((option: SelectOption, index: number) => ({
           selected: !!selected.find((opt) => opt.value === option.value),
           hideOption: false,
-          id: option.text + '-' + index,
+          id: `${selectMenuId.current}-option-${index}`,
           object: option.object,
           role: 'option',
           'aria-selected': option.selected,
@@ -238,7 +238,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
             !!selected.find((opt) => opt.value === option.value) ||
             option.value === defaultValue,
           hideOption: false,
-          id: option.text + '-' + index,
+          id: `${selectMenuId.current}-option-${index}`,
           object: option.object,
           role: 'option',
           'aria-selected': option.selected,
@@ -869,13 +869,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
         setDropdownVisibility(true);
       }
 
-      // Arrow Down: For filterable selects, move focus into dropdown options
-      // Non-filterable selects are handled by Dropdown component natively
+      // Arrow Down: when the dropdown is open, move focus into its options.
+      // Applies to both filterable and non-filterable selects.
       if (
-        filterable &&
         event?.key === eventKeys.ARROWDOWN &&
-        document.activeElement === event.target
+        document.activeElement === event.target &&
+        dropdownVisible
       ) {
+        event.preventDefault();
         dropdownRef.current?.focusFirstElement?.();
       }
 
@@ -1081,7 +1082,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
                   shape={selectShapeToTextInputShapeMap.get(mergedShape)}
                   size={selectSizeToTextInputSizeMap.get(mergedSize)}
                   value={selectedOptionText}
-                  ariaLabel={ariaLabel}
+                  ariaLabel={ariaLabel ?? selectInputProps?.ariaLabel}
                 />
               </div>
             </Dropdown>

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -91,6 +91,11 @@ export interface SelectProps
    */
   clearable?: boolean;
   /**
+   * The Select clear value button aria label.
+   * @default 'Clear selection'
+   */
+  clearButtonAriaLabel?: string;
+  /**
    * Configure how contextual props are consumed.
    */
   configContextProps?: ConfigContextProps;

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -416,7 +416,7 @@ exports[`Select Renders with default values when multiple 1`] = `
     >
       <div
         class="tag-pills multi-select-pill blue-green medium"
-        id="selectPillOption 2-1"
+        id="selectPilllist--option-1"
         style="visibility: hidden;"
         tabindex="-1"
       >
@@ -448,7 +448,7 @@ exports[`Select Renders with default values when multiple 1`] = `
       </div>
       <div
         class="tag-pills multi-select-pill blue-green medium"
-        id="selectPillOption 3-2"
+        id="selectPilllist--option-2"
         style="visibility: hidden;"
         tabindex="-1"
       >


### PR DESCRIPTION
## SUMMARY:

Accessibility fixes for the shared `Select` (combobox) and `Panel` components, aligning them with the WAI-ARIA APG Combobox and Dialog patterns. These are product-wide and affect every Octuple `Select`/`Panel` consumer. The work was driven by an accessibility audit of the "All Filters" panel on the Duplicate Position intake form, and pairs with the consumer-side change in EightfoldAI/vscode#108828.

**`src/components/Select/Select.tsx`**

- **Keyboard navigation into options (both filterable and non-filterable).** In `handleInputKeyDown`, `ArrowDown` now moves keyboard focus from the combobox input into the dropdown's option list for *both* filterable (list-autocomplete) and select-only comboboxes. Previously the `filterable &&` guard meant only filterable selects could enter their options by keyboard; plain dropdowns trapped focus on the input. The behavior is now gated on the dropdown being open (`dropdownVisible`) and calls `event.preventDefault()` so the page does not also scroll.
- **Accessible name preserved.** The input's `ariaLabel` now falls back to `selectInputProps?.ariaLabel` (`ariaLabel ?? selectInputProps?.ariaLabel`) instead of being clobbered to `undefined`. A combobox name supplied via `textInputProps` is now kept and announced.
- **Valid, unique option ids.** Each option `id` is now derived from the menu id plus the option index (`${selectMenuId.current}-option-${index}`) instead of `option.text + '-' + index`. The previous scheme produced invalid and/or duplicate `aria-activedescendant` IDREFs (e.g. when option text contained spaces or repeated across options); the ids are now stable and unique.
- **Active-descendant lifecycle.** `aria-activedescendant` is cleared when the listbox closes (it would otherwise dangle, pointing at an option that has unmounted) and is scoped to this Select's own options, so navigating one combobox no longer stamps another Select's input.
- **Clear button accessible name.** New optional `clearButtonAriaLabel` prop (default `'Clear selection'`) gives the clearable button an accessible name.

**`src/components/Panel/Panel.tsx`**

- **Scoped, escalating Escape.** The default `escapeTargetSelector` denylist now includes `[role="combobox"][aria-expanded="true"]`. The Panel's global Escape handler does not close the panel when the Escape target matches this denylist. Scoping the combobox token to `aria-expanded="true"` produces an "escalating Escape": pressing Escape while a combobox's listbox is **open** closes only the listbox (the panel stays open); a second Escape (combobox now collapsed, so it no longer matches the denylist) closes the panel. Previously, Escape on a combobox input closed the entire panel in one keystroke.

**Tests & snapshot**

- Updated `Select.test.tsx` option-id assertions (selection, `onOptionsChange`, `aria-activedescendant`, and pill tests) to the new menu-scoped id scheme.
- Regenerated the `Select` snapshot for the new ids; no `Panel` snapshot change.
- Added tests for the clear-button accessible name and for `aria-activedescendant` being cleared on close and scoped per-Select.

These changes are standards-aligned with the WAI-ARIA APG Combobox and Dialog patterns; the only API addition is the optional, backward-compatible `clearButtonAriaLabel` prop.

## GITHUB ISSUE (Open Source Contributors)

N/A — internal Eightfold accessibility work (see JIRA below).

## JIRA TASK (Eightfold Employees Only):

https://eightfoldai.atlassian.net/browse/ENG-167719

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist

> The `Select` assertions and snapshot are updated in this PR for the new option ids (see “Tests & snapshot” above) — no reviewer action needed to regenerate snapshots.

## TEST PLAN:

Combobox keyboard navigation (`Select`):

- Open a **non-filterable** (select-only) `Select`, then press `ArrowDown` from the input → focus moves into the option list and the first option becomes active; the page does not scroll.
- Open a **filterable** `Select` and confirm `ArrowDown` still moves focus into the options (no regression).
- With the dropdown **closed**, `ArrowDown` does not jump focus into a hidden list.

Accessible name (`Select`):

- Provide a combobox name via `textInputProps.ariaLabel` and confirm the combobox input is announced with that name (no longer `undefined`).

Option ids / active-descendant (`Select`):

- Inspect rendered options and confirm each option `id` is unique and valid, and that `aria-activedescendant` on the input points at the active option's id while navigating with the keyboard. Verify with options whose text contains spaces and/or duplicate text across options.

Escalating Escape (`Panel`):

- Inside a `Panel`, open a combobox's listbox and press `Escape` → only the listbox closes; the panel stays open. Press `Escape` again (combobox now collapsed) → the panel closes.
- Confirm `Escape` still closes the panel directly when focus is not on an expanded combobox (no regression to the existing `listbox`/`menu`/`tooltip`/dropdown/tooltip-wrapper behavior).

Cross-repo: validate end-to-end on the "All Filters" panel of the Duplicate Position intake form via EightfoldAI/vscode#108828.




