### PR TITLE
chore(release): 2.57.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.57.7](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.57.7) (2026-07-02)
+
+### Bug Fixes
+
+- **Select:** announce option groups and positions in improvedA11y listbox ([f8bec0a](https://github.com/EightfoldAI/octuple/commits/f8bec0aa5a2898c13396c32fae1a1d9f312c3aa8))
+
 ### [2.57.6](https://github.com/EightfoldAI/octuple/compare/v2.57.5...v2.57.6) (2026-06-19)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.57.6",
+  "version": "2.57.7",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
Release commit for v2.57.7 (version bump + CHANGELOG), generated by `yarn release` (standard-version).

Tag `v2.57.7` is already pushed and the Publish Octuple workflow is running. This PR lands the corresponding release commit on `main` (direct push blocked by branch protection).

Includes:
- fix(Select): announce option groups and positions in improvedA11y listbox (f8bec0a)