### PR TITLE
[Select] Update menu item structure + handle keyboard navigation a11y

### DIFF
--- a/src/components/Menu/MenuItem/MenuItem.types.ts
+++ b/src/components/Menu/MenuItem/MenuItem.types.ts
@@ -125,6 +125,15 @@ export interface MenuItemButtonProps
    * Role for the list item (li) element
    */
   listItemRole?: string;
+  /**
+   * When true, render the option as a single `<li role="option">` that carries
+   * the option's identity attributes (`id`, `role`, `aria-selected`) directly.
+   * The inner `<button>` is removed and its content moves into a presentational
+   * `<span>`, so DOM focus can stay on the combobox input. Used by Select's
+   * `aria-activedescendant` a11y pattern (`improvedA11y`).
+   * @default false
+   */
+  renderAsListItem?: boolean;
 }
 
 export interface MenuItemLinkProps

--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -38,6 +38,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
       wrap = false,
       menuRenderer,
       listItemRole,
+      renderAsListItem = false,
       ...rest
     },
     ref: React.ForwardedRef<HTMLButtonElement>
@@ -53,7 +54,8 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
         [styles.neutral]: variant === MenuVariant.neutral,
         [styles.primary]: variant === MenuVariant.primary,
         [styles.disruptive]: variant === MenuVariant.disruptive,
-        [styles.active]: active,
+        [styles.active]: active && !renderAsListItem,
+        [styles.activeDescendant]: active && renderAsListItem,
         [styles.disabled]: disabled,
       },
       classNames,
@@ -68,9 +70,7 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
       },
     ]);
 
