### PR TITLE
fix(Avatar): hover styling

### DIFF
--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import MatchMediaMock from 'jest-matchmedia-mock';
-import { Avatar, AvatarGroup } from './';
+import { Avatar, AvatarGroup, StatusItemsPosition } from './';
+import { IconName } from '../Icon';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -177,5 +178,42 @@ describe('Avatar', () => {
       </Avatar>
     );
     expect(wrapper.find('img').prop('tabIndex')).toBeUndefined();
+  });
+
+  const statusItems = {
+    [StatusItemsPosition.Bottom]: {
+      ariaLabel: 'Status',
+      path: IconName.mdiClock,
+      size: '8px',
+    },
+  };
+
+  test('Avatar with image renders status items inside the animated root', () => {
+    const wrapper = mount(
+      <Avatar src="test.jpg" alt="test" statusItems={statusItems} />
+    );
+    const root = wrapper.find('.avatar-root').first();
+    // The animated element must contain both the image and the status items,
+    // otherwise hover animations detach the status items from the Avatar.
+    expect(root.find('img').length).toEqual(1);
+    expect(root.find('.avatar-status-item').length).toEqual(1);
+    expect(wrapper.find('img').hasClass('avatar-root')).toBeFalsy();
+  });
+
+  test('Fallback Avatar renders status items inside the animated root', () => {
+    const wrapper = mount(<Avatar statusItems={statusItems}>AB</Avatar>);
+    const root = wrapper.find('.avatar-root').first();
+    expect(root.find('.avatar-status-item').length).toEqual(1);
+  });
+
+  test('Icon Avatar renders status items inside the animated root', () => {
+    const wrapper = mount(
+      <Avatar
+        iconProps={{ path: IconName.mdiAccount }}
+        statusItems={statusItems}
+      />
+    );
+    const root = wrapper.find('.avatar-root').first();
+    expect(root.find('.avatar-status-item').length).toEqual(1);
   });
 });

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -413,6 +413,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
     ]);
 
     const wrapperContainerClassNames: string = mergeClasses([
+      styles.avatarRoot,
       styles.avatarImgWrapper,
       popupClassNames,
       classNames,
@@ -504,6 +505,7 @@ export const Avatar: FC<AvatarProps> = React.forwardRef(
     }
 
     const wrapperClassNames: string = mergeClasses([
+      styles.avatarRoot,
       imageClassNames,
       classNames,
     ]);

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -2,7 +2,14 @@ import React from 'react';
 import { Stories } from '@storybook/addon-docs';
 import { action } from '@storybook/addon-actions';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Avatar, AvatarGroup, AvatarGroupVariant, AvatarPopupProps } from '.';
+import {
+  Avatar,
+  AvatarGroup,
+  AvatarGroupVariant,
+  AvatarPopupProps,
+  StatusItemsPosition,
+} from '.';
+import { IconName } from '../Icon';
 import { TooltipSize, TooltipTheme } from '../Tooltip';
 
 export default {
@@ -38,6 +45,18 @@ export default {
 const imageProps = {
   src: 'https://images.pexels.com/photos/771742/pexels-photo-771742.jpeg',
   alt: 'random profile image',
+};
+
+// Status items should follow the Avatar when it animates on hover.
+const statusItems = {
+  [StatusItemsPosition.Bottom]: {
+    ariaLabel: 'Clock icon',
+    backgroundColor: 'var(--grey-background1-color)',
+    color: 'var(--grey-secondary-color)',
+    path: IconName.mdiClock,
+    size: '8px',
+    wrapperStyle: { padding: '2px' },
+  },
 };
 
 interface User {
@@ -97,6 +116,7 @@ const Basic_Story: ComponentStory<typeof AvatarGroup> = (args) => (
       onMouseLeave={action('avatar-mouseleave')}
       src={imageProps.src}
       size={args.size}
+      statusItems={statusItems}
       tabIndex={0}
       theme={'blue'}
       tooltipProps={{
@@ -113,6 +133,7 @@ const Basic_Story: ComponentStory<typeof AvatarGroup> = (args) => (
       onMouseEnter={action('avatar-mouseenter')}
       onMouseLeave={action('avatar-mouseleave')}
       size={args.size}
+      statusItems={statusItems}
       tabIndex={0}
       theme={'green'}
       tooltipProps={{

--- a/src/components/Avatar/Styles/group.scss
+++ b/src/components/Avatar/Styles/group.scss
@@ -14,6 +14,10 @@
   .avatar {
     border: $space-xxxs solid var(--background-color);
     position: relative;
+  }
+
+  .avatar-root {
+    position: relative;
 
     &:hover {
       z-index: $z-index-500;
@@ -21,7 +25,7 @@
   }
 
   &.animate {
-    .avatar {
+    .avatar-root {
       transition: transform $motion-duration-extra-fast $motion-easing-easeout;
 
       &:hover:not(.avatar-popup-hidden):not(.avatar-popup-visible):not(:focus-visible) {

--- a/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Avatar Avatar size is 40px 1`] = `
 LoadedCheerio {
   "0": Node {
     "attribs": Object {
-      "class": "wrapper-style avatar image-style",
+      "class": "wrapper-style avatar-root avatar image-style",
       "style": "width: 40px; height: 40px; min-width: 40px; min-height: 40px; font-size: 18px;",
       "tabindex": "0",
     },
@@ -132,7 +132,7 @@ exports[`Avatar Avatar type is round 1`] = `
 LoadedCheerio {
   "0": Node {
     "attribs": Object {
-      "class": "wrapper-style avatar image-style round",
+      "class": "wrapper-style avatar-root avatar image-style round",
       "style": "width: 32px; height: 32px; min-width: 32px; min-height: 32px; font-size: 18px;",
       "tabindex": "0",
     },
@@ -260,7 +260,7 @@ exports[`Avatar Avatar type square is default 1`] = `
 LoadedCheerio {
   "0": Node {
     "attribs": Object {
-      "class": "wrapper-style avatar image-style",
+      "class": "wrapper-style avatar-root avatar image-style",
       "style": "width: 32px; height: 32px; min-width: 32px; min-height: 32px; font-size: 18px;",
       "tabindex": "0",
     },

--- a/src/components/Navbar/__snapshots__/Navbar.test.tsx.snap
+++ b/src/components/Navbar/__snapshots__/Navbar.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Navbar Navbar matches custom theme 1`] = `
           tabindex="0"
         >
           <div
-            class="avatar-img-wrapper round"
+            class="avatar-root avatar-img-wrapper round"
             style="width: 32px; height: 32px; min-width: 32px; min-height: 32px; font-size: 18px;"
           >
             <img
@@ -108,7 +108,7 @@ exports[`Navbar Renders without crashing 1`] = `
             tabindex="0"
           >
             <div
-              class="avatar-img-wrapper round"
+              class="avatar-root avatar-img-wrapper round"
               style="width: 32px; height: 32px; min-width: 32px; min-height: 32px; font-size: 18px;"
             >
               <img


### PR DESCRIPTION
## SUMMARY:

When an avatar shows a photo, hovering it in a group lifted the circle but left the grey status dot behind.

- The hover lift was applied to the photo, and the dot sits next to the photo rather than inside it, so only the photo moved.
- The lift is now applied to the element that wraps both, so the avatar and its dot move together.
- Avatars showing initials or an icon were never affected and stay exactly as they are.
- Nothing changes when not hovering. The two snapshot files only pick up one added class.

## GITHUB ISSUE (Open Source Contributors)

## JIRA TASK (Eightfold Employees Only):
https://eightfoldai.atlassian.net/browse/ENG-197378

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:
Tested locally

https://github.com/user-attachments/assets/2bdf1bf5-c7e1-4e41-af12-112c5d77ef17


Before:

https://github.com/user-attachments/assets/b80f8422-215d-41aa-b302-aee32abc7bbc

