### PR TITLE
fix(table): keep rows rendered when pageSizes prop changes at runtime

### DIFF
--- a/src/components/Table/Hooks/usePagination.ts
+++ b/src/components/Table/Hooks/usePagination.ts
@@ -80,6 +80,12 @@ export default function usePagination(
     }
   );
 
+  // A changed pageSizes prop can orphan the pageSize persisted by Pagination's mount effect
+  const { pageSize, pageSizes } = mergedPagination;
+  if (pageSizes && pageSize !== undefined && !pageSizes.includes(pageSize)) {
+    mergedPagination.pageSize = pageSizes[0];
+  }
+
   // Reset `current` if data length or pageSize changed
   const pages: number[] = mergedPagination.pageSizes!;
   let maxPage: number;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -579,6 +579,14 @@ function InternalTable<RecordType extends object = any>(
           );
         }
       }
+
+      // pageSize not in pageSizes: fall back to the first size instead of rendering empty
+      const fallbackPageSize: number = pageSizes[0] ?? DEFAULT_PAGE_SIZE;
+      mergedPagination.pageSize = fallbackPageSize;
+      return mergedData.slice(
+        (currentPage - 1) * fallbackPageSize,
+        currentPage * fallbackPageSize
+      );
     } else {
       if (mergedData.length < total!) {
         if (mergedData.length > pageSize) {

--- a/src/components/Table/Tests/Table.pagination.test.js
+++ b/src/components/Table/Tests/Table.pagination.test.js
@@ -79,7 +79,7 @@ describe('Table.table-pagination', () => {
   });
 
   it('keeps rendering rows when a dynamic pageSizes prop changes value', () => {
-    // act() flushes Pagination's mount effect, which persists the initial size (the bug trigger)
+    // act() flushes Pagination's mount effect, which persists the initial size
     let wrapper;
     act(() => {
       wrapper = mount(

--- a/src/components/Table/Tests/Table.pagination.test.js
+++ b/src/components/Table/Tests/Table.pagination.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import Table from '../index';
@@ -75,6 +76,27 @@ describe('Table.table-pagination', () => {
 
     wrapper.setProps({ pagination: { pageSize: 1 } });
     expect(renderedNames(wrapper)).toEqual(['Lola']);
+  });
+
+  it('keeps rendering rows when a dynamic pageSizes prop changes value', () => {
+    // act() flushes Pagination's mount effect, which persists the initial size (the bug trigger)
+    let wrapper;
+    act(() => {
+      wrapper = mount(
+        createTable({
+          dataSource: longData,
+          pagination: { pageSizes: [10] },
+        })
+      );
+    });
+    wrapper.update();
+    expect(renderedNames(wrapper)).toHaveLength(10);
+
+    act(() => {
+      wrapper.setProps({ pagination: { pageSizes: [9] } });
+    });
+    wrapper.update();
+    expect(renderedNames(wrapper)).toHaveLength(9);
   });
 
   it('should not crash when trigger onChange in render', () => {


### PR DESCRIPTION
## SUMMARY:

Issue - If Table's internal pageSize is no longer present in an updated `pagination.pageSizes` prop, the pageData lookup finds no match and returns null. The table renders "No data found" with data still loaded, and only a remount recovers it.

How it happens - Pagination's mount effect persists the initial size into Table's inner pagination state, so any consumer that recomputes pageSizes later hits the mismatch. This is what blanked the Position Overview drill-in lists in vscode on window resize (found during ENG-203034 verification; product-side fix in EightfoldAI/vscode#113083).

Fix - In usePagination, normalize the merged pageSize to `pageSizes[0]` when pageSizes no longer contains it. In Table's pageData, replace the return-null fallthrough with a slice using the first size.

## GITHUB ISSUE (Open Source Contributors)

NA

## JIRA TASK (Eightfold Employees Only):

https://eightfoldai.atlassian.net/browse/ENG-205018

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

- New unit test in Table.pagination.test.js - mounts with `pageSizes: [10]`, re-renders with `pageSizes: [9]`, asserts rows still render. Fails without the fix (0 rows).
- Table and Pagination suites pass (22 suites, 243 tests); the pre-commit hook runs the full repo suite.
- No behavior change when pageSize is still valid - normalization only engages on the mismatch.
