### PR TITLE
fix(pagination): recompute page count when pageSize or pageSizes props change

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -171,4 +171,77 @@ describe('Pagination', () => {
         .hasAttribute('disabled')
     ).toBe(true);
   });
+
+  test('Pagination should recompute page count when pageSize prop changes', () => {
+    const { container, rerender } = render(
+      <Pagination
+        currentPage={1}
+        onCurrentChange={() => {}}
+        pageSize={11}
+        pageSizes={[11]}
+        total={37}
+      />
+    );
+    expect(container.querySelectorAll('.pager li')).toHaveLength(4);
+
+    rerender(
+      <Pagination
+        currentPage={1}
+        onCurrentChange={() => {}}
+        pageSize={6}
+        pageSizes={[6]}
+        total={37}
+      />
+    );
+    expect(container.querySelectorAll('.pager li')).toHaveLength(7);
+  });
+
+  test('Pagination should recompute page count when only pageSizes prop changes', () => {
+    const { container, rerender } = render(
+      <Pagination
+        currentPage={1}
+        onCurrentChange={() => {}}
+        pageSizes={[11]}
+        total={37}
+      />
+    );
+    expect(container.querySelectorAll('.pager li')).toHaveLength(4);
+
+    rerender(
+      <Pagination
+        currentPage={1}
+        onCurrentChange={() => {}}
+        pageSizes={[6]}
+        total={37}
+      />
+    );
+    expect(container.querySelectorAll('.pager li')).toHaveLength(7);
+  });
+
+  test('Pagination should clamp current page when a pageSize change shrinks page count', () => {
+    const onCurrentChange = jest.fn();
+    const { rerender } = render(
+      <Pagination
+        currentPage={7}
+        onCurrentChange={onCurrentChange}
+        pageSize={6}
+        pageSizes={[6]}
+        selfControlled={false}
+        total={37}
+      />
+    );
+    expect(onCurrentChange).not.toHaveBeenCalled();
+
+    rerender(
+      <Pagination
+        currentPage={7}
+        onCurrentChange={onCurrentChange}
+        pageSize={11}
+        pageSizes={[11]}
+        selfControlled={false}
+        total={37}
+      />
+    );
+    expect(onCurrentChange).toHaveBeenCalledWith(4);
+  });
 });

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import React, { FC, Ref, useContext, useEffect, useState } from 'react';
+import React, {
+  FC,
+  Ref,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import GradientContext, { Gradient } from '../ConfigProvider/GradientContext';
 import { OcThemeName } from '../ConfigProvider';
 import ThemeContext, {
@@ -196,6 +203,29 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
       setCurrentPage(currentPage);
     }, [currentPage]);
 
+    // Mount normalization is handled above; this only tracks later prop changes
+    const skipInitialSizeSyncRef = useRef<boolean>(true);
+
+    useEffect((): void => {
+      if (skipInitialSizeSyncRef.current) {
+        skipInitialSizeSyncRef.current = false;
+        return;
+      }
+      const nextPageSize: number =
+        !pageSizes.length || pageSizes.includes(pageSize)
+          ? pageSize
+          : pageSizes[0];
+      setPageSize(nextPageSize);
+      setPageSizes(pageSizes);
+      if (total > 0) {
+        const nextPageCount: number = Math.ceil(total / nextPageSize);
+        setPageCount(nextPageCount);
+        if (_currentPage > nextPageCount) {
+          handleCurrentChange(nextPageCount);
+        }
+      }
+    }, [pageSize, pageSizes.join(',')]);
+
     useEffect((): void => {
       if (loop) {
         setPageCount(pageCount);
@@ -285,7 +315,7 @@ export const Pagination: FC<PaginationProps> = React.forwardRef(
 
     const onSizeChangeHandler = (val: number): void => {
       setPageSize(val);
-      setPageCount(Math.ceil(total / _pageSize));
+      setPageCount(Math.ceil(total / val));
       onSizeChange && onSizeChange(val);
 
       // TODO: Improve this to find _currentPage in newly calc'd _pageSize.

--- a/src/components/Table/Tests/Table.pagination.test.js
+++ b/src/components/Table/Tests/Table.pagination.test.js
@@ -99,6 +99,33 @@ describe('Table.table-pagination', () => {
     expect(renderedNames(wrapper)).toHaveLength(9);
   });
 
+  it('recomputes page count when a dynamic pageSize prop changes value', () => {
+    const resizableData = [];
+    for (let i = 0; i < 37; i += 1) {
+      resizableData.push({ key: i, name: `${i}` });
+    }
+
+    let wrapper;
+    act(() => {
+      wrapper = mount(
+        createTable({
+          dataSource: resizableData,
+          pagination: { pageSize: 11, pageSizes: [11] },
+        })
+      );
+    });
+    wrapper.update();
+    expect(renderedNames(wrapper)).toHaveLength(11);
+    expect(wrapper.find('ul.pager li')).toHaveLength(4);
+
+    act(() => {
+      wrapper.setProps({ pagination: { pageSize: 6, pageSizes: [6] } });
+    });
+    wrapper.update();
+    expect(renderedNames(wrapper)).toHaveLength(6);
+    expect(wrapper.find('ul.pager li')).toHaveLength(7);
+  });
+
   it('should not crash when trigger onChange in render', () => {
     function App() {
       const [page, setPage] = React.useState({


### PR DESCRIPTION
## SUMMARY:

Issue - When a consumer changes `pageSize`/`pageSizes` at runtime (Position Overview drill-in panels recompute rows-per-page from window height on resize/zoom), the table re-slices rows with the new size but the pager keeps the old page count. Example: 37 rows at 11/page = 4 pages; after zooming to 6/page the table shows 6 rows but the pager still shows 4 pages, so rows 25-37 are unreachable.

Root cause - Pagination copies `pageSize`/`pageSizes` into internal state at mount and never re-syncs them (`total` and `currentPage` have sync effects; the size props don't). `getPageCount()` divides total by the stale internal size, so the pager freezes at the mount-time count while Table's row slice stays reactive. Follow-up to #1157 (product side: EightfoldAI/vscode#113083).

Fix -
- Add a sync effect for the size props: on change, normalize (fall back to `pageSizes[0]` when `pageSize` is not in the list) and update internal state. Parent-driven changes don't fire `onSizeChange`.
- If the new page count is smaller than the current page, fire `onCurrentChange(pageCount)` so consumers reposition/refetch. Mirrors the clamp Table already does in `usePagination`.
- `onSizeChangeHandler` computed the jumper's page count with the previous `_pageSize`; now uses the new value.

No vscode change needed - EightfoldAI/vscode#113083 already passes the right props; this makes Pagination honor them.

## GITHUB ISSUE (Open Source Contributors)

NA

## JIRA TASK (Eightfold Employees Only):

Follow-up to https://eightfoldai.atlassian.net/browse/ENG-205018

## CHANGE TYPE:

- [x] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [ ] Tests for this change already exist
- [x] I have added unittests for this change

## TEST PLAN:

- New Pagination tests: pageSize 11->6 with total 37 moves the pager from 4 to 7 pages; same for a pageSizes-only consumer; shrinking the count from 7 to 4 with currentPage 7 fires onCurrentChange(4). All three fail without the fix.
- New Table test: re-rendering with pagination { pageSize: 6, pageSizes: [6] } after mounting with 11 re-slices rows (11->6) and updates the pager (4->7 pages).
- Full repo suite green (222 suites, 2650 tests), typecheck and lint clean.
- Manual repro from the product bug: open a Position Overview drill-in list, zoom/resize so rows-per-page shrinks, page count now grows to match and the last rows stay reachable.