### PR TITLE
chore(release): 2.58.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.58.7](https://github.com/EightfoldAI/octuple/compare/v2.58.6...v2.58.7) (2026-08-12)
+
+### Bug Fixes
+
+- **Avatar:** hover styling ([#1162](https://github.com/EightfoldAI/octuple/issues/1162)) ([1876abf](https://github.com/EightfoldAI/octuple/commits/1876abf83bc596a9023840a577799d2e3e39eed0))
+
 ### [2.58.6](https://github.com/EightfoldAI/octuple/compare/v2.58.5...v2.58.6) (2026-08-12)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.58.6",
+  "version": "2.58.7",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
## SUMMARY:

Version bump to 2.58.7 with CHANGELOG. Contains:

- fix(Avatar): hover styling (#1162)

Tag + npm publish happen after this merges (tag-on-main flow).

## GITHUB ISSUE (Open Source Contributors)

NA

## JIRA TASK (Eightfold Employees Only):

NA

## CHANGE TYPE:

- [ ] Bugfix Pull Request
- [ ] Feature Pull Request

## TEST COVERAGE:

- [x] Tests for this change already exist

## TEST PLAN:

- Release chore only (package.json + CHANGELOG). CI green on the included commit (#1162 reviewed + merged with its own tests/snapshots).