### PR TITLE
fix(Slider): handle visually hidden labels

### DIFF
--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -441,4 +441,40 @@ describe('Slider', () => {
     expect(thumbs[0]?.getAttribute('aria-valuetext')).toBe('20 percent');
     expect(thumbs[1]?.getAttribute('aria-valuetext')).toBe('80 percent');
   });
+
+  test('should render hidden handle label spans for range slider with ariaMinHandleLabel, ariaMaxHandleLabel and id', () => {
+    const { container } = render(
+      <Slider
+        value={[20, 80]}
+        id="test-slider"
+        ariaMinHandleLabel="Lower bound"
+        ariaMaxHandleLabel="Upper bound"
+      />
+    );
+    const lowerLabel = container.querySelector('#test-slider-0-handle-label');
+    const upperLabel = container.querySelector('#test-slider-1-handle-label');
+    expect(lowerLabel).toBeTruthy();
+    expect(lowerLabel.textContent).toBe('Lower bound');
+    expect(upperLabel).toBeTruthy();
+    expect(upperLabel.textContent).toBe('Upper bound');
+  });
+
+  test('should compose aria-labelledby with handle label id for range slider', () => {
+    const { container } = render(
+      <Slider
+        value={[20, 80]}
+        id="test-slider"
+        ariaMinHandleLabel="Lower bound"
+        ariaMaxHandleLabel="Upper bound"
+        ariaLabelledBy="external-label"
+      />
+    );
+    const thumbs = container.querySelectorAll('input[type="range"]');
+    expect(thumbs[0]?.getAttribute('aria-labelledby')).toBe(
+      'external-label test-slider-0-handle-label'
+    );
+    expect(thumbs[1]?.getAttribute('aria-labelledby')).toBe(
+      'external-label test-slider-1-handle-label'
+    );
+  });
 });

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -49,7 +49,7 @@ import { ResizeObserver } from '../../shared/ResizeObserver/ResizeObserver';
 import useOffset from './Hooks/useOffset';
 import { Breakpoints, useMatchMedia } from '../../hooks/useMatchMedia';
 import { useCanvasDirection } from '../../hooks/useCanvasDirection';
-import { mergeClasses } from '../../shared/utilities';
+import { mergeClasses, visuallyHidden } from '../../shared/utilities';
 
 import styles from './slider.module.scss';
 import themedComponentStyles from './slider.theme.module.scss';
@@ -88,6 +88,8 @@ export const Slider: FC<SliderProps> = React.forwardRef(
       allowDisabledFocus = false,
       ariaLabel,
       ariaLabelledBy,
+      ariaMaxHandleLabel,
+      ariaMinHandleLabel,
       ariaValueText,
       autoFocus = false,
       classNames,
@@ -937,6 +939,24 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                     }
                   }}
                 />
+                {isRange && id && ariaMinHandleLabel && (
+                  <span
+                    key={`${getIdentifier(id, 0)}-handle-label`}
+                    id={`${getIdentifier(id, 0)}-handle-label`}
+                    style={visuallyHidden}
+                  >
+                    {ariaMinHandleLabel}
+                  </span>
+                )}
+                {isRange && id && ariaMaxHandleLabel && (
+                  <span
+                    key={`${getIdentifier(id, 1)}-handle-label`}
+                    id={`${getIdentifier(id, 1)}-handle-label`}
+                    style={visuallyHidden}
+                  >
+                    {ariaMaxHandleLabel}
+                  </span>
+                )}
                 {values.map((val: number, index: number) => (
                   <Tooltip
                     classNames={mergeClasses([
@@ -966,7 +986,11 @@ export const Slider: FC<SliderProps> = React.forwardRef(
                       ref={ref}
                       aria-disabled={mergedDisabled}
                       aria-label={ariaLabel}
-                      aria-labelledby={ariaLabelledBy}
+                      aria-labelledby={
+                        isRange && id && ariaLabelledBy && (index === 0 ? ariaMinHandleLabel : ariaMaxHandleLabel)
+                          ? `${ariaLabelledBy} ${getIdentifier(id, index)}-handle-label`
+                          : ariaLabelledBy
+                      }
                       aria-valuetext={
                         Array.isArray(ariaValueText)
                           ? ariaValueText[index]

--- a/src/components/Slider/Slider.types.ts
+++ b/src/components/Slider/Slider.types.ts
@@ -203,6 +203,18 @@ export interface SliderInputProps
    */
   ariaLabelledBy?: string;
   /**
+   * Screen-reader-only label for the max handle in a range Slider.
+   * Becomes a visually hidden <span> whose id is appended to aria-labelledby.
+   * Only used when the Slider is a range (value is an array).
+   */
+  ariaMaxHandleLabel?: string;
+  /**
+   * Screen-reader-only label for the min handle in a range Slider.
+   * Becomes a visually hidden <span> whose id is appended to aria-labelledby.
+   * Only used when the Slider is a range (value is an array).
+   */
+  ariaMinHandleLabel?: string;
+  /**
    * The Slider aria-valuetext attribute.
    * Provides a human-readable text alternative for the current value.
    * For range sliders, pass an array of two strings for each thumb.


### PR DESCRIPTION
## SUMMARY:
Add handle sr-only labels

> **Re-raise of #1125.** #1125 was reverted by #1128 ("Revert: dropdown and slider changes"), which reverted the Slider change together with the unrelated Dropdown change (#1113). This PR re-applies the **identical** Slider diff (cherry-picked from the original merge commit `2b164970`). No functional changes from the original.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-191585

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Behaviour has been tested locally:

https://github.com/user-attachments/assets/b147cc3a-0222-4da2-b8a7-2afbc06a623f
