### PR TITLE
fix(Select/List): improvedA11y combobox VPAT fixes (Hub #242, #391, #392)

### DIFF
--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -187,4 +187,34 @@ describe('List', () => {
     expect(item2).not.toHaveFocus();
     expect(item1).toHaveFocus();
   });
+
+  test('applies aria-labelledby to the list element (ul), not the wrapper div', () => {
+    const { container } = render(
+      <List
+        {...listProps}
+        listType="ul"
+        role="listbox"
+        aria-labelledby="external-label"
+      />
+    );
+    const list = container.querySelector('ul');
+    const wrapper = container.querySelector('div.my-ref-class');
+    expect(list).toHaveAttribute('aria-labelledby', 'external-label');
+    expect(wrapper).not.toHaveAttribute('aria-labelledby');
+  });
+
+  test('applies aria-labelledby to the ordered list element (ol), not the wrapper div', () => {
+    const { container } = render(
+      <List
+        {...listProps}
+        listType="ol"
+        role="listbox"
+        aria-labelledby="external-label"
+      />
+    );
+    const list = container.querySelector('ol');
+    const wrapper = container.querySelector('div.my-ref-class');
+    expect(list).toHaveAttribute('aria-labelledby', 'external-label');
+    expect(wrapper).not.toHaveAttribute('aria-labelledby');
+  });
 });

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -37,6 +37,7 @@ export const List = <T extends any>({
   id,
   applyCyclicNavigation = false,
   'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
   ...rest
 }: ListProps<T>) => {
   const htmlDir: string = useCanvasDirection();
@@ -263,6 +264,7 @@ export const List = <T extends any>({
           id={id}
           role={role}
           aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
           className={containerClasses}
           style={{ ...listStyle }}
         >
@@ -275,6 +277,7 @@ export const List = <T extends any>({
           id={id}
           role={role}
           aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
           className={containerClasses}
           style={{ ...listStyle }}
         >

--- a/src/components/Select/Locale/ar_SA.tsx
+++ b/src/components/Select/Locale/ar_SA.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'تطابق موجود.',
     resultsAvailableText: 'تطابقات موجودة.',
     noResultsFoundText: 'لم يتم العثور على تطابق لـ',
+    optionPositionSeparatorText: 'من',
   },
 };
 

--- a/src/components/Select/Locale/bg_BG.tsx
+++ b/src/components/Select/Locale/bg_BG.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'съвпадение намерено.',
     resultsAvailableText: 'съвпадения намерени.',
     noResultsFoundText: 'Няма намерено съвпадение за',
+    optionPositionSeparatorText: 'от',
   },
 };
 

--- a/src/components/Select/Locale/cs_CZ.tsx
+++ b/src/components/Select/Locale/cs_CZ.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'shoda nalezena.',
     resultsAvailableText: 'shody nalezeny.',
     noResultsFoundText: 'Žádná shoda nenalezena pro',
+    optionPositionSeparatorText: 'z',
   },
 };
 

--- a/src/components/Select/Locale/da_DK.tsx
+++ b/src/components/Select/Locale/da_DK.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'match fundet.',
     resultsAvailableText: 'matches fundet.',
     noResultsFoundText: 'Ingen match fundet for',
+    optionPositionSeparatorText: 'af',
   },
 };
 

--- a/src/components/Select/Locale/de_DE.tsx
+++ b/src/components/Select/Locale/de_DE.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'Treffer gefunden.',
     resultsAvailableText: 'Treffer gefunden.',
     noResultsFoundText: 'Keine Treffer gefunden für',
+    optionPositionSeparatorText: 'von',
   },
 };
 

--- a/src/components/Select/Locale/el_GR.tsx
+++ b/src/components/Select/Locale/el_GR.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'αποτέλεσμα βρέθηκε.',
     resultsAvailableText: 'αποτελέσματα βρέθηκαν.',
     noResultsFoundText: 'Δεν βρέθηκε αποτέλεσμα για',
+    optionPositionSeparatorText: 'από',
   },
 };
 

--- a/src/components/Select/Locale/en_GB.tsx
+++ b/src/components/Select/Locale/en_GB.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'match found.',
     resultsAvailableText: 'matches found.',
     noResultsFoundText: 'No match found for',
+    optionPositionSeparatorText: 'of',
   },
 };
 

--- a/src/components/Select/Locale/en_US.tsx
+++ b/src/components/Select/Locale/en_US.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'match found.',
     resultsAvailableText: 'matches found.',
     noResultsFoundText: 'No match found for',
+    optionPositionSeparatorText: 'of',
   },
 };
 

