### PR TITLE
fix(Cropper): round zoom value to avoid raw float in indicator

### DIFF
--- a/src/components/Upload/Cropper/EasyCrop.tsx
+++ b/src/components/Upload/Cropper/EasyCrop.tsx
@@ -29,6 +29,11 @@ import { IconName } from '../../Icon';
 
 import styles from './cropper.module.scss';
 
+// Zoom is incremented by ZOOM_STEP (0.1), so repeated additions accumulate
+// float error 1 -> 1.1 -> 1.21 -> 1.331. Rounding to one decimal is
+// lossless for all valid zoom values and keeps the displayed value clean.
+const roundZoom = (z: number): number => Math.round(z * 10) / 10;
+
 const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
   const {
     aspect,
@@ -189,7 +194,7 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               onClick={() => {
                 setRotateButtonDirection('');
                 setZoomButtonDirection('out');
-                setZoomVal(zoomVal - ZOOM_STEP);
+                setZoomVal(roundZoom(zoomVal - ZOOM_STEP));
               }}
               shape={ButtonShape.Round}
               size={ButtonSize.Small}
@@ -207,7 +212,7 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
                 zoomVal < Number(value)
                   ? setZoomButtonDirection('in')
                   : setZoomButtonDirection('out');
-                setZoomVal(Number(value));
+                setZoomVal(roundZoom(Number(value)));
               }}
               hideMax
               hideMin
@@ -228,7 +233,7 @@ const EasyCrop = forwardRef<EasyCropHandle, EasyCropProps>((props, ref) => {
               onClick={() => {
                 setRotateButtonDirection('');
                 setZoomButtonDirection('in');
-                setZoomVal(zoomVal + ZOOM_STEP);
+                setZoomVal(roundZoom(zoomVal + ZOOM_STEP));
               }}
               shape={ButtonShape.Round}
               size={ButtonSize.Small}


### PR DESCRIPTION
## SUMMARY:
Bug: Cropper zoom indicator showed raw floats like 1.4000000000000001 because repeated 0.1 additions accumulate IEEE-754 error, and the value was passed verbatim to the Slider's visible label.

Fix applied in [EasyCrop.tsx](vscode-webview://1eglgl53je8oqjktshct66oe5ur7rjvuijnh539h1hrn668vo6ta/src/components/Upload/Cropper/EasyCrop.tsx):

Added a helper above the component:

const roundZoom = (z: number): number => Math.round(z * 10) / 10;
Wrapped all three setZoomVal sites:
Zoom-out (−) button → setZoomVal(roundZoom(zoomVal - ZOOM_STEP)) (line 197)
Slider onChange → setZoomVal(roundZoom(Number(value))) (line 215)
Zoom-in (+) button → setZoomVal(roundZoom(zoomVal + ZOOM_STEP)) (line 236)

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-201907

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:
Checked Cropper Changes
Before

https://github.com/user-attachments/assets/aec33898-7000-4b40-8b5e-d996c747b093


After

https://github.com/user-attachments/assets/2e497214-d429-4530-94ad-fa190dce3674

