### PR TITLE
chore(release): 2.58.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.58.5](https://github.com/EightfoldAI/octuple/compare/v2.58.4...v2.58.5) (2026-08-11)
+
+
+### Bug Fixes
+
+* **a11y:** correct select chevron role and type rangepicker aria-label props ([#1156](https://github.com/EightfoldAI/octuple/issues/1156)) ([f22fb38](https://github.com/EightfoldAI/octuple/commits/f22fb38e6b2d7602dd2a8535a69dfa04c14b3d99))
+* **table:** keep rows rendered when pageSizes prop changes at runtime ([fac8548](https://github.com/EightfoldAI/octuple/commits/fac854849fa2731fb5328c67658522d90ecc8fff))
+
 ### [2.58.4](https://github.com/EightfoldAI/octuple/compare/v2.58.3...v2.58.4) (2026-07-14)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.58.4",
+  "version": "2.58.5",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
## Release 2.58.5 (patch)

Version bump + CHANGELOG only. Tag and npm publish happen after this merges (tag-on-main flow).

### Included fixes
- fac85484 fix(table): keep rows rendered when pageSizes prop changes at runtime
- f22fb38e fix(a11y): correct select chevron role and type rangepicker aria-label props (#1156)