### PR TITLE
feat(Dropdown): add disableAutoFlip & disableReferenceTrackingOnScroll as Props

### DIFF
--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -256,7 +256,7 @@ const ComplexDropdownWithoutAriaHaspopupComponent = (): JSX.Element => {
   return (
     <Dropdown {...dropdownProps} ariaRef={buttonRef} ariaHaspopupValue={null}>
       <div>
-          <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
+        <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
       </div>
     </Dropdown>
   );

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -256,11 +256,7 @@ const ComplexDropdownWithoutAriaHaspopupComponent = (): JSX.Element => {
   return (
     <Dropdown {...dropdownProps} ariaRef={buttonRef} ariaHaspopupValue={null}>
       <div>
-        <Button
-          ref={buttonRef}
-          data-testid="test-button-id"
-          text="Test button"
-        />
+                <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
       </div>
     </Dropdown>
   );

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -269,11 +269,7 @@ const ComplexDropdownWithCustomAriaHaspopupComponent = (): JSX.Element => {
   return (
     <Dropdown {...dropdownProps} ariaRef={buttonRef} ariaHaspopupValue="dialog">
       <div>
-        <Button
-          ref={buttonRef}
-          data-testid="test-button-id"
-          text="Test button"
-        />
+        <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
       </div>
     </Dropdown>
   );

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -256,7 +256,11 @@ const ComplexDropdownWithoutAriaHaspopupComponent = (): JSX.Element => {
   return (
     <Dropdown {...dropdownProps} ariaRef={buttonRef} ariaHaspopupValue={null}>
       <div>
-        <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
+        <Button
+          ref={buttonRef}
+          data-testid="test-button-id"
+          text="Test button"
+        />
       </div>
     </Dropdown>
   );
@@ -269,7 +273,11 @@ const ComplexDropdownWithCustomAriaHaspopupComponent = (): JSX.Element => {
   return (
     <Dropdown {...dropdownProps} ariaRef={buttonRef} ariaHaspopupValue="dialog">
       <div>
-        <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
+        <Button
+          ref={buttonRef}
+          data-testid="test-button-id"
+          text="Test button"
+        />
       </div>
     </Dropdown>
   );
@@ -973,5 +981,35 @@ describe('Dropdown', () => {
     const referenceElement = getByTestId('test-button-id');
 
     expect(referenceElement.getAttribute('aria-haspopup')).toBe('dialog');
+  });
+
+  test('Should open normally with disableAutoFlip set', async () => {
+    const { container, getByTestId } = render(
+      <Dropdown {...dropdownProps} disableAutoFlip>
+        <Button data-testid="dropdown-reference" text="Dropdown menu test" />
+      </Dropdown>
+    );
+    const referenceElement = getByTestId('dropdown-reference');
+    act(() => {
+      userEvent.click(referenceElement);
+    });
+    await waitFor(() => screen.getByText('User profile 1'));
+    expect(referenceElement.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('.dropdown-wrapper')).toBeTruthy();
+  });
+
+  test('Should open normally with disableReferenceTrackingOnScroll set', async () => {
+    const { container, getByTestId } = render(
+      <Dropdown {...dropdownProps} disableReferenceTrackingOnScroll>
+        <Button data-testid="dropdown-reference" text="Dropdown menu test" />
+      </Dropdown>
+    );
+    const referenceElement = getByTestId('dropdown-reference');
+    act(() => {
+      userEvent.click(referenceElement);
+    });
+    await waitFor(() => screen.getByText('User profile 1'));
+    expect(referenceElement.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('.dropdown-wrapper')).toBeTruthy();
   });
 });

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -256,7 +256,7 @@ const ComplexDropdownWithoutAriaHaspopupComponent = (): JSX.Element => {
   return (
     <Dropdown {...dropdownProps} ariaRef={buttonRef} ariaHaspopupValue={null}>
       <div>
-                <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
+          <Button ref={buttonRef} data-testid="test-button-id" text="Test button" />
       </div>
     </Dropdown>
   );

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -480,11 +480,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           const currentRole = ariaRef.current.getAttribute('role');
           const currentAriaHaspopup =
             ariaRef.current.getAttribute('aria-haspopup');
-          if (
-            currentRole !== 'combobox' &&
-            !currentAriaHaspopup &&
-            ariaHaspopupValue
-          ) {
+          if (currentRole !== 'combobox' && !currentAriaHaspopup && ariaHaspopupValue) {
             ariaRef.current.setAttribute('aria-haspopup', ariaHaspopupValue);
           }
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -82,6 +82,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         overlayTabIndex = -1,
         overlayProps,
         toggleDropdownOnShiftTab = false,
+        disableAutoFlip = false,
       },
       ref: React.ForwardedRef<DropdownRef>
     ) => {
@@ -105,7 +106,11 @@ export const Dropdown: FC<DropdownProps> = React.memo(
       const { x, y, strategy, update, refs, context } = useFloating({
         placement,
         strategy: positionStrategy,
-        middleware: [fOffset(offset), flip(), shift()],
+        middleware: [
+          fOffset(offset),
+          ...(disableAutoFlip ? [] : [flip()]),
+          shift(),
+        ],
       });
 
       const intervalRef: React.MutableRefObject<NodeJS.Timer> =
@@ -475,7 +480,11 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           const currentRole = ariaRef.current.getAttribute('role');
           const currentAriaHaspopup =
             ariaRef.current.getAttribute('aria-haspopup');
-          if (currentRole !== 'combobox' && !currentAriaHaspopup && ariaHaspopupValue) {
+          if (
+            currentRole !== 'combobox' &&
+            !currentAriaHaspopup &&
+            ariaHaspopupValue
+          ) {
             ariaRef.current.setAttribute('aria-haspopup', ariaHaspopupValue);
           }
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -498,11 +498,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           const currentRole = ariaRef.current.getAttribute('role');
           const currentAriaHaspopup =
             ariaRef.current.getAttribute('aria-haspopup');
-          if (
-            currentRole !== 'combobox' &&
-            !currentAriaHaspopup &&
-            ariaHaspopupValue
-          ) {
+          if (currentRole !== 'combobox' && !currentAriaHaspopup && ariaHaspopupValue) {
             ariaRef.current.setAttribute('aria-haspopup', ariaHaspopupValue);
           }
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -83,6 +83,7 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         overlayProps,
         toggleDropdownOnShiftTab = false,
         disableAutoFlip = false,
+        disableReferenceTrackingOnScroll = false,
       },
       ref: React.ForwardedRef<DropdownRef>
     ) => {
@@ -245,17 +246,34 @@ export const Dropdown: FC<DropdownProps> = React.memo(
         return autoUpdate(
           refs.reference.current,
           refs.floating.current,
-          update
+          update,
+          { ancestorScroll: !disableReferenceTrackingOnScroll }
         );
-      }, [refs.reference, refs.floating, update]);
+      }, [
+        disableReferenceTrackingOnScroll,
+        refs.reference,
+        refs.floating,
+        update,
+      ]);
 
       // Add a new useEffect to update position when overlay content changes
       useEffect(() => {
-        if (mergedVisible && refs.floating.current) {
-          // Update the position when the overlay content changes
-          update();
+        if (
+          disableReferenceTrackingOnScroll ||
+          !mergedVisible ||
+          !refs.floating.current
+        ) {
+          return;
         }
-      }, [overlay, mergedVisible, update, refs.floating]);
+        // Update the position when the overlay content changes
+        update();
+      }, [
+        disableReferenceTrackingOnScroll,
+        overlay,
+        mergedVisible,
+        update,
+        refs.floating,
+      ]);
 
       const dropdownClasses: string = mergeClasses([
         dropdownClassNames,
@@ -480,7 +498,11 @@ export const Dropdown: FC<DropdownProps> = React.memo(
           const currentRole = ariaRef.current.getAttribute('role');
           const currentAriaHaspopup =
             ariaRef.current.getAttribute('aria-haspopup');
-          if (currentRole !== 'combobox' && !currentAriaHaspopup && ariaHaspopupValue) {
+          if (
+            currentRole !== 'combobox' &&
+            !currentAriaHaspopup &&
+            ariaHaspopupValue
+          ) {
             ariaRef.current.setAttribute('aria-haspopup', ariaHaspopupValue);
           }
 

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -192,6 +192,14 @@ export interface DropdownProps {
    * The props of the overlay
    */
   overlayProps?: React.HTMLAttributes<HTMLDivElement>;
+
+  /**
+   * When true, the dropdown will not auto-flip to the opposite side when the
+   * preferred placement overflows. Use to keep a fixed placement (e.g. anchored
+   * below a trigger toward a scrollable region).
+   * @default false
+   */
+  disableAutoFlip?: boolean;
 }
 
 export type DropdownRef = {

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -197,6 +197,11 @@ export interface DropdownProps {
    * When true, the dropdown will not auto-flip to the opposite side when the
    * preferred placement overflows. Use to keep a fixed placement (e.g. anchored
    * below a trigger toward a scrollable region).
+   *
+   * CAUTION - this suppresses dropdown's auto-flip if the space on
+   * the configured side is less than the dropdown-overlay height.
+   * If the side fixed doesn't have a scrollable region, then the dropdown overlay is stuck.
+   *
    * @default false
    */
   disableAutoFlip?: boolean;
@@ -207,6 +212,9 @@ export interface DropdownProps {
    * open — it stays where it opened. Element resize and layout-shift tracking via
    * autoUpdate are unaffected. Use alongside disableAutoFlip when the reference is
    * inside a container that scrolls out from under a fixed-placement dropdown.
+   *
+   * CAUTION: this also suppresses the reposition that would otherwise run when the
+   * overlay's own rendered content changes size while open.
    * @default false
    */
   disableReferenceTrackingOnScroll?: boolean;

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -201,7 +201,6 @@ export interface DropdownProps {
    * CAUTION - this suppresses dropdown's auto-flip if the space on
    * the configured side is less than the dropdown-overlay height.
    * If the side fixed doesn't have a scrollable region, then the dropdown overlay is stuck.
-   *
    * @default false
    */
   disableAutoFlip?: boolean;

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -200,6 +200,16 @@ export interface DropdownProps {
    * @default false
    */
   disableAutoFlip?: boolean;
+
+  /**
+   * When true, the dropdown does not reposition when an ancestor of the reference
+   * or floating element scrolls, or when the overlay content changes size while
+   * open — it stays where it opened. Element resize and layout-shift tracking via
+   * autoUpdate are unaffected. Use alongside disableAutoFlip when the reference is
+   * inside a container that scrolls out from under a fixed-placement dropdown.
+   * @default false
+   */
+  disableReferenceTrackingOnScroll?: boolean;
 }
 
 export type DropdownRef = {


### PR DESCRIPTION
## SUMMARY:

PR adds a default-off prop `disableAutoFlip` to disable auto-flipping of dropdown component. 
Observed - dropdown height exceed visible screen length and clips to the top leading to responsiveness issues.
Disabling auto-flip let's the dropdown use the overflow in placement direction - `bottom-*` and prevent clipping in screen with smaller heights

Also disabled reference-tracking (auto) on scroll via an optional prop.

Two props introduced - 
1. disableAutoFlip
2. disableReferenceTrackingOnScroll

Both default to False to preserve the existing behaviour on all components not using the props

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-198354

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [x] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

Optional prop with default as False.
Verified usage via oc-sync in `vscode`


<img width="781" height="550" alt="Screenshot 2026-07-02 at 9 40 50 PM" src="https://github.com/user-attachments/assets/fc224c0e-728e-4195-b72d-a1aba66db937" />


Screen-Recording for usage in vscode - 



https://github.com/user-attachments/assets/ae0a9008-f3fa-46d4-b6c3-d7a3de90a80d