--- a/src/components/Select/Locale/es_DO.tsx
+++ b/src/components/Select/Locale/es_DO.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'match found.',
     resultsAvailableText: 'matches found.',
     noResultsFoundText: 'No match found for',
+    optionPositionSeparatorText: 'de',
   },
 };
 

--- a/src/components/Select/Locale/es_ES.tsx
+++ b/src/components/Select/Locale/es_ES.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'coincidencia encontrada.',
     resultsAvailableText: 'coincidencias encontradas.',
     noResultsFoundText: 'No se encontró ninguna coincidencia para',
+    optionPositionSeparatorText: 'de',
   },
 };
 

--- a/src/components/Select/Locale/es_MX.tsx
+++ b/src/components/Select/Locale/es_MX.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'coincidencia encontrada.',
     resultsAvailableText: 'coincidencias encontradas.',
     noResultsFoundText: 'No se encontró ninguna coincidencia para',
+    optionPositionSeparatorText: 'de',
   },
 };
 

--- a/src/components/Select/Locale/fi_FI.tsx
+++ b/src/components/Select/Locale/fi_FI.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'osuma löytyi.',
     resultsAvailableText: 'osumia löytyi.',
     noResultsFoundText: 'Osumia ei löydy haulle',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/fr_BE.tsx
+++ b/src/components/Select/Locale/fr_BE.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'correspondance trouvée.',
     resultsAvailableText: 'correspondances trouvées.',
     noResultsFoundText: 'Aucune correspondance trouvée pour',
+    optionPositionSeparatorText: 'sur',
   },
 };
 

--- a/src/components/Select/Locale/fr_CA.tsx
+++ b/src/components/Select/Locale/fr_CA.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'correspondance trouvée.',
     resultsAvailableText: 'correspondances trouvées.',
     noResultsFoundText: 'Aucune correspondance trouvée pour',
+    optionPositionSeparatorText: 'sur',
   },
 };
 

--- a/src/components/Select/Locale/fr_FR.tsx
+++ b/src/components/Select/Locale/fr_FR.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'correspondance trouvée.',
     resultsAvailableText: 'correspondances trouvées.',
     noResultsFoundText: 'Aucune correspondance trouvée pour',
+    optionPositionSeparatorText: 'sur',
   },
 };
 

--- a/src/components/Select/Locale/he_IL.tsx
+++ b/src/components/Select/Locale/he_IL.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'התאמה נמצאה.',
     resultsAvailableText: 'התאמות נמצאו.',
     noResultsFoundText: 'לא נמצאה התאמה עבור',
+    optionPositionSeparatorText: 'מתוך',
   },
 };
 

--- a/src/components/Select/Locale/hi_IN.tsx
+++ b/src/components/Select/Locale/hi_IN.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'मिलान मिला।',
     resultsAvailableText: 'मिलान मिले।',
     noResultsFoundText: 'कोई मिलान नहीं मिला:',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/hr_HR.tsx
+++ b/src/components/Select/Locale/hr_HR.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'podudaranje pronađeno.',
     resultsAvailableText: 'podudaranja pronađena.',
     noResultsFoundText: 'Nije pronađeno podudaranje za',
+    optionPositionSeparatorText: 'od',
   },
 };
 

--- a/src/components/Select/Locale/ht_HT.tsx
+++ b/src/components/Select/Locale/ht_HT.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'match jwenn.',
     resultsAvailableText: 'matches jwenn.',
     noResultsFoundText: 'Pa gen match jwenn pou',
+    optionPositionSeparatorText: 'sou',
   },
 };
 

--- a/src/components/Select/Locale/hu_HU.tsx
+++ b/src/components/Select/Locale/hu_HU.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'találat megtalálva.',
     resultsAvailableText: 'találatok megtalálva.',
     noResultsFoundText: 'Nincs találat erre:',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/it_IT.tsx
+++ b/src/components/Select/Locale/it_IT.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'corrispondenza trovata.',
     resultsAvailableText: 'corrispondenze trovate.',
     noResultsFoundText: 'Nessuna corrispondenza trovata per',
+    optionPositionSeparatorText: 'di',
   },
 };
 

--- a/src/components/Select/Locale/ja_JP.tsx
+++ b/src/components/Select/Locale/ja_JP.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: '件の一致が見つかりました。',
     resultsAvailableText: '件の一致が見つかりました。',
     noResultsFoundText: '一致する結果が見つかりません:',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/ko_KR.tsx
+++ b/src/components/Select/Locale/ko_KR.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: '개 일치 항목 찾음.',
     resultsAvailableText: '개 일치 항목 찾음.',
     noResultsFoundText: '일치하는 항목을 찾을 수 없습니다:',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/ms_MY.tsx