-    const handleOnClick = (
-      event: React.MouseEvent<HTMLButtonElement | MouseEvent>
-    ): void => {
+    const handleOnClick = (event: React.MouseEvent<HTMLElement>): void => {
       if (disabled) {
         event.preventDefault();
         return;
@@ -175,6 +175,33 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
 
       return dropdownMenuItems ? dropdownMenuButton() : menuButton();
     };
+
+    if (renderAsListItem) {
+      const { id: optionId, 'aria-selected': optionAriaSelected } = rest;
+      return (
+        <li
+          className={menuItemClassNames}
+          role={role}
+          id={optionId}
+          aria-selected={optionAriaSelected}
+          onClick={handleOnClick}
+        >
+          <span className={styles.menuItemButton}>
+            {iconProps && alignIcon === MenuItemIconAlign.Left && getIcon()}
+            <span className={styles.menuItemWrapper}>
+              <span className={styles.itemText}>
+                <span className={styles.label}>{text}</span>
+                {counter && <span>{counter}</span>}
+              </span>
+              {subText && (
+                <span className={itemSubTextClassNames}>{subText}</span>
+              )}
+            </span>
+            {iconProps && alignIcon === MenuItemIconAlign.Right && getIcon()}
+          </span>
+        </li>
+      );
+    }
 
     return (
       <li className={menuItemClassNames} role={listItemRole ?? 'presentation'}>

--- a/src/components/Menu/MenuItem/MenuItemButton/__tests__/MenuItemButton.test.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/__tests__/MenuItemButton.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MenuItemButton } from '../MenuItemButton';
 import { MenuVariant } from '../../../Menu.types';
@@ -17,5 +17,119 @@ describe('MenuItemButton', () => {
 
     const button = getByRole('menuitem');
     expect(button).toBeInTheDocument();
+  });
+
+  describe('renderAsListItem (Select aria-activedescendant pattern)', () => {
+    test('renders the option as an <li> carrying id/role/aria-selected, with no inner button', () => {
+      const { container, getByRole } = render(
+        <MenuItemButton
+          text="Apple"
+          role="option"
+          id="apple-0"
+          aria-selected
+          renderAsListItem
+          variant={MenuVariant.neutral}
+        />
+      );
+
+      const option = getByRole('option');
+      expect(option.tagName).toBe('LI');
+      expect(option).toHaveAttribute('id', 'apple-0');
+      expect(option).toHaveAttribute('aria-selected', 'true');
+      // The inner <button> is removed in this mode; content sits in a span.
+      expect(container.querySelector('button')).toBeNull();
+    });
+
+    test('highlights the active option with the active-descendant class, not the active fill', () => {
+      const { getByRole } = render(
+        <MenuItemButton
+          text="Apple"
+          role="option"
+          id="apple-0"
+          active
+          renderAsListItem
+          variant={MenuVariant.neutral}
+        />
+      );
+
+      const option = getByRole('option');
+      expect(option).toHaveClass('active-descendant');
+      expect(option).not.toHaveClass('active');
+    });
+
+    test('applies neither active nor active-descendant when not highlighted', () => {
+      const { getByRole } = render(
+        <MenuItemButton
+          text="Apple"
+          role="option"
+          id="apple-0"
+          renderAsListItem
+          variant={MenuVariant.neutral}
+        />
+      );
+
+      const option = getByRole('option');
+      expect(option).not.toHaveClass('active');
+      expect(option).not.toHaveClass('active-descendant');
+    });
+
+    test('fires onClick with the option value when the list item is clicked', () => {
+      const onClick = jest.fn();
+      const { getByRole } = render(
+        <MenuItemButton
+          text="Apple"
+          role="option"
+          id="apple-0"
+          value="apple"
+          renderAsListItem
+          onClick={onClick}
+          variant={MenuVariant.neutral}
+        />
+      );
+
+      fireEvent.click(getByRole('option'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledWith('apple', expect.anything());
+    });
+
+    test('does not fire onClick when the option is disabled', () => {
+      const onClick = jest.fn();
+      const { getByRole } = render(
+        <MenuItemButton
+          text="Apple"
+          role="option"
+          id="apple-0"
+          value="apple"
+          disabled
+          renderAsListItem
+          onClick={onClick}
+          variant={MenuVariant.neutral}
+        />
+      );
+
+      fireEvent.click(getByRole('option'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    test('falls back to the legacy button option (with active fill) when renderAsListItem is false', () => {
+      const { container } = render(
+        <MenuItemButton
+          text="Apple"
+          role="option"
+          active
+          variant={MenuVariant.neutral}
+        />
+      );
+
+      // Legacy DOM: a focusable <button> wrapped in a presentational <li>.
+      const button = container.querySelector('button');
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('role', 'option');
+
+      const listItem = container.querySelector('li');
+      expect(listItem).toHaveAttribute('role', 'presentation');
+      expect(listItem).toHaveClass('active');
+      expect(listItem).not.toHaveClass('active-descendant');
+    });
   });
 });

--- a/src/components/Menu/MenuItem/MenuItemButton/__tests__/MenuItemButton.test.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/__tests__/MenuItemButton.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MenuItemButton } from '../MenuItemButton';
 import { MenuVariant } from '../../../Menu.types';
+import { MenuItemIconAlign } from '../../MenuItem.types';
+import { IconName } from '../../../../Icon';
 
 describe('MenuItemButton', () => {
   test('should render regular menuButton when dropdownMenuItems exist but menuRenderer is not provided', () => {
@@ -130,6 +132,38 @@ describe('MenuItemButton', () => {
       expect(listItem).toHaveAttribute('role', 'presentation');
       expect(listItem).toHaveClass('active');
       expect(listItem).not.toHaveClass('active-descendant');
+    });
+
+    test('renders icon (left and right), counter and subText inside the list item', () => {
+      const { getByText, rerender } = render(
+        <MenuItemButton
+          text="Apple"
+          subText="A fruit"
+          counter="3"
+          role="option"
+          id="apple-0"
+          iconProps={{ path: IconName.mdiAccount }}
+          renderAsListItem
+          variant={MenuVariant.neutral}
+        />
+      );
+      expect(getByText('Apple')).toBeInTheDocument();
+      expect(getByText('A fruit')).toBeInTheDocument();
+      expect(getByText('3')).toBeInTheDocument();
+
+      // Right-aligned icon path renders without error.
+      rerender(
+        <MenuItemButton
+          text="Apple"
+          role="option"
+          id="apple-0"
+          alignIcon={MenuItemIconAlign.Right}
+          iconProps={{ path: IconName.mdiAccount }}
+          renderAsListItem
+          variant={MenuVariant.neutral}
+        />
+      );
+      expect(getByText('Apple')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Menu/MenuItem/menuItem.module.scss
+++ b/src/components/Menu/MenuItem/menuItem.module.scss
@@ -161,6 +161,11 @@
     }
   }
 
+  &.active-descendant {
+    box-shadow: var(--focus-visible-box-shadow);
+    @include focus-visible-forced-colors();
+  }
+
   &.disabled {
     cursor: not-allowed;
     opacity: $disabled-alpha-value;

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1178,3 +1178,166 @@ describe('Select', () => {
     });
   });
 });
+
+describe('Select improvedA11y', () => {
+  let matchMediaAd: any;
+
+  beforeAll(() => {
+    matchMediaAd = new MatchMediaMock();
+  });
+
+  afterEach(() => {
+    matchMediaAd.clear();
+  });
+
+  const adOptions = [
+    { text: 'Apple', value: 'apple' },
+    { text: 'Banana', value: 'banana' },
+    { text: 'Cherry', value: 'cherry' },
+  ];
+
+  test('moves id/role/aria-selected onto the <li> and drops the inner button', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit');
+    fireEvent.click(input);
+    const optionEls = await waitFor(() => getAllByRole('option'));
+    expect(optionEls).toHaveLength(adOptions.length);
+    optionEls.forEach((el: HTMLElement) => {
+      // The list item itself is the option; the inner button is removed.
+      expect(el.tagName).toBe('LI');
+      expect(el.hasAttribute('id')).toBe(true);
+      expect(el.hasAttribute('aria-selected')).toBe(true);
+      expect(el.querySelector('button')).toBeNull();
+    });
+  });
+
+  test('keeps focus on the input and moves aria-activedescendant on ArrowDown/ArrowUp', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    const optionEls = await waitFor(() => getAllByRole('option'));
+    const [first, second] = optionEls;
+
+    // Opening highlights the first option.
+    await waitFor(() =>
+      expect(input.getAttribute('aria-activedescendant')).toBe(first.id)
+    );
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() =>
+      expect(input.getAttribute('aria-activedescendant')).toBe(second.id)
+    );
+    // Focus never moved into the listbox.
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    await waitFor(() =>
+      expect(input.getAttribute('aria-activedescendant')).toBe(first.id)
+    );
+    expect(document.activeElement).toBe(input);
+  });
+
+  test('selects the highlighted option on Enter', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // move to second option
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(input.value).toBe('Banana'));
+  });
+
+  test('clears aria-activedescendant when the dropdown closes', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+    await waitFor(() =>
+      expect(input.getAttribute('aria-activedescendant')).toBeTruthy()
+    );
+
+    // Selecting a single value closes the dropdown.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() =>
+      expect(input.getAttribute('aria-activedescendant')).toBeFalsy()
+    );
+  });
+
+  test('still renders a focusable button option when the flag is off', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select filterable options={adOptions} placeholder="Fruit" />
+    );
+    const input = getByPlaceholderText('Fruit');
+    fireEvent.click(input);
+    const optionEls = await waitFor(() => getAllByRole('option'));
+    // Legacy behavior: role="option" lives on an inner <button>.
+    expect(optionEls[0].tagName).toBe('BUTTON');
+  });
+
+  test('highlights the active option with the focus border, not a fill', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+
+    // On open the first option shows the focus border, not a background fill.
+    await waitFor(() =>
+      expect(
+        getAllByRole('option')[0].classList.contains('active-descendant')
+      ).toBe(true)
+    );
+    expect(getAllByRole('option')[0].classList.contains('active')).toBe(false);
+
+    // Arrow Down moves the border to the next option.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() =>
+      expect(
+        getAllByRole('option')[1].classList.contains('active-descendant')
+      ).toBe(true)
+    );
+    expect(
+      getAllByRole('option')[0].classList.contains('active-descendant')
+    ).toBe(false);
+  });
+});

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1340,4 +1340,87 @@ describe('Select improvedA11y', () => {
       getAllByRole('option')[0].classList.contains('active-descendant')
     ).toBe(false);
   });
