### PR TITLE
chore(release): 2.57.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.57.9](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.57.9) (2026-07-06)
+
+### Features
+
+- **Dropdown:** add disableAutoFlip & disableReferenceTrackingOnScroll as Props ([#1135](https://github.com/EightfoldAI/octuple/issues/1135)) ([87ad268](https://github.com/EightfoldAI/octuple/commits/87ad268f978f18afb799f037349431a79bebbb5d))
+
+### Bug Fixes
+
+- **Select:** announce option groups and positions in improvedA11y listbox ([f8bec0a](https://github.com/EightfoldAI/octuple/commits/f8bec0aa5a2898c13396c32fae1a1d9f312c3aa8))
+- **Slider:** handle visually hidden labels ([#1125](https://github.com/EightfoldAI/octuple/issues/1125)) ([#1143](https://github.com/EightfoldAI/octuple/issues/1143)) ([10c27f6](https://github.com/EightfoldAI/octuple/commits/10c27f6da66c74ac98c3a9eaac16d1c826972651))
+- **Table:** add scroll tolerance so Scroller arrows reach the last column at fractional zoom ([#1140](https://github.com/EightfoldAI/octuple/issues/1140)) ([6e191b9](https://github.com/EightfoldAI/octuple/commits/6e191b9f5e6594ecb69cde2aeb2e75c01e3f40bf))
+
 ### [2.57.8](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.57.8) (2026-07-03)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.57.8",
+  "version": "2.57.9",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
Release **v2.57.9** (patch).

## Included since v2.57.8
- **fix(Slider):** handle visually hidden labels (#1125) (#1143)

Bump + CHANGELOG generated by \`standard-version\`. Tag \`v2.57.9\` pushed — npm publish + GitHub release pipeline running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)