### PR TITLE
chore(release): 2.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.59.0](https://github.com/EightfoldAI/octuple/compare/v2.58.7...v2.59.0) (2026-08-18)
+
+
+### Bug Fixes
+
+* **react19:** react 19 compatibility with guarded fallbacks, zero change for react <=18 ([#1161](https://github.com/EightfoldAI/octuple/issues/1161)) ([2ccc2b6](https://github.com/EightfoldAI/octuple/commits/2ccc2b687102251bbb47a6c016091a8ffda318bd))
+
 ### [2.58.7](https://github.com/EightfoldAI/octuple/compare/v2.58.6...v2.58.7) (2026-08-12)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eightfold.ai/octuple",
-  "version": "2.58.7",
+  "version": "2.59.0",
   "license": "MIT",
   "description": "Eightfold Octuple Design System Component Library",
   "sideEffects": [


### PR DESCRIPTION
Version bump only. No source changes.

- `package.json`: 2.58.7 → 2.59.0
- `CHANGELOG.md`: 2.59.0 section

Minor rather than patch: the only commit in the range is [#1161](https://github.com/EightfoldAI/octuple/pull/1161) react 19 compatibility. It is `fix`-typed, so conventional-commit auto-detect would give 2.58.8, but it adds React 19 support for consumers — a minor is the honest signal for downstream apps.

Merging this does not publish. The `v2.59.0` tag is created on the merged `main` commit afterwards, and that tag push triggers the npm publish pipeline.