+
+  test('does not highlight, move, or select when no options are navigable (all disabled)', async () => {
+    const disabledOptions = adOptions.map((o) => ({ ...o, disabled: true }));
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={disabledOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+
+    // The seed effect clears the highlight when nothing is navigable.
+    await waitFor(() =>
+      expect(input.getAttribute('aria-activedescendant')).toBeFalsy()
+    );
+
+    // ArrowDown finds nothing to move to; Enter finds nothing to select.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(input.getAttribute('aria-activedescendant')).toBeFalsy();
+    expect(input.value).toBe('');
+  });
+
+  test('keeps the highlighted option when the option set grows but it stays present', async () => {
+    const { getAllByRole, getByPlaceholderText, rerender } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    const optionEls = await waitFor(() => getAllByRole('option'));
+    const firstId = optionEls[0].id;
+    await waitFor(() =>
+      expect(input.getAttribute('aria-activedescendant')).toBe(firstId)
+    );
+
+    // The option set changes (an option is appended) but the highlighted
+    // option is still present, so the highlight is kept rather than re-seeded.
+    rerender(
+      <Select
+        improvedA11y
+        filterable
+        options={[...adOptions, { text: 'Date', value: 'date' }]}
+        placeholder="Fruit"
+      />
+    );
+    await waitFor(() => expect(getAllByRole('option')).toHaveLength(4));
+    expect(input.getAttribute('aria-activedescendant')).toBe(firstId);
+  });
+
+  test('selects without closing the dropdown on Enter in multiple mode', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        multiple
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Multiple-select keeps the dropdown open for further selections.
+    await waitFor(() =>
+      expect(getAllByRole('option')).toHaveLength(adOptions.length)
+    );
+  });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -115,6 +115,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       toggleButtonAriaLabel,
       'data-test-id': dataTestId,
       keepCountPillFocus = true,
