### PR TITLE
fix(a11y): correct select chevron role and type rangepicker aria-label props

### DIFF
--- a/src/components/DateTimePicker/Internal/OcPicker.types.ts
+++ b/src/components/DateTimePicker/Internal/OcPicker.types.ts
@@ -1024,6 +1024,10 @@ export type OcRangePickerSharedProps<DateType> = {
    * Allow start or end input leave empty.
    */
   allowEmpty?: [boolean, boolean];
+  /** Aria label for the range's start-date input. */
+  startDateInputAriaLabel?: string;
+  /** Aria label for the range's end-date input. */
+  endDateInputAriaLabel?: string;
   /**
    * Configure how to provide automated assistance in filling out form field values.
    * https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -966,10 +966,8 @@ export const Select: FC<SelectProps> = React.forwardRef(
       );
 
     // Move the active descendant without moving DOM focus
-    const moveActiveDescendant = (
-      direction: 'down' | 'up'
-    ): void => {
-      const navigable: SelectOption[] = getNavigableOptions();  // pickable options
+    const moveActiveDescendant = (direction: 'down' | 'up'): void => {
+      const navigable: SelectOption[] = getNavigableOptions(); // pickable options
       if (navigable.length === 0) {
         return;
       }
@@ -1100,10 +1098,9 @@ export const Select: FC<SelectProps> = React.forwardRef(
               ? toggleButtonAriaLabel
               : 'Toggle dropdown',
             htmlType: 'button',
-            // The button does not need to be the tab order as
-            // the input itself provides the focus and action.
+            // Decorative chevron hidden from AT via aria-hidden; the role="combobox"
+            // input is the interaction surface. No role="presentation" (WCAG 4.1.2).
             tabIndex: -1,
-            role: 'presentation',
             ariaHidden: true,
             iconProps: {
               path: dropdownVisible

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1098,8 +1098,6 @@ export const Select: FC<SelectProps> = React.forwardRef(
               ? toggleButtonAriaLabel
               : 'Toggle dropdown',
             htmlType: 'button',
-            // Decorative chevron hidden from AT via aria-hidden; the role="combobox"
-            // input is the interaction surface. No role="presentation" (WCAG 4.1.2).
             tabIndex: -1,
             ariaHidden: true,
             iconProps: {

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -51,7 +51,6 @@ exports[`Select Renders empty options in multiple mode without crashing 1`] = `
                   aria-hidden="true"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                  role="presentation"
                   tabindex="-1"
                   type="button"
                 >
@@ -131,7 +130,6 @@ exports[`Select Renders empty options in single mode without crashing 1`] = `
                   aria-hidden="true"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                  role="presentation"
                   tabindex="-1"
                   type="button"
                 >
@@ -211,7 +209,6 @@ exports[`Select Renders null options in multiple mode without crashing 1`] = `
                   aria-hidden="true"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                  role="presentation"
                   tabindex="-1"
                   type="button"
                 >
@@ -291,7 +288,6 @@ exports[`Select Renders null options in single mode without crashing 1`] = `
                   aria-hidden="true"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                  role="presentation"
                   tabindex="-1"
                   type="button"
                 >
@@ -371,7 +367,6 @@ exports[`Select Renders with default value 1`] = `
                   aria-hidden="true"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                  role="presentation"
                   tabindex="-1"
                   type="button"
                 >
@@ -519,7 +514,6 @@ exports[`Select Renders with default values when multiple 1`] = `
                   aria-hidden="true"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                  role="presentation"
                   tabindex="-1"
                   type="button"
                 >
@@ -599,7 +593,6 @@ exports[`Select Renders without crashing 1`] = `
                   aria-hidden="true"
                   aria-label="Toggle dropdown"
                   class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                  role="presentation"
                   tabindex="-1"
                   type="button"
                 >
@@ -678,7 +671,6 @@ exports[`Select Select is large 1`] = `
                 aria-hidden="true"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-large icon-left"
-                role="presentation"
                 tabindex="-1"
                 type="button"
               >
@@ -756,7 +748,6 @@ exports[`Select Select is medium 1`] = `
                 aria-hidden="true"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                role="presentation"
                 tabindex="-1"
                 type="button"
               >
@@ -834,7 +825,6 @@ exports[`Select Select is pill shaped 1`] = `
                 aria-hidden="true"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium round-shape icon-left"
-                role="presentation"
                 tabindex="-1"
                 type="button"
               >
@@ -912,7 +902,6 @@ exports[`Select Select is rectangle shaped 1`] = `
                 aria-hidden="true"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                role="presentation"
                 tabindex="-1"
                 type="button"
               >
@@ -990,7 +979,6 @@ exports[`Select Select is small 1`] = `
                 aria-hidden="true"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-small icon-left"
-                role="presentation"
                 tabindex="-1"
                 type="button"
               >
@@ -1068,7 +1056,6 @@ exports[`Select Select is underline shaped 1`] = `
                 aria-hidden="true"
                 aria-label="Toggle dropdown"
                 class="icon-button right-icon button button-system-ui transparent button-medium icon-left"
-                role="presentation"
                 tabindex="-1"
                 type="button"
               >


### PR DESCRIPTION
## SUMMARY:

Two WCAG-related accessibility fixes surfaced by the Eightfold condition / If-Then builder.

1. **`Select` chevron (WCAG 4.1.2):** the dropdown toggle chevron rendered as `role="presentation"` + `aria-hidden="true"` **with** an `aria-label`. A presentational role on a `<button>` strips its semantics and the `aria-label` is ignored — an inconsistent state axe flags as a presentation-role conflict. Since the `role="combobox"` input already owns open/close (`aria-expanded` / `aria-controls`), this removes `role="presentation"` and keeps `aria-hidden`, so the chevron is cleanly hidden from assistive tech per the combobox pattern.
2. **`RangePicker` date-input aria labels (typing / DX):** `startDateInputAriaLabel` / `endDateInputAriaLabel` are consumed by the internal range picker but were declared only on a local type, so they were missing from the public `.d.ts`. Consumers had to cast (`as unknown as …`) to name the start/end date inputs. They're now on the public `OcRangePickerSharedProps`, so the cast can be dropped downstream.

## GITHUB ISSUE (Open Source Contributors)

N/A

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-203981

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist
- [ ] I have added unittests for this change

## TEST PLAN:

### Issue 1 — `Select` chevron (WCAG 4.1.2)
Verified in Storybook (**Select → Basic**) by inspecting the chevron `<button>` on `main` vs this branch:

- **Before (`main` / 2.58.4):** `<button aria-hidden="true" role="presentation" tabindex="-1" aria-label="Toggle dropdown">` — presentational role on an interactive button with an ignored label. axe flags it as **1 Incomplete** (*"ARIA role presentation must be removed when the element is made visible, as it is not allowed for the element"*).
- **After (this PR):** `<button aria-hidden="true" tabindex="-1" aria-label="Toggle dropdown">` — `role="presentation"` removed, `aria-hidden` retained. axe: **0 violations / 0 incomplete**. The `role="combobox"` input remains the interaction surface.
- **Keyboard:** `Tab` skips the chevron; the combobox input opens/closes via `Enter` / `↓` / `Esc`.
- **VoiceOver:** announces only the combobox — no separate "Toggle dropdown" button.

<img width="1284" height="472" alt="Screenshot 2026-07-21 at 4 26 25 PM" src="https://github.com/user-attachments/assets/8e62c2cd-c48f-4525-9d65-545d5b976047" />

**Before:**
<img width="1512" height="982" alt="Screenshot 2026-07-21 at 4 26 53 PM" src="https://github.com/user-attachments/assets/200b8cdb-721b-43e7-bfa0-e133b1d1c59b" />


**After:**
<img width="1512" height="982" alt="Screenshot 2026-07-21 at 4 29 04 PM" src="https://github.com/user-attachments/assets/feb13ed5-aec3-4a46-9cc1-862510c8ecd1" />


### Issue 3a — `RangePicker` aria-label prop types
Verified via the type system + compiled output (this is a type change, not a runtime one):

- `yarn typecheck` → clean. The props type-check across the codebase; on `main` they were not usable without a cast.
- The props are now emitted in the **public** `.d.ts`:

  ```
  lib/components/DateTimePicker/Internal/OcPicker.types.d.ts
    932:  startDateInputAriaLabel?: string;
    934:  endDateInputAriaLabel?: string;
  ```

  → `<RangePicker startDateInputAriaLabel="…" endDateInputAriaLabel="…" />` now type-checks with **no `as unknown as …` cast** downstream.

### Regression
- Full unit suite green in pre-commit: **222 suites / 2645 tests** pass.
- `Select` snapshots regenerated — the only rendered-DOM change is the removed `role="presentation"` on the chevron; no behavioral change (mouse `onClick` and keyboard combobox interaction unchanged).

> Note: this PR covers **Issue 1** and **Issue 3a** from ENG-203981. Issues 2 (keyboard-active option contrast) and 3b (`RangePicker` aria passthrough) were already satisfied in octuple 2.58.4 and need no change here.
