### PR TITLE
chore(release): 2.58.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.58.2](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.58.2) (2026-07-09)
+
+### Features
+
+- **Dropdown:** add disableAutoFlip & disableReferenceTrackingOnScroll as Props ([#1135](https://github.com/EightfoldAI/octuple/issues/1135)) ([87ad268](https://github.com/EightfoldAI/octuple/commits/87ad268f978f18afb799f037349431a79bebbb5d))
+
+### Bug Fixes
+
+- **Cropper:** round zoom value to avoid raw float in indicator ([d2f79bb](https://github.com/EightfoldAI/octuple/commits/d2f79bba04f27f12e8366c90c4a2d05d3476bcc2))
+- **Select/List:** improvedA11y combobox VPAT fixes (Hub [#242](https://github.com/EightfoldAI/octuple/issues/242), [#391](https://github.com/EightfoldAI/octuple/issues/391), [#392](https://github.com/EightfoldAI/octuple/issues/392)) ([d67e1f7](https://github.com/EightfoldAI/octuple/commits/d67e1f770941d428368e44047e11bdb6a61ef9a2)), closes [#1149](https://github.com/EightfoldAI/octuple/issues/1149)
+- **Select:** announce option groups and positions in improvedA11y listbox ([f8bec0a](https://github.com/EightfoldAI/octuple/commits/f8bec0aa5a2898c13396c32fae1a1d9f312c3aa8))
+- **Slider:** handle visually hidden labels ([#1125](https://github.com/EightfoldAI/octuple/issues/1125)) ([#1143](https://github.com/EightfoldAI/octuple/issues/1143)) ([10c27f6](https://github.com/EightfoldAI/octuple/commits/10c27f6da66c74ac98c3a9eaac16d1c826972651))
+- **Table:** add scroll tolerance so Scroller arrows reach the last column at fractional zoom ([#1140](https://github.com/EightfoldAI/octuple/issues/1140)) ([6e191b9](https://github.com/EightfoldAI/octuple/commits/6e191b9f5e6594ecb69cde2aeb2e75c01e3f40bf))
+
 ### [2.58.1](https://github.com/EightfoldAI/octuple/compare/v2.58.0...v2.58.1) (2026-07-09)
 
 ### Reverts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [2.58.2](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.58.2) (2026-07-09)
-
-### Features
-
-- **Dropdown:** add disableAutoFlip & disableReferenceTrackingOnScroll as Props ([#1135](https://github.com/EightfoldAI/octuple/issues/1135)) ([87ad268](https://github.com/EightfoldAI/octuple/commits/87ad268f978f18afb799f037349431a79bebbb5d))
+### [2.58.2](https://github.com/EightfoldAI/octuple/compare/v2.58.1...v2.58.2) (2026-07-09)
 
 ### Bug Fixes
 
-- **Cropper:** round zoom value to avoid raw float in indicator ([d2f79bb](https://github.com/EightfoldAI/octuple/commits/d2f79bba04f27f12e8366c90c4a2d05d3476bcc2))
 - **Select/List:** improvedA11y combobox VPAT fixes (Hub [#242](https://github.com/EightfoldAI/octuple/issues/242), [#391](https://github.com/EightfoldAI/octuple/issues/391), [#392](https://github.com/EightfoldAI/octuple/issues/392)) ([d67e1f7](https://github.com/EightfoldAI/octuple/commits/d67e1f770941d428368e44047e11bdb6a61ef9a2)), closes [#1149](https://github.com/EightfoldAI/octuple/issues/1149)
-- **Select:** announce option groups and positions in improvedA11y listbox ([f8bec0a](https://github.com/EightfoldAI/octuple/commits/f8bec0aa5a2898c13396c32fae1a1d9f312c3aa8))
-- **Slider:** handle visually hidden labels ([#1125](https://github.com/EightfoldAI/octuple/issues/1125)) ([#1143](https://github.com/EightfoldAI/octuple/issues/1143)) ([10c27f6](https://github.com/EightfoldAI/octuple/commits/10c27f6da66c74ac98c3a9eaac16d1c826972651))
-- **Table:** add scroll tolerance so Scroller arrows reach the last column at fractional zoom ([#1140](https://github.com/EightfoldAI/octuple/issues/1140)) ([6e191b9](https://github.com/EightfoldAI/octuple/commits/6e191b9f5e6594ecb69cde2aeb2e75c01e3f40bf))
 
 ### [2.58.1](https://github.com/EightfoldAI/octuple/compare/v2.58.0...v2.58.1) (2026-07-09)
 
@@ -22,20 +14,19 @@ All notable changes to this project will be documented in this file. See [standa
 
 - **Upload:** revert "always apply accept filter in onChange handler ([#1102](https://github.com/EightfoldAI/octuple/issues/1102))" ([#1138](https://github.com/EightfoldAI/octuple/issues/1138)) ([8ce7f46](https://github.com/EightfoldAI/octuple/commits/8ce7f4613e15216a8c891aa2eee60e58f225b217))
 
-## [2.58.0](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.58.0) (2026-07-07)
-
-### Features
-
-- **Dropdown:** add disableAutoFlip & disableReferenceTrackingOnScroll as Props ([#1135](https://github.com/EightfoldAI/octuple/issues/1135)) ([87ad268](https://github.com/EightfoldAI/octuple/commits/87ad268f978f18afb799f037349431a79bebbb5d))
+## [2.58.0](https://github.com/EightfoldAI/octuple/compare/v2.57.9...v2.58.0) (2026-07-07)
 
 ### Bug Fixes
 
 - **Cropper:** round zoom value to avoid raw float in indicator ([d2f79bb](https://github.com/EightfoldAI/octuple/commits/d2f79bba04f27f12e8366c90c4a2d05d3476bcc2))
-- **Select:** announce option groups and positions in improvedA11y listbox ([f8bec0a](https://github.com/EightfoldAI/octuple/commits/f8bec0aa5a2898c13396c32fae1a1d9f312c3aa8))
-- **Slider:** handle visually hidden labels ([#1125](https://github.com/EightfoldAI/octuple/issues/1125)) ([#1143](https://github.com/EightfoldAI/octuple/issues/1143)) ([10c27f6](https://github.com/EightfoldAI/octuple/commits/10c27f6da66c74ac98c3a9eaac16d1c826972651))
-- **Table:** add scroll tolerance so Scroller arrows reach the last column at fractional zoom ([#1140](https://github.com/EightfoldAI/octuple/issues/1140)) ([6e191b9](https://github.com/EightfoldAI/octuple/commits/6e191b9f5e6594ecb69cde2aeb2e75c01e3f40bf))
 
-### [2.57.9](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.57.9) (2026-07-06)
+### [2.57.9](https://github.com/EightfoldAI/octuple/compare/v2.57.8...v2.57.9) (2026-07-06)
+
+### Bug Fixes
+
+- **Slider:** handle visually hidden labels ([#1125](https://github.com/EightfoldAI/octuple/issues/1125)) ([#1143](https://github.com/EightfoldAI/octuple/issues/1143)) ([10c27f6](https://github.com/EightfoldAI/octuple/commits/10c27f6da66c74ac98c3a9eaac16d1c826972651))
+
+### [2.57.8](https://github.com/EightfoldAI/octuple/compare/v2.57.7...v2.57.8) (2026-07-03)
 
 ### Features
 
@@ -43,19 +34,6 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-- **Select:** announce option groups and positions in improvedA11y listbox ([f8bec0a](https://github.com/EightfoldAI/octuple/commits/f8bec0aa5a2898c13396c32fae1a1d9f312c3aa8))
-- **Slider:** handle visually hidden labels ([#1125](https://github.com/EightfoldAI/octuple/issues/1125)) ([#1143](https://github.com/EightfoldAI/octuple/issues/1143)) ([10c27f6](https://github.com/EightfoldAI/octuple/commits/10c27f6da66c74ac98c3a9eaac16d1c826972651))
-- **Table:** add scroll tolerance so Scroller arrows reach the last column at fractional zoom ([#1140](https://github.com/EightfoldAI/octuple/issues/1140)) ([6e191b9](https://github.com/EightfoldAI/octuple/commits/6e191b9f5e6594ecb69cde2aeb2e75c01e3f40bf))
-
-### [2.57.8](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.57.8) (2026-07-03)
-
-### Features
-
-- **Dropdown:** add disableAutoFlip & disableReferenceTrackingOnScroll as Props ([#1135](https://github.com/EightfoldAI/octuple/issues/1135)) ([87ad268](https://github.com/EightfoldAI/octuple/commits/87ad268f978f18afb799f037349431a79bebbb5d))
-
-### Bug Fixes
-
-- **Select:** announce option groups and positions in improvedA11y listbox ([f8bec0a](https://github.com/EightfoldAI/octuple/commits/f8bec0aa5a2898c13396c32fae1a1d9f312c3aa8))
 - **Table:** add scroll tolerance so Scroller arrows reach the last column at fractional zoom ([#1140](https://github.com/EightfoldAI/octuple/issues/1140)) ([6e191b9](https://github.com/EightfoldAI/octuple/commits/6e191b9f5e6594ecb69cde2aeb2e75c01e3f40bf))
 
 ### [2.57.7](https://github.com/EightfoldAI/octuple/compare/v2.57.6...v2.57.7) (2026-07-02)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.58.1",
+  "version": "2.58.2",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
Release 2.58.2 — improvedA11y `Select`/`List` combobox VPAT fixes (Allyant Hub #242, #391, #392).

Tag `v2.58.2` pushed; npm-publish pipeline done.