+++ b/src/components/Select/Locale/ms_MY.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'padanan ditemui.',
     resultsAvailableText: 'padanan ditemui.',
     noResultsFoundText: 'Tiada padanan ditemui untuk',
+    optionPositionSeparatorText: 'daripada',
   },
 };
 

--- a/src/components/Select/Locale/nb_NO.tsx
+++ b/src/components/Select/Locale/nb_NO.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'treff funnet.',
     resultsAvailableText: 'treff funnet.',
     noResultsFoundText: 'Ingen treff funnet for',
+    optionPositionSeparatorText: 'av',
   },
 };
 

--- a/src/components/Select/Locale/nl_BE.tsx
+++ b/src/components/Select/Locale/nl_BE.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'overeenkomst gevonden.',
     resultsAvailableText: 'overeenkomsten gevonden.',
     noResultsFoundText: 'Geen overeenkomst gevonden voor',
+    optionPositionSeparatorText: 'van',
   },
 };
 

--- a/src/components/Select/Locale/nl_NL.tsx
+++ b/src/components/Select/Locale/nl_NL.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'overeenkomst gevonden.',
     resultsAvailableText: 'overeenkomsten gevonden.',
     noResultsFoundText: 'Geen overeenkomst gevonden voor',
+    optionPositionSeparatorText: 'van',
   },
 };
 

--- a/src/components/Select/Locale/pl_PL.tsx
+++ b/src/components/Select/Locale/pl_PL.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'dopasowanie znalezione.',
     resultsAvailableText: 'dopasowania znalezione.',
     noResultsFoundText: 'Nie znaleziono dopasowania dla',
+    optionPositionSeparatorText: 'z',
   },
 };
 

--- a/src/components/Select/Locale/pt_BR.tsx
+++ b/src/components/Select/Locale/pt_BR.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'correspondência encontrada.',
     resultsAvailableText: 'correspondências encontradas.',
     noResultsFoundText: 'Nenhuma correspondência encontrada para',
+    optionPositionSeparatorText: 'de',
   },
 };
 

--- a/src/components/Select/Locale/pt_PT.tsx
+++ b/src/components/Select/Locale/pt_PT.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'correspondência encontrada.',
     resultsAvailableText: 'correspondências encontradas.',
     noResultsFoundText: 'Nenhuma correspondência encontrada para',
+    optionPositionSeparatorText: 'de',
   },
 };
 

--- a/src/components/Select/Locale/ro_RO.tsx
+++ b/src/components/Select/Locale/ro_RO.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'potrivire găsită.',
     resultsAvailableText: 'potriviri găsite.',
     noResultsFoundText: 'Nicio potrivire găsită pentru',
+    optionPositionSeparatorText: 'din',
   },
 };
 

--- a/src/components/Select/Locale/ru_RU.tsx
+++ b/src/components/Select/Locale/ru_RU.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'совпадение найдено.',
     resultsAvailableText: 'совпадения найдены.',
     noResultsFoundText: 'Совпадений не найдено для',
+    optionPositionSeparatorText: 'из',
   },
 };
 

--- a/src/components/Select/Locale/sk_SK.tsx
+++ b/src/components/Select/Locale/sk_SK.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'zhoda nájdená.',
     resultsAvailableText: 'zhody nájdené.',
     noResultsFoundText: 'Žiadna zhoda nenájdená pre',
+    optionPositionSeparatorText: 'z',
   },
 };
 

--- a/src/components/Select/Locale/sr_RS.tsx
+++ b/src/components/Select/Locale/sr_RS.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'подударање пронађено.',
     resultsAvailableText: 'подударања пронађена.',
     noResultsFoundText: 'Није пронађено подударање за',
+    optionPositionSeparatorText: 'од',
   },
 };
 

--- a/src/components/Select/Locale/sv_SE.tsx
+++ b/src/components/Select/Locale/sv_SE.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'träff hittad.',
     resultsAvailableText: 'träffar hittade.',
     noResultsFoundText: 'Ingen träff hittad för',
+    optionPositionSeparatorText: 'av',
   },
 };
 

--- a/src/components/Select/Locale/te_IN.tsx
+++ b/src/components/Select/Locale/te_IN.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'సరిపోలిక కనుగొనబడింది.',
     resultsAvailableText: 'సరిపోలికలు కనుగొనబడ్డాయి.',
     noResultsFoundText: 'సరిపోలిక కనుగొనబడలేదు:',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/th_TH.tsx
