### PR TITLE
Announce option groups and positions in improvedA11y Select

### DIFF
--- a/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
+++ b/src/components/Menu/MenuItem/MenuItemButton/MenuItemButton.tsx
@@ -177,13 +177,22 @@ export const MenuItemButton: FC<MenuItemButtonProps> = forwardRef(
     };
 
     if (renderAsListItem) {
-      const { id: optionId, 'aria-selected': optionAriaSelected } = rest;
+      const {
+        id: optionId,
+        'aria-selected': ariaSelected,
+        'aria-setsize': ariaSetSize,
+        'aria-posinset': ariaPosInSet,
+        'aria-describedby': ariaDescribedBy,
+      } = rest;
       return (
         <li
           className={menuItemClassNames}
           role={role}
           id={optionId}
-          aria-selected={optionAriaSelected}
+          aria-selected={ariaSelected}
+          aria-setsize={ariaSetSize}
+          aria-posinset={ariaPosInSet}
+          aria-describedby={ariaDescribedBy}
           onClick={handleOnClick}
         >
           <span className={styles.menuItemButton}>

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1218,6 +1218,36 @@ describe('Select improvedA11y', () => {
     });
   });
 
+  test('groups options under sub headers with set size and position info', async () => {
+    const groupedOptions = [
+      { text: 'With HRIS', value: '__hris__', type: MenuItemType.subHeader },
+      { text: 'Apple', value: 'apple' },
+      { text: 'Others', value: '__others__', type: MenuItemType.subHeader },
+      { text: 'Banana', value: 'banana' },
+    ];
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={groupedOptions}
+        placeholder="Fruit"
+      />
+    );
+    fireEvent.click(getByPlaceholderText('Fruit'));
+    const optionEls = await waitFor(() => getAllByRole('option'));
+
+    // Sub headers are presentational group labels, not selectable options.
+    expect(optionEls).toHaveLength(2);
+    expect(optionEls[0]).toHaveAttribute('aria-setsize', '2');
+    expect(optionEls[0]).toHaveAttribute('aria-posinset', '1');
+    expect(optionEls[1]).toHaveAttribute('aria-posinset', '2');
+
+    // Each option references its group label via aria-describedby.
+    const describedBy = optionEls[0].getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy)?.textContent).toBe('With HRIS');
+  });
+
   test('keeps focus on the input and moves aria-activedescendant on ArrowDown/ArrowUp', async () => {
     const { getAllByRole, getByPlaceholderText } = render(
       <Select

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -739,6 +739,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
       const filteredOptions = (options || []).filter(
         (opt: SelectOption) => !opt.hideOption
       );
+      const optionCount: number = filteredOptions.filter(
+        (opt: SelectOption) => opt.type !== MenuItemType.subHeader
+      ).length;
+      let groupLabelId: string | undefined;
+      let position: number = 0;
       const updatedItems: SelectOption[] = filteredOptions.map(
         ({ hideOption, role: optRole, ...opt }) => {
           const item: SelectOption = {
@@ -760,10 +765,19 @@ export const Select: FC<SelectProps> = React.forwardRef(
             item.role = optRole ?? 'option';
           }
 
-          // Pass prop to menuItemButton option
           if (improvedA11y) {
-            item.renderAsListItem = true;
-            item.active = opt.id === activeDescendantId;
+            if (opt.type === MenuItemType.subHeader) {
+              // Sub headers are group labels, not selectable options.
+              item.role = undefined;
+              item['aria-selected'] = undefined;
+              groupLabelId = item.id;
+            } else {
+              item.renderAsListItem = true;
+              item.active = opt.id === activeDescendantId;
+              item['aria-setsize'] = optionCount;
+              item['aria-posinset'] = ++position;
+              item['aria-describedby'] = groupLabelId;
+            }
           }
 
           return item;


### PR DESCRIPTION
## SUMMARY:

Makes the `improvedA11y` Select listbox conform to the WAI-ARIA listbox pattern when options are grouped under sub headers:

- Sub headers now render as presentational group labels (`role` removed) instead of `role="option"`, so screen readers no longer announce them as selectable options or count them in the option set.
- Each grouped option references its sub header via `aria-describedby`, so its group name is announced.
- Each option exposes `aria-setsize` / `aria-posinset` ("N of M"), with sub headers excluded from the count.

All new behavior is gated behind the existing `improvedA11y` prop, so non-`improvedA11y` consumers are unaffected.

## GITHUB ISSUE (Open Source Contributors)

N/A

## JIRA TASK (Eightfold Employees Only):

https://eightfoldai.atlassian.net/browse/ENG-167727

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

Verified live in a consuming app (a grouped template Select with "With HRIS job information" / "Others" groups), with `improvedA11y` enabled:

- The listbox exposes exactly the selectable options as `role="option"` (sub headers excluded) — 3 options for a 2-group list.
- Each option carries `aria-setsize="3"` and `aria-posinset` 1/2/3.
- Each option's `aria-describedby` resolves to its group label text.
- Sub headers render as `<span>` with no `role` and no `aria-selected`, inside `<li role="presentation">`.
- Keyboard: Arrow Up/Down moves `aria-activedescendant` across options, skipping sub headers, with DOM focus remaining on the combobox input.

Non-`improvedA11y` Select/Menu usages (e.g. nav dropdowns) were checked and render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127ZbvzW5a888TLW3jTJXWJ