+      improvedA11y = false,
       'aria-label': ariaLabel,
     },
     ref: Ref<HTMLDivElement>
@@ -163,6 +164,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
     const [selectedOptionText, setSelectedOptionText] = useState<string>('');
     const [resetTextInput, setResetTextInput] = useState<boolean>(false);
     const [_initialFocus, setInitialFocus] = useState<boolean>(false);
+    const [activeDescendantId, setActiveDescendantId] = useState<string>(null);
 
     const { isFormItemInput } = useContext(FormItemInputContext);
     const mergedFormItemInput: boolean = isFormItemInput || formItemInput;
@@ -758,6 +760,12 @@ export const Select: FC<SelectProps> = React.forwardRef(
             item.role = optRole ?? 'option';
           }
 
+          // Pass prop to menuItemButton option
+          if (improvedA11y) {
+            item.renderAsListItem = true;
+            item.active = opt.id === activeDescendantId;
+          }
+
           return item;
         }
       );
@@ -777,7 +785,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
               // Imperatively update aria-activedescendant so screen readers
               // announce the selected option even when the selection is driven
               // by a pointer event (which does not fire a focusin event).
-              if (option?.id) {
+              if (!improvedA11y && option?.id) {
                 inputRef.current?.setAttribute(
                   'aria-activedescendant',
                   option.id
@@ -848,11 +856,93 @@ export const Select: FC<SelectProps> = React.forwardRef(
       onBlur?.(event);
     };
 
+    // Options that are allowed to be highlighted,
+    const getNavigableOptions = (): SelectOption[] =>
+      (options || []).filter(
+        (opt: SelectOption) =>
+          !opt.hideOption &&
+          opt.type !== MenuItemType.subHeader &&
+          !opt.disabled
+      );
+
+    // Move the active descendant without moving DOM focus
+    const moveActiveDescendant = (
+      direction: 'down' | 'up'
+    ): void => {
+      const navigable: SelectOption[] = getNavigableOptions();  // pickable options
+      if (navigable.length === 0) {
+        return;
+      }
+      const currentIndex: number = navigable.findIndex(
+        (opt: SelectOption) => opt.id === activeDescendantId
+      );
+      const step: number = direction === 'down' ? 1 : -1;
+      const nextIndex: number =
+        currentIndex < 0
+          ? direction === 'down'
+            ? 0
+            : navigable.length - 1
+          : (currentIndex + step + navigable.length) % navigable.length;
+      const nextId: string = navigable[nextIndex]?.id;
+      if (!nextId) {
+        return;
+      }
+      setActiveDescendantId(nextId);
+      if (canUseDocElement()) {
+        requestAnimationFrame(() => {
+          document
+            .getElementById(nextId)
+            ?.scrollIntoView?.({ block: 'nearest' }); // sync option highlight with scroll
+        });
+      }
+    };
+
+    // Select currently highlighted option (enter)
+    const selectActiveDescendant = (): boolean => {
+      const option: SelectOption = getNavigableOptions().find(
+        (opt: SelectOption) => opt.id === activeDescendantId
+      );
+      if (!option) {
+        return false;
+      }
+      currentlySelectedOption.current = option;
+
+      toggleOption(option);
+      if (!multiple) {
+        setDropdownVisibility(false);
+      }
+      return true;
+    };
+
     const handleInputKeyDown = (
       event: React.KeyboardEvent<HTMLInputElement>
     ): void => {
       if (mergedDisabled) {
         return;
+      }
+
+      // set keydown behaviors
+      if (improvedA11y && dropdownVisible) {
+        if (event?.key === eventKeys.ARROWDOWN) {
+          event.preventDefault();
+          event.stopPropagation();
+          moveActiveDescendant('down');
+          onKeyDown?.(event);
+          return;
+        }
+        if (event?.key === eventKeys.ARROWUP) {
+          event.preventDefault();
+          event.stopPropagation();
+          moveActiveDescendant('up');
+          onKeyDown?.(event);
+          return;
+        }
+        if (event?.key === eventKeys.ENTER && selectActiveDescendant()) {
+          event.preventDefault();
+          event.stopPropagation();
+          onKeyDown?.(event);
+          return;
+        }
       }
 
       // Handle Octuple's internal keyboard navigation FIRST
@@ -968,7 +1058,14 @@ export const Select: FC<SelectProps> = React.forwardRef(
       updateLayout();
     }, [dropdownWidth, selectWidth]);
 
+    const navigableOptionIds: string = getNavigableOptions()
+      .map((opt: SelectOption) => opt.id)
+      .join('|');
+
     useEffect(() => {
+      if (improvedA11y) {
+        return undefined;
+      }
       const input = inputRef.current;
       if (!dropdownVisible) {
         input?.removeAttribute('aria-activedescendant');
@@ -999,6 +1096,34 @@ export const Select: FC<SelectProps> = React.forwardRef(
       };
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dropdownVisible]);
+
+    // Active-descendant a11y pattern: seed the highlighted option when the
+    // dropdown opens (the selected option, else the first), keep it valid as
+    // the option set changes, and clear it when the dropdown closes.
+    useEffect(() => {
+      if (!improvedA11y) {
+        return;
+      }
+      if (!dropdownVisible) {
+        setActiveDescendantId(null);
+        return;
+      }
+      const navigable: SelectOption[] = getNavigableOptions();
+      if (navigable.length === 0) {
+        setActiveDescendantId(null);
+        return;
+      }
+      setActiveDescendantId((prev: string) => {
+        if (prev && navigable.some((opt: SelectOption) => opt.id === prev)) {
+          return prev;
+        }
+        const selected: SelectOption = navigable.find(
+          (opt: SelectOption) => opt.selected
+        );
+        return (selected ?? navigable[0])?.id ?? null;
+      });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [improvedA11y, dropdownVisible, navigableOptionIds]);
 
     return (
       <ResizeObserver onResize={updateLayout}>
@@ -1053,6 +1178,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
                 {dropdownVisible && showPills() ? getPills() : null}
                 <TextInput
                   ref={inputRef}
+                  aria-activedescendant={
+                    improvedA11y ? activeDescendantId ?? undefined : undefined
+                  }
                   aria-controls={selectMenuId?.current}
                   aria-expanded={dropdownVisible}
                   configContextProps={configContextProps}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1097,9 +1097,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dropdownVisible]);
 
-    // Active-descendant a11y pattern: seed the highlighted option when the
-    // dropdown opens (the selected option, else the first), keep it valid as
-    // the option set changes, and clear it when the dropdown closes.
+    // Active-descendant a11y pattern: seed the highlighted option
     useEffect(() => {
       if (!improvedA11y) {
         return;

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -255,4 +255,17 @@ export interface SelectProps
    * @default true
    */
   keepCountPillFocus?: boolean;
+  /**
+   * Opt-in flag (provided for a safe, incremental rollout) that switches the
+   * Select to the `aria-activedescendant` listbox a11y pattern used by
+   * react-select:
+   * - Arrow Up/Down keep DOM focus on the input; the highlighted option is
+   *   tracked via the input's `aria-activedescendant` instead of moving focus
+   *   into the options. Enter selects the active option.
+   * - Each option's `id`/`role`/`aria-selected` move onto its `<li>` so the
+   *   list item itself is the listbox option (the inner `<button>` is kept).
+   * When false (default) the legacy roving-focus behavior is preserved.
+   * @default false
+   */
+  improvedA11y?: boolean;
 }


### PR DESCRIPTION
## SUMMARY:
Adds an opt-in improvedA11y prop (default false) to Select that implements the react-select-style aria-activedescendant pattern: 
- DOM focus stays on the combobox input while Arrow keys move a declarative highlight
- each option renders as a single <li role="option"> (no inner <button>) with the focus shown as a border rather than a fill. 
- All behavior is gated, so with the flag off the rendered DOM and keyboard nav are byte-identical to before. 

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-199230

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

- Tested locally for pipeline page
Recording: https://drive.google.com/file/d/1CRD79xLu_v_bOLsO1LxHymdiGB82AIh9/view?usp=sharing