### PR TITLE
chore(release): 2.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.58.1](https://github.com/EightfoldAI/octuple/compare/v2.58.0...v2.58.1) (2026-07-09)
+
+### Reverts
+
+- **Upload:** revert "always apply accept filter in onChange handler ([#1102](https://github.com/EightfoldAI/octuple/issues/1102))" ([#1138](https://github.com/EightfoldAI/octuple/issues/1138)) ([8ce7f46](https://github.com/EightfoldAI/octuple/commits/8ce7f4613e15216a8c891aa2eee60e58f225b217))
+
 ## [2.58.0](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.58.0) (2026-07-07)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.58.0",
+  "version": "2.58.1",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
Release bump for `v2.58.1` (patch).

## Contents
- Revert "fix(Upload): always apply accept filter in onChange handler (#1102)" (#1138)

## Notes
- Tag `v2.58.1` pushed → npm-publish pipeline running.
- Based on `main` @ `2.58.0` (reconciled via #1146).
- CHANGELOG entry hand-corrected: standard-version's auto-entry re-listed 2.58.0 items and omitted the revert (tags aren't ancestors of `main`, so its compare base resolved to v2.57.6).