+++ b/src/components/Select/Locale/th_TH.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'รายการที่ตรงกันพบแล้ว',
     resultsAvailableText: 'รายการที่ตรงกันพบแล้ว',
     noResultsFoundText: 'ไม่พบรายการที่ตรงกันสำหรับ',
+    optionPositionSeparatorText: 'จาก',
   },
 };
 

--- a/src/components/Select/Locale/tr_TR.tsx
+++ b/src/components/Select/Locale/tr_TR.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'eşleşme bulundu.',
     resultsAvailableText: 'eşleşme bulundu.',
     noResultsFoundText: 'Eşleşme bulunamadı:',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/uk_UA.tsx
+++ b/src/components/Select/Locale/uk_UA.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'збіг знайдено.',
     resultsAvailableText: 'збіги знайдено.',
     noResultsFoundText: 'Збігів не знайдено для',
+    optionPositionSeparatorText: 'з',
   },
 };
 

--- a/src/components/Select/Locale/vi_VN.tsx
+++ b/src/components/Select/Locale/vi_VN.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: 'kết quả phù hợp tìm thấy.',
     resultsAvailableText: 'kết quả phù hợp tìm thấy.',
     noResultsFoundText: 'Không tìm thấy kết quả phù hợp cho',
+    optionPositionSeparatorText: 'trên',
   },
 };
 

--- a/src/components/Select/Locale/zh_CN.tsx
+++ b/src/components/Select/Locale/zh_CN.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: '个匹配项已找到。',
     resultsAvailableText: '个匹配项已找到。',
     noResultsFoundText: '未找到匹配项：',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Locale/zh_TW.tsx
+++ b/src/components/Select/Locale/zh_TW.tsx
@@ -6,6 +6,7 @@ const locale: SelectLocale = {
     resultAvailableText: '個相符項目已找到。',
     resultsAvailableText: '個相符項目已找到。',
     noResultsFoundText: '未找到相符項目：',
+    optionPositionSeparatorText: '/',
   },
 };
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1453,4 +1453,89 @@ describe('Select improvedA11y', () => {
       expect(getAllByRole('option')).toHaveLength(adOptions.length)
     );
   });
+
+  test('aria-selected follows the active descendant as arrow keys move focus (single-select)', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    const optionEls = await waitFor(() => getAllByRole('option'));
+
+    // Opening highlights the first option; aria-selected sits on it alone.
+    await waitFor(() => {
+      const current = getAllByRole('option');
+      expect(current[0]).toHaveAttribute('aria-selected', 'true');
+      expect(current[1]).toHaveAttribute('aria-selected', 'false');
+      expect(current[2]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    // ArrowDown moves the highlight, and aria-selected moves with it.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => {
+      const current = getAllByRole('option');
+      expect(current[0]).toHaveAttribute('aria-selected', 'false');
+      expect(current[1]).toHaveAttribute('aria-selected', 'true');
+      expect(current[2]).toHaveAttribute('aria-selected', 'false');
+    });
+    expect(optionEls).toHaveLength(3);
+  });
+
+  test('aria-selected reflects committed selection, not focus, in multiple mode', async () => {
+    const { getAllByRole, getByPlaceholderText } = render(
+      <Select
+        improvedA11y
+        filterable
+        multiple
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+
+    // Highlight the first option, then move focus to the second.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    // Nothing is committed yet, so no option should read as selected even
+    // though one is highlighted (selection must not follow focus here).
+    await waitFor(() => {
+      getAllByRole('option').forEach((el: HTMLElement) => {
+        expect(el).toHaveAttribute('aria-selected', 'false');
+      });
+    });
+  });
+
+  test('announces the highlighted option in the live region as focus moves', async () => {
+    const { getByPlaceholderText, getByRole, getAllByRole } = render(
+      <Select
+        improvedA11y
+        filterable
+        options={adOptions}
+        placeholder="Fruit"
+      />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+
+    // Opening highlights the first option: announce its name and position.
+    await waitFor(() => {
+      expect(getByRole('status')).toHaveTextContent('Apple, 1 of 3');
+    });
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => {
+      expect(getByRole('status')).toHaveTextContent('Banana, 2 of 3');
+    });
+  });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -367,9 +367,37 @@ export const Select: FC<SelectProps> = React.forwardRef(
         const noResultsText = selectLocale?.lang?.noResultsFoundText;
         message = searchQuery ? `${noResultsText} ${searchQuery}` : '';
       }
+
+      // VoiceOver ignores aria-activedescendant, so announce the active option
+      // here. Tradeoff: NVDA hears it twice (native + this echo).
+      if (improvedA11y && activeDescendantId) {
+        const visibleOptions: SelectOption[] = (options || []).filter(
+          (opt: SelectOption) =>
+            !opt.hideOption && opt.type !== MenuItemType.subHeader
+        );
+        const activeIndex: number = visibleOptions.findIndex(
+          (opt: SelectOption) => opt.id === activeDescendantId
+        );
+        const activeOption: SelectOption = visibleOptions[activeIndex];
+        if (activeOption) {
+          const positionSeparator: string =
+            selectLocale?.lang?.optionPositionSeparatorText ?? 'of';
+          message = `${activeOption.text}, ${
+            activeIndex + 1
+          } ${positionSeparator} ${visibleOptionsCount}`;
+        }
+      }
+
       lastLiveRegionMessageRef.current = message;
       return message;
-    }, [dropdownVisible, options, searchQuery, selectLocale]);
+    }, [
+      dropdownVisible,
+      options,
+      searchQuery,
+      selectLocale,
+      improvedA11y,
+      activeDescendantId,
+    ]);
 
     const toggleOption = (option: SelectOption): void => {
       setSearchQuery('');
@@ -774,6 +802,11 @@ export const Select: FC<SelectProps> = React.forwardRef(
             } else {
               item.renderAsListItem = true;
               item.active = opt.id === activeDescendantId;
+              // APG: single-select selection follows focus; multi-select keeps
+              // aria-selected on committed choices (set above from opt.selected).
+              if (!multiple) {
+                item['aria-selected'] = item.active;
+              }
               item['aria-setsize'] = optionCount;
               item['aria-posinset'] = ++position;
               item['aria-describedby'] = groupLabelId;

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -30,6 +30,11 @@ type SelectLang = {
    * Announced when no options are visible (e.g. after filtering yields zero results).
    */
   noResultsFoundText?: string;
+  /**
+   * Connector between an option's position and total in the live region
+   * announcement, e.g. the "of" in "Apple, 1 of 3". Defaults to "of".
+   */
+  optionPositionSeparatorText?: string;
 };
 
 export type SelectLocale = {


### PR DESCRIPTION
## Summary

Fixes three WAI-ARIA APG combobox a11y defects confirmed live on QA (Allyant Hub #242, #391, #392), all rooted in the shared `Select`/`Menu`/`List` components in `improvedA11y` mode. A single library fix resolves them for every `improvedA11y` `Select` consumer (`TemplateSelectModal`, `TimeSlotSelect`, and any other usage).

### 1. Listbox missing accessible name (#391)
`List` destructured only `aria-label` and applied it to the `<ul>`/`<ol>`; `aria-labelledby` fell into `...rest` and landed on the outer wrapper `<div>` instead of the `role="listbox"` element. Consumers passing `aria-labelledby` via `menuProps` (e.g. `TimeSlotSelect`) got a listbox with no accessible name. Now forwarded to both `<ul>` and `<ol>` alongside `aria-label`.

### 2. `aria-selected` doesn't follow keyboard focus (#392, #242)
`aria-selected` was set once from the committed value (`opt.selected`) and never moved as Arrow keys changed the active descendant, so focus and selection state diverged. Per the APG Combobox pattern ("selection follows focus in the listbox"), **single-select** listboxes now track the active descendant. **Multi-select** listboxes keep `aria-selected` on the committed choices (guarded with `!multiple`) — moving it with focus there would be incorrect.

### 3. VoiceOver never announces the highlighted option (#392, #242)
The visually-hidden live region reacted only to `dropdownVisible`/`options`/`searchQuery`/`selectLocale`, never to `activeDescendantId`, so VoiceOver announced only "expanded" and nothing as the user arrowed through options (NVDA compensates via native `aria-activedescendant`). The active option's text and position are now announced.

**⚠️ Reviewer flag:** this causes NVDA to hear the option name twice (once natively via activedescendant, once via this echo) — accepted tradeoff for VoiceOver support.

The "of" connector in the announcement ("Apple, 1 of 3") is localizable via a new optional `optionPositionSeparatorText` locale key (set on `en_US`/`en_GB`; other locales fall back to `"of"` in code pending translation).

## Test plan
- New unit tests for all three fixes (List: attr lands on list el not wrapper; Select: selection-follows-focus single-select, multi-select unchanged, live-region echo on arrow nav).
- `npx jest src/components/List src/components/Select src/components/Menu` → **122 tests pass**, snapshots clean.
- Verified end-to-end chain: `menuProps.aria-labelledby` → Select `restMenuProps` → Menu `...rest` → List → `<ul role="listbox">`.

## Consumer impact
No app-side code changes needed. `vscode` consumers already pass correct attributes; they only need to bump `@eightfold.ai/octuple` after this releases.