### PR TITLE
Revert "fix(Upload): always apply accept filter in onChange handler"

### DIFF
--- a/src/components/Upload/Internal/AjaxUploader.tsx
+++ b/src/components/Upload/Internal/AjaxUploader.tsx
@@ -34,10 +34,10 @@ class AjaxUploader extends Component<OcUploadProps> {
   private _isMounted: boolean;
 
   onChange = (_event: React.ChangeEvent<HTMLInputElement>): void => {
-    const { accept } = this.props;
+    const { accept, directory } = this.props;
     const { files } = _event.target;
-    const acceptedFiles = [...(files as any)].filter((file: OcFile) =>
-      attrAccept(file, accept)
+    const acceptedFiles = [...(files as any)].filter(
+      (file: OcFile) => !directory || attrAccept(file, accept)
     );
     this.uploadFiles(acceptedFiles);
     this.reset();

--- a/src/components/Upload/Internal/Tests/uploader.test.js
+++ b/src/components/Upload/Internal/Tests/uploader.test.js
@@ -706,7 +706,7 @@ describe('uploader', () => {
           type: 'text/plain',
         },
       ],
-      1,
+      2,
       '',
       {
         directory: false,


### PR DESCRIPTION
Reverts #1102

### What #1102 did & why
`AjaxUploader.onChange` used to pass every picked file through to `uploadFiles` → `beforeUpload`/`customRequest`, leaving type checks to the consumer. #1102 changed it to always run `attrAccept`:

```diff
- (file) => !directory || attrAccept(file, accept)
+ (file) => attrAccept(file, accept)
```

It was added to block a customer bug ([CS-15960](https://eightfoldai.atlassian.net/browse/CS-15960)) where users bypassed the picker via "All Files" and uploaded unsupported types.

[](https://eightfoldai.atlassian.net/browse/ENG-201962)

### Why revert now
`accept` is a browser hint, not enforcement — and running `attrAccept` here **silently drops** mismatched files *before* `beforeUpload`/`customRequest` fire. Consumers that validate in those callbacks and show their own error lost that path entirely: the file just vanishes, no feedback. **Regression: [ENG-200748](https://eightfoldai.atlassian.net/browse/ENG-200748)** (also traced in [vscode#110534](https://github.com/EightfoldAI/vscode/pull/110534)).

This restores the pre-#1102 pass-through: directory uploads still filter; file-picker uploads reach the consumer callbacks.

### Before upgrading vscode
The original [CS-15960](https://eightfoldai.atlassian.net/browse/CS-15960) consumer (`FileUpload.tsx`) does no type check of its own, so reverting alone reopens it. It's being fixed at the consumer in **[vscode#110938](https://github.com/EightfoldAI/vscode/pull/110938)** — land that first / in the same octuple bump.


[CS-15960]: https://eightfoldai.atlassian.net/browse/CS-15960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-200748]: https://eightfoldai.atlassian.net/browse/ENG-200748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CS-15960]: https://eightfoldai.atlassian.net/browse/CS-15960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