### PR TITLE
chore(release): 2.58.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [2.58.5](https://github.com/EightfoldAI/octuple/compare/v2.58.4...v2.58.5) (2026-08-11)
-
+### [2.58.6](https://github.com/EightfoldAI/octuple/compare/v2.58.5...v2.58.6) (2026-08-12)
 
 ### Bug Fixes
 
-* **a11y:** correct select chevron role and type rangepicker aria-label props ([#1156](https://github.com/EightfoldAI/octuple/issues/1156)) ([f22fb38](https://github.com/EightfoldAI/octuple/commits/f22fb38e6b2d7602dd2a8535a69dfa04c14b3d99))
-* **table:** keep rows rendered when pageSizes prop changes at runtime ([fac8548](https://github.com/EightfoldAI/octuple/commits/fac854849fa2731fb5328c67658522d90ecc8fff))
+- **pagination:** recompute page count when pageSize or pageSizes props change ([#1163](https://github.com/EightfoldAI/octuple/issues/1163)) ([1f25f77](https://github.com/EightfoldAI/octuple/commits/1f25f7775a8f9380001ef1af71f348975535cf30))
+
+### [2.58.5](https://github.com/EightfoldAI/octuple/compare/v2.58.4...v2.58.5) (2026-08-11)
+
+### Bug Fixes
+
+- **a11y:** correct select chevron role and type rangepicker aria-label props ([#1156](https://github.com/EightfoldAI/octuple/issues/1156)) ([f22fb38](https://github.com/EightfoldAI/octuple/commits/f22fb38e6b2d7602dd2a8535a69dfa04c14b3d99))
+- **table:** keep rows rendered when pageSizes prop changes at runtime ([fac8548](https://github.com/EightfoldAI/octuple/commits/fac854849fa2731fb5328c67658522d90ecc8fff))
 
 ### [2.58.4](https://github.com/EightfoldAI/octuple/compare/v2.58.3...v2.58.4) (2026-07-14)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.58.5",
+  "version": "2.58.6",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
## SUMMARY:

Version bump to 2.58.6 with CHANGELOG. Contains:

- fix(pagination): recompute page count when pageSize or pageSizes props change (#1163)
- test(FadeIn): replace fixed sleeps with waitFor to fix CI flake

Tag + npm publish happen after this merges (tag-on-main flow).

## GITHUB ISSUE (Open Source Contributors)

NA

## JIRA TASK (Eightfold Employees Only):

NA

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist

## TEST PLAN:

- Release chore only (package.json + CHANGELOG). CI green on the included commits; full suite ran on #1163 (222 suites / 2650 tests).