### PR TITLE
fix(Select): announce result count with the active option for improvedA11y combobox

### DIFF
--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1514,7 +1514,7 @@ describe('Select improvedA11y', () => {
     });
   });
 
-  test('announces the highlighted option in the live region as focus moves', async () => {
+  test('announces the result count with the highlighted option, and only the option on arrow keys', async () => {
     const { getByPlaceholderText, getByRole, getAllByRole } = render(
       <Select
         improvedA11y
@@ -1528,14 +1528,44 @@ describe('Select improvedA11y', () => {
     fireEvent.click(input);
     await waitFor(() => getAllByRole('option'));
 
-    // Opening highlights the first option: announce its name and position.
     await waitFor(() => {
-      expect(getByRole('status')).toHaveTextContent('Apple, 1 of 3');
+      const status: string = getByRole('status').textContent;
+      expect(status).toContain('matches found');
+      expect(status).toContain('Apple, 1 of 3');
     });
 
     fireEvent.keyDown(input, { key: 'ArrowDown' });
     await waitFor(() => {
       expect(getByRole('status')).toHaveTextContent('Banana, 2 of 3');
     });
+    expect(getByRole('status').textContent).not.toContain('matches found');
+  });
+
+  test('announces the seeded option group on open, but not while arrowing', async () => {
+    const grouped = [
+      { text: 'With HRIS', value: 'hris', type: MenuItemType.subHeader },
+      { text: 'Apple', value: 'apple' },
+      { text: 'Others', value: 'others', type: MenuItemType.subHeader },
+      { text: 'Banana', value: 'banana' },
+    ];
+    const { getByPlaceholderText, getByRole, getAllByRole } = render(
+      <Select improvedA11y filterable options={grouped} placeholder="Fruit" />
+    );
+    const input = getByPlaceholderText('Fruit') as HTMLInputElement;
+    input.focus();
+    fireEvent.click(input);
+    await waitFor(() => getAllByRole('option'));
+
+    // Open: the seeded option carries its group (VoiceOver won't read it natively).
+    await waitFor(() => {
+      expect(getByRole('status')).toHaveTextContent('Apple, With HRIS');
+    });
+
+    // Arrow: group is left to VoiceOver's native reading, so the echo omits it.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await waitFor(() => {
+      expect(getByRole('status')).toHaveTextContent('Banana, 2 of 2');
+    });
+    expect(getByRole('status').textContent).not.toContain('Others');
   });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -34,6 +34,7 @@ import {
 import { Pill, PillSize, PillType } from '../Pills';
 import { IconName } from '../Icon';
 import {
+  ANNOUNCE_DEBOUNCE_DURATION,
   SelectOption,
   SelectProps,
   SelectShape,
@@ -340,8 +341,30 @@ export const Select: FC<SelectProps> = React.forwardRef(
       }
     }, [filterable, initialFocus]);
 
+    // Option id -> its group label (nearest preceding sub header).
+    const optionGroupById = useMemo<Record<string, string>>(() => {
+      if (!improvedA11y) {
+        return {};
+      }
+      const groups: Record<string, string> = {};
+      let group = '';
+      for (const opt of options || []) {
+        if (opt.hideOption) {
+          continue;
+        }
+        if (opt.type === MenuItemType.subHeader) {
+          group = opt.text ?? '';
+        } else if (opt.id) {
+          groups[opt.id] = group;
+        }
+      }
+      return groups;
+    }, [options, improvedA11y]);
+
     // Derive the live region message, memoized to prevent spurious
     const lastLiveRegionMessageRef = useRef<string>('');
+    // Mode: 'list' (open/filter) includes the count; 'nav' (arrows) omits it.
+    const announceModeRef = useRef<'list' | 'nav'>('list');
     const liveRegionMessage = useMemo<string>(() => {
       if (!dropdownVisible) {
         return lastLiveRegionMessageRef.current;
@@ -382,9 +405,24 @@ export const Select: FC<SelectProps> = React.forwardRef(
         if (activeOption) {
           const positionSeparator: string =
             selectLocale?.lang?.optionPositionSeparatorText ?? 'of';
-          message = `${activeOption.text}, ${
+          const position: string = `${
             activeIndex + 1
           } ${positionSeparator} ${visibleOptionsCount}`;
+          // Group only on open/filter; the seeded option isn't announced natively.
+          const activeText: string =
+            announceModeRef.current === 'nav'
+              ? `${activeOption.text}, ${position}`
+              : [
+                  activeOption.text,
+                  optionGroupById[activeDescendantId] ?? '',
+                  position,
+                ]
+                  .filter(Boolean)
+                  .join(', ');
+          message =
+            announceModeRef.current === 'nav'
+              ? activeText
+              : `${message} ${activeText}`;
         }
       }
 
@@ -398,6 +436,21 @@ export const Select: FC<SelectProps> = React.forwardRef(
       improvedA11y,
       activeDescendantId,
     ]);
+
+    // Debounce open/filter so keystroke updates coalesce; arrow nav is immediate.
+    const [announcedMessage, setAnnouncedMessage] = useState<string>('');
+    useEffect(() => {
+      if (!improvedA11y) {
+        return undefined;
+      }
+      const delay: number =
+        announceModeRef.current === 'nav' ? 0 : ANNOUNCE_DEBOUNCE_DURATION;
+      const timer: ReturnType<typeof setTimeout> = setTimeout(
+        () => setAnnouncedMessage(liveRegionMessage),
+        delay
+      );
+      return () => clearTimeout(timer);
+    }, [liveRegionMessage, improvedA11y]);
 
     const toggleOption = (option: SelectOption): void => {
       setSearchQuery('');
@@ -934,6 +987,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (!nextId) {
         return;
       }
+      announceModeRef.current = 'nav';
       setActiveDescendantId(nextId);
       if (canUseDocElement()) {
         requestAnimationFrame(() => {
@@ -1149,6 +1203,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
       if (!improvedA11y) {
         return;
       }
+      announceModeRef.current = 'list';
       if (!dropdownVisible) {
         setActiveDescendantId(null);
         return;
@@ -1192,7 +1247,7 @@ export const Select: FC<SelectProps> = React.forwardRef(
               className={styles.selectLiveRegion}
               role="status"
             >
-              {liveRegionMessage}
+              {improvedA11y ? announcedMessage : liveRegionMessage}
             </div>
             {/* When Dropdown is hidden, place Pills outside the reference element */}
             {!dropdownVisible && showPills() ? getPills() : null}

--- a/src/components/Select/Select.types.ts
+++ b/src/components/Select/Select.types.ts
@@ -13,6 +13,8 @@ import { PillProps } from '../Pills';
 import { MenuItemButtonProps } from '../Menu/MenuItem/MenuItem.types';
 import { InputStatus } from '../../shared/utilities';
 
+export const ANNOUNCE_DEBOUNCE_DURATION: number = 400;
+
 type SelectLang = {
   /**
    * The Select locale.


### PR DESCRIPTION
## SUMMARY:

The `improvedA11y` combobox echoed the highlighted option into the result-count live region, **overwriting** the count — so screen readers stopped announcing "N matches found" while filtering (regression surfaced after #1149). This combines the count and option in one polite announcement instead.

**What screen readers now hear** (single live region):

- **Open / filter:** `"{count} matches found. {option}, {group}, {n} of {total}"` — one announcement, including the seeded option's **group**.
  - VoiceOver merges live-region updates into one utterance, so racing separate count/option regions dropped one of them.
  - VoiceOver doesn't read the *seeded* option's group natively on open, so we include it here.
- **Arrow navigation:** `"{option}, {n} of {total}"` — option only; **no count** (avoids re-announcing it as noise) and **no group** (VoiceOver reads the option + its group natively while arrowing, so echoing them would double-announce).
- **Debounced** on open/filter so per-keystroke updates coalesce into one announcement and don't race the combobox input's own typing echo; arrow-nav announces immediately.
- **Plain (non-`improvedA11y`) Selects are completely unchanged** — all of the above is gated behind `improvedA11y`.

**Implementation** (minimal delta on #1149):

- `liveRegionMessage` now **appends** the option to the count instead of overwriting it, gated by an `announceModeRef` (`'list'` on open/filter, `'nav'` on arrow — set in the seed effect and `moveActiveDescendant`).
- Group comes from an `optionId → group` map **memoized on `options`** (O(1) lookup, no per-announcement rescan), also gated to `improvedA11y`.
- Debounce is a `useEffect` + `setTimeout` (the repo's standard pattern, e.g. `Accordion`), gated to `improvedA11y`; the delay is the `ANNOUNCE_DEBOUNCE_DURATION` constant in `Select.types.ts`, matching the repo's timing-constant convention (`ANIMATION_DURATION`, …).
- Adds one exported timing constant (`ANNOUNCE_DEBOUNCE_DURATION`), consistent with the existing ones (`ANIMATION_DURATION`, …); no new component props, no locale changes.

## GITHUB ISSUE (Open Source Contributors)

N/A

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-203165
Follow-up to the combobox VPAT work in #1149.


## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

- Updated `Select.test.tsx`: open announces the count and `Apple, 1 of 3`; after `ArrowDown` the region announces `Banana, 2 of 3` without the count.
- Added a grouped test: open announces the seeded option's group (`Apple, With HRIS`); `ArrowDown` announces `Banana, 2 of 2` **without** the group (left to VoiceOver's native reading).
- Full `Select.test.tsx` suite passes (81 tests); `Form` suite unaffected (the `improvedA11y` gate keeps plain Selects untouched).
- Verified with VoiceOver + Safari on grouped and ungrouped template Selects.
