### PR TITLE
fix(DatePicker): make underline variant border override order-independent

### DIFF
--- a/src/components/DateTimePicker/Internal/ocpicker.module.scss
+++ b/src/components/DateTimePicker/Internal/ocpicker.module.scss
@@ -9,7 +9,7 @@
   border-radius: $picker-border-radius;
   display: inline-flex;
   font-family: var(--font-stack-full);
-  
+
   .pickerLabel {
     position: relative;
   }
@@ -1705,6 +1705,10 @@
   }
 
   &-underline {
+    // Must live in this file: overriding `.picker`'s border from another file
+    // (equal specificity) depends on the consuming app's CSS emission order.
+    border-color: transparent;
+
     .picker-input {
       &:before {
         border-bottom: 1px solid var(--input-border-color);


### PR DESCRIPTION
## SUMMARY:

Underline picker variant hides the box border via `datepicker.module.scss` `.picker-underline { border-color: transparent }`, which ties on specificity with `.picker { border: ... }` in `Internal/ocpicker.module.scss` — so the winner depends on the consuming app's CSS emission order, which webpack can flip on unrelated changes. When flipped, the box border reappears and clips the suffix calendar icon (seen on stage scheduling panel; QA unaffected on the same octuple version).

Fix: declare `border-color: transparent` in ocpicker.module.scss's own `&-underline` block — same-file order always puts it after the base rule, making the override bundler-order-proof. Covers DatePicker/TimePicker/RangePicker.

## GITHUB ISSUE (Open Source Contributors)

N/A

## JIRA TASK (Eightfold Employees Only):

TBD

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

1. Storybook: DatePicker/TimePicker/RangePicker with `shape=underline`, date selected — underline only, no box border, suffix icon fully visible. ✅
2. Regression: rectangle/pill shapes keep their box border; jest suite green. